### PR TITLE
Modify vmapExtractor to search for files in newer MPQs first. (WRONG)

### DIFF
--- a/contrib/vmap_extractor/vmapextract/mpq_libmpq.cpp
+++ b/contrib/vmap_extractor/vmapextract/mpq_libmpq.cpp
@@ -33,7 +33,7 @@ MPQArchive::MPQArchive(const char* filename)
         }
         return;
     }
-    gOpenArchives.push_front(this);
+    gOpenArchives.push_back(this);
 }
 
 void MPQArchive::close()

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -490,7 +490,7 @@ int main(int argc, char** argv)
     for (size_t i = 0; i < archiveNames.size(); ++i)
     {
         MPQArchive* archive = new MPQArchive(archiveNames[i].c_str());
-        if (!gOpenArchives.size() || gOpenArchives.front() != archive)
+        if (!gOpenArchives.size() || gOpenArchives.back() != archive)
             delete archive;
     }
 


### PR DESCRIPTION
Fix was incorrect. No fix is needed on WotLK. Going to submit a correct one for classic. =)
