### PR TITLE
Implement skeletton for WaypointMovement by id

### DIFF
--- a/src/game/MotionMaster.cpp
+++ b/src/game/MotionMaster.cpp
@@ -56,6 +56,8 @@ void MotionMaster::Initialize()
         MovementGenerator* movement = FactorySelector::selectMovementGenerator((Creature*)m_owner);
         push(movement == NULL ? &si_idleMovement : movement);
         top()->Initialize(*m_owner);
+        if (top()->GetMovementGeneratorType() == WAYPOINT_MOTION_TYPE)
+            ((WaypointMovementGenerator<Creature>*)top())->InitializeWaypointPath(*((Creature*)(m_owner)), 0);
     }
     else
         push(&si_idleMovement);
@@ -371,7 +373,7 @@ void MotionMaster::MoveFleeing(Unit* enemy, uint32 time)
     }
 }
 
-void MotionMaster::MoveWaypoint()
+void MotionMaster::MoveWaypoint(int32 id /*=0*/)
 {
     if (m_owner->GetTypeId() == TYPEID_UNIT)
     {
@@ -384,7 +386,9 @@ void MotionMaster::MoveWaypoint()
         Creature* creature = (Creature*)m_owner;
 
         DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "Creature %s (Entry %u) start MoveWaypoint()", m_owner->GetGuidStr().c_str(), m_owner->GetEntry());
-        Mutate(new WaypointMovementGenerator<Creature>(*creature));
+        WaypointMovementGenerator<Creature>* newWPMMgen = new WaypointMovementGenerator<Creature>(*creature);
+        Mutate(newWPMMgen);
+        newWPMMgen->InitializeWaypointPath(*creature, id);
     }
     else
     {

--- a/src/game/MotionMaster.h
+++ b/src/game/MotionMaster.h
@@ -105,7 +105,7 @@ class MANGOS_DLL_SPEC MotionMaster : private std::stack<MovementGenerator*>
         void MovePoint(uint32 id, float x, float y, float z, bool generatePath = true);
         void MoveSeekAssistance(float x, float y, float z);
         void MoveSeekAssistanceDistract(uint32 timer);
-        void MoveWaypoint();
+        void MoveWaypoint(int32 id = 0);
         void MoveTaxiFlight(uint32 path, uint32 pathnode);
         void MoveDistract(uint32 timeLimit);
         void MoveJump(float x, float y, float z, float horizontalSpeed, float max_height, uint32 id = 0);

--- a/src/game/WaypointManager.h
+++ b/src/game/WaypointManager.h
@@ -64,9 +64,9 @@ class WaypointManager
         void Load();
         void Unload();
 
-        WaypointPath* GetPath(uint32 id)
+        WaypointPath* GetPath(uint32 guid)
         {
-            WaypointPathMap::iterator itr = m_pathMap.find(id);
+            WaypointPathMap::iterator itr = m_pathMap.find(guid);
             return itr != m_pathMap.end() ? &itr->second : NULL;
         }
 
@@ -74,6 +74,28 @@ class WaypointManager
         {
             WaypointPathMap::iterator itr = m_pathTemplateMap.find(entry);
             return itr != m_pathTemplateMap.end() ? &itr->second : NULL;
+        }
+
+        WaypointPath* GetPathById(uint32 npcEntry, int32 id)
+        {
+            WaypointPathMap::iterator itr = m_keyPathMap.find(createWPKey(npcEntry, id));
+            return itr != m_keyPathMap.end() ? &itr->second : NULL;
+        }
+
+        void AddPath(uint32 npcEntry, int32 id, WaypointPath const* path)
+        {
+            WaypointPath& _path = m_keyPathMap[createWPKey(npcEntry, id)];
+            _clearPath(_path);
+            _path = *path;
+            //for (WaypointPath::const_iterator itr = path->begin(); itr != path->end(); ++itr)
+            //    _path.insert(*itr);
+        }
+
+        void DeletePath(uint32 npcEntry, int32 id)
+        {
+            WaypointPathMap::iterator itr = m_keyPathMap.find(createWPKey(npcEntry, id));
+            if (itr != m_keyPathMap.end())
+                _clearPath(itr->second);
         }
 
         void AddLastNode(uint32 id, float x, float y, float z, float o, uint32 delay, uint32 wpGuid);
@@ -89,9 +111,15 @@ class WaypointManager
         void _addNode(uint32 id, uint32 point, float x, float y, float z, float o, uint32 delay, uint32 wpGuid);
         void _clearPath(WaypointPath& path);
 
-        typedef UNORDERED_MAP<uint32 /*guidOrEntry*/, WaypointPath> WaypointPathMap;
+        int32 createWPKey(uint32 npcEntry, int32 id) const
+        {
+            return id > 0 ? npcEntry * 0xFF + id : npcEntry * -0xFF - id;
+        }
+
+        typedef UNORDERED_MAP<int32 /*guidOrEntryOrKey*/, WaypointPath> WaypointPathMap;
         WaypointPathMap m_pathMap;
         WaypointPathMap m_pathTemplateMap;
+        WaypointPathMap m_keyPathMap;
 };
 
 #define sWaypointMgr MaNGOS::Singleton<WaypointManager>::Instance()

--- a/src/game/WaypointMovementGenerator.h
+++ b/src/game/WaypointMovementGenerator.h
@@ -72,13 +72,11 @@ class MANGOS_DLL_SPEC WaypointMovementGenerator<Creature>
         void Finalize(Creature&);
         void Reset(Creature& u);
         bool Update(Creature& u, const uint32& diff);
+        void InitializeWaypointPath(Creature& u, int32 id);
 
         void MovementInform(Creature&);
 
         MovementGeneratorType GetMovementGeneratorType() const { return WAYPOINT_MOTION_TYPE; }
-
-        // now path movement implmementation
-        void LoadPath(Creature& c);
 
         bool GetResetPosition(Creature&, float& x, float& y, float& z);
 
@@ -87,6 +85,8 @@ class MANGOS_DLL_SPEC WaypointMovementGenerator<Creature>
         uint32 getLastReachedWaypoint() const { return m_isArrivalDone ? i_currentNode + 1 : i_currentNode; }
 
     private:
+        void LoadPath(Creature& c, int32 id);
+
         void Stop(int32 time) { i_nextMoveTime.Reset(time); }
         bool Stopped(Creature& u);
         bool CanMove(int32 diff, Creature& u);


### PR DESCRIPTION
Main Goal:

Unify waypoint handling between guid-waypoints, entry-waypoints, additional paths assigned uniquely to summoned mobs and waypoints assigned via SD2

Ideas:
- merge creature_movement and creature_movement_template into one table.
  Any idea for this would be welcome

Also i suggest to add the possibiilty to store paths (entry, someCustomIdForThePath) in this same table to be able to ie let a mob start way X on quest A, and way Y on quest B
( COMMAND_START_MOVEMENT(waypoint, X) for A and
  COMMAND_START_MOVMEENT(waypoint, Y) for B     )

Currently done:
- Also improve a bit default behaviour for WaypointMMGen
- Add new storage for WaypointPath of NpcEntry, id to WaypointMgr
- Add wrappers to load paths by npcEntry, id to WaypointMgr
- Change MotionMaster::MoveWaypoint to be able to select a path

TODO:
- TODO: Well, load content to the new storage
- TODO: Add wrappers to actually use the new paths
- TODO: To be really usefull, this will require ways a rewrite of MotionMaster to keep WaypointMovement that was stacked also after evade..
- TODO: Figure how to store more content
- TODO: Figure also how to assign summoning and individual path (COMMAND_SUMMON_WITH_PATH ?)
