### PR TITLE
Fix spell 24834 (Shadow Bolt Whirl)

### DIFF
--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -1226,14 +1226,14 @@ void Aura::TriggerSpell()
                     case 24834:                             // Shadow Bolt Whirl
                     {
                         uint32 spellForTick[8] = { 24820, 24821, 24822, 24823, 24835, 24836, 24837, 24838 };
-                        uint32 tick = GetAuraTicks();
+                        uint32 tick = GetAuraTicks() % 8; // prevent aura to stop casting shadow bolts after one rotation
                         if (tick < 8)
                         {
                             trigger_spell_id = spellForTick[tick];
 
-                            // casted in left/right (but triggered spell have wide forward cone)
+                            // casted clockwise, one rotation = 8 ticks (but triggered spell have wide forward cone)
                             float forward = target->GetOrientation();
-                            float angle = target->GetOrientation() + (tick % 2 == 0 ? M_PI_F / 2 : - M_PI_F / 2);
+                            float angle = target->GetOrientation() - (tick * 2 * M_PI_F / 8);
                             target->SetOrientation(angle);
                             triggerTarget->CastSpell(triggerTarget, trigger_spell_id, true, NULL, this, casterGUID);
                             target->SetOrientation(forward);


### PR DESCRIPTION
Fix behavior of Lethon's ablility Shadow Bolt Whirl
(http://www.wowwiki.com/Lethon)
Spell should not stop after 8 ticks
Spell should rotate clockwise (four ticks right side, then four ticks
left side) instead of alternating from right to left every tick
