### PR TITLE
Redump sql databases to unify formatting

### DIFF
--- a/sql/characters.sql
+++ b/sql/characters.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.11
+-- MySQL dump 10.13
 --
 -- Host: localhost    Database: characters
 -- ------------------------------------------------------
--- Server version    5.0.45-Debian_1ubuntu3.1-log
+-- Server version	5.5.15
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -21,7 +21,7 @@
 
 DROP TABLE IF EXISTS `character_db_version`;
 CREATE TABLE `character_db_version` (
-  `required_12487_01_characters_characters` bit(1) default NULL
+  `required_12487_01_characters_characters` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Last applied sql update to DB';
 
 --
@@ -41,11 +41,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `account_data`;
 CREATE TABLE `account_data` (
-  `account` int(11) unsigned NOT NULL default '0',
-  `type` int(11) unsigned NOT NULL default '0',
-  `time` bigint(11) unsigned NOT NULL default '0',
+  `account` int(11) unsigned NOT NULL DEFAULT '0',
+  `type` int(11) unsigned NOT NULL DEFAULT '0',
+  `time` bigint(11) unsigned NOT NULL DEFAULT '0',
   `data` longblob NOT NULL,
-  PRIMARY KEY  (`account`,`type`)
+  PRIMARY KEY (`account`,`type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -63,16 +63,16 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `arena_team`;
 CREATE TABLE `arena_team` (
-  `arenateamid` int(10) unsigned NOT NULL default '0',
+  `arenateamid` int(10) unsigned NOT NULL DEFAULT '0',
   `name` char(255) NOT NULL,
-  `captainguid` int(10) unsigned NOT NULL default '0',
-  `type` tinyint(3) unsigned NOT NULL default '0',
-  `BackgroundColor` int(10) unsigned NOT NULL default '0',
-  `EmblemStyle` int(10) unsigned NOT NULL default '0',
-  `EmblemColor` int(10) unsigned NOT NULL default '0',
-  `BorderStyle` int(10) unsigned NOT NULL default '0',
-  `BorderColor` int(10) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`arenateamid`)
+  `captainguid` int(10) unsigned NOT NULL DEFAULT '0',
+  `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `BackgroundColor` int(10) unsigned NOT NULL DEFAULT '0',
+  `EmblemStyle` int(10) unsigned NOT NULL DEFAULT '0',
+  `EmblemColor` int(10) unsigned NOT NULL DEFAULT '0',
+  `BorderStyle` int(10) unsigned NOT NULL DEFAULT '0',
+  `BorderColor` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`arenateamid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -90,14 +90,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `arena_team_member`;
 CREATE TABLE `arena_team_member` (
-  `arenateamid` int(10) unsigned NOT NULL default '0',
-  `guid` int(10) unsigned NOT NULL default '0',
-  `played_week` int(10) unsigned NOT NULL default '0',
-  `wons_week` int(10) unsigned NOT NULL default '0',
-  `played_season` int(10) unsigned NOT NULL default '0',
-  `wons_season` int(10) unsigned NOT NULL default '0',
-  `personal_rating` int(10) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`arenateamid`,`guid`)
+  `arenateamid` int(10) unsigned NOT NULL DEFAULT '0',
+  `guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `played_week` int(10) unsigned NOT NULL DEFAULT '0',
+  `wons_week` int(10) unsigned NOT NULL DEFAULT '0',
+  `played_season` int(10) unsigned NOT NULL DEFAULT '0',
+  `wons_season` int(10) unsigned NOT NULL DEFAULT '0',
+  `personal_rating` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`arenateamid`,`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -115,14 +115,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `arena_team_stats`;
 CREATE TABLE `arena_team_stats` (
-  `arenateamid` int(10) unsigned NOT NULL default '0',
-  `rating` int(10) unsigned NOT NULL default '0',
-  `games_week` int(10) unsigned NOT NULL default '0',
-  `wins_week` int(10) unsigned NOT NULL default '0',
-  `games_season` int(10) unsigned NOT NULL default '0',
-  `wins_season` int(10) unsigned NOT NULL default '0',
-  `rank` int(10) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`arenateamid`)
+  `arenateamid` int(10) unsigned NOT NULL DEFAULT '0',
+  `rating` int(10) unsigned NOT NULL DEFAULT '0',
+  `games_week` int(10) unsigned NOT NULL DEFAULT '0',
+  `wins_week` int(10) unsigned NOT NULL DEFAULT '0',
+  `games_season` int(10) unsigned NOT NULL DEFAULT '0',
+  `wins_season` int(10) unsigned NOT NULL DEFAULT '0',
+  `rank` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`arenateamid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -140,21 +140,21 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `auction`;
 CREATE TABLE `auction` (
-  `id` int(11) unsigned NOT NULL default '0',
-  `houseid` int(11) unsigned NOT NULL default '0',
-  `itemguid` int(11) unsigned NOT NULL default '0',
-  `item_template` int(11) unsigned NOT NULL default '0' COMMENT 'Item Identifier',
-  `item_count` int(11) unsigned NOT NULL default '0',
-  `item_randompropertyid` int(11) NOT NULL default '0',
-  `itemowner` int(11) unsigned NOT NULL default '0',
-  `buyoutprice` int(11) NOT NULL default '0',
-  `time` bigint(40) unsigned NOT NULL default '0',
-  `moneyTime` bigint(40) unsigned NOT NULL default '0',
-  `buyguid` int(11) unsigned NOT NULL default '0',
-  `lastbid` int(11) NOT NULL default '0',
-  `startbid` int(11) NOT NULL default '0',
-  `deposit` int(11) NOT NULL default '0',
-  PRIMARY KEY  (`id`)
+  `id` int(11) unsigned NOT NULL DEFAULT '0',
+  `houseid` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemguid` int(11) unsigned NOT NULL DEFAULT '0',
+  `item_template` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Item Identifier',
+  `item_count` int(11) unsigned NOT NULL DEFAULT '0',
+  `item_randompropertyid` int(11) NOT NULL DEFAULT '0',
+  `itemowner` int(11) unsigned NOT NULL DEFAULT '0',
+  `buyoutprice` int(11) NOT NULL DEFAULT '0',
+  `time` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `moneyTime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `buyguid` int(11) unsigned NOT NULL DEFAULT '0',
+  `lastbid` int(11) NOT NULL DEFAULT '0',
+  `startbid` int(11) NOT NULL DEFAULT '0',
+  `deposit` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -172,10 +172,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `bugreport`;
 CREATE TABLE `bugreport` (
-  `id` int(11) NOT NULL auto_increment COMMENT 'Identifier',
-  `type` longtext NOT NULL default '',
-  `content` longtext NOT NULL default '',
-  PRIMARY KEY  (`id`)
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Identifier',
+  `type` longtext NOT NULL,
+  `content` longtext NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Debug System';
 
 --
@@ -202,8 +202,17 @@ CREATE TABLE `calendar_events` (
   `eventTime` int(10) unsigned NOT NULL DEFAULT '0',
   `title` varchar(128) NOT NULL DEFAULT '',
   `description` varchar(1024) NOT NULL DEFAULT '',
-  PRIMARY KEY  (`eventId`)
+  PRIMARY KEY (`eventId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `calendar_events`
+--
+
+LOCK TABLES `calendar_events` WRITE;
+/*!40000 ALTER TABLE `calendar_events` DISABLE KEYS */;
+/*!40000 ALTER TABLE `calendar_events` ENABLE KEYS */;
+UNLOCK TABLES;
 
 --
 -- Table structure for table `calendar_invites`
@@ -218,96 +227,16 @@ CREATE TABLE `calendar_invites` (
   `status` tinyint(10) unsigned NOT NULL DEFAULT '0',
   `lastUpdateTime` int(10) unsigned NOT NULL DEFAULT '0',
   `rank` tinyint(10) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`inviteId`)
+  PRIMARY KEY (`inviteId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
--- Table structure for table `characters`
+-- Dumping data for table `calendar_invites`
 --
 
-DROP TABLE IF EXISTS `characters`;
-CREATE TABLE `characters` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `account` int(11) unsigned NOT NULL default '0' COMMENT 'Account Identifier',
-  `name` varchar(12) NOT NULL default '',
-  `race` tinyint(3) unsigned NOT NULL default '0',
-  `class` tinyint(3) unsigned NOT NULL default '0',
-  `gender` TINYINT UNSIGNED NOT NULL default '0',
-  `level` TINYINT UNSIGNED NOT NULL default '0',
-  `xp` INT UNSIGNED NOT NULL default '0',
-  `money` INT UNSIGNED NOT NULL default '0',
-  `playerBytes` INT UNSIGNED NOT NULL default '0',
-  `playerBytes2` INT UNSIGNED NOT NULL default '0',
-  `playerFlags` INT UNSIGNED NOT NULL default '0',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `map` int(11) unsigned NOT NULL default '0' COMMENT 'Map Identifier',
-  `dungeon_difficulty` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `orientation` float NOT NULL default '0',
-  `taximask` longtext,
-  `online` tinyint(3) unsigned NOT NULL default '0',
-  `cinematic` tinyint(3) unsigned NOT NULL default '0',
-  `totaltime` int(11) unsigned NOT NULL default '0',
-  `leveltime` int(11) unsigned NOT NULL default '0',
-  `logout_time` bigint(20) unsigned NOT NULL default '0',
-  `is_logout_resting` tinyint(3) unsigned NOT NULL default '0',
-  `rest_bonus` float NOT NULL default '0',
-  `resettalents_cost` int(11) unsigned NOT NULL default '0',
-  `resettalents_time` bigint(20) unsigned NOT NULL default '0',
-  `trans_x` float NOT NULL default '0',
-  `trans_y` float NOT NULL default '0',
-  `trans_z` float NOT NULL default '0',
-  `trans_o` float NOT NULL default '0',
-  `transguid` bigint(20) unsigned NOT NULL default '0',
-  `extra_flags` int(11) unsigned NOT NULL default '0',
-  `stable_slots` tinyint(1) unsigned NOT NULL default '0',
-  `at_login` int(11) unsigned NOT NULL default '0',
-  `zone` int(11) unsigned NOT NULL default '0',
-  `death_expire_time` bigint(20) unsigned NOT NULL default '0',
-  `taxi_path` text,
-  `arenaPoints` int(10) UNSIGNED NOT NULL default '0',
-  `totalHonorPoints` int(10) UNSIGNED NOT NULL default '0',
-  `todayHonorPoints` int(10) UNSIGNED NOT NULL default '0',
-  `yesterdayHonorPoints` int(10) UNSIGNED NOT NULL default '0',
-  `totalKills` int(10) UNSIGNED NOT NULL default '0',
-  `todayKills` smallint(5) UNSIGNED NOT NULL default '0',
-  `yesterdayKills` smallint(5) UNSIGNED NOT NULL default '0',
-  `chosenTitle` int(10) UNSIGNED NOT NULL default '0',
-  `knownCurrencies` bigint(20) UNSIGNED NOT NULL default '0',
-  `watchedFaction` int(10) UNSIGNED NOT NULL default '0',
-  `drunk` tinyint(3) UNSIGNED NOT NULL default '0',
-  `health` int(10) UNSIGNED NOT NULL default '0',
-  `power1` int(10) UNSIGNED NOT NULL default '0',
-  `power2` int(10) UNSIGNED NOT NULL default '0',
-  `power3` int(10) UNSIGNED NOT NULL default '0',
-  `power4` int(10) UNSIGNED NOT NULL default '0',
-  `power5` int(10) UNSIGNED NOT NULL default '0',
-  `power6` int(10) UNSIGNED NOT NULL default '0',
-  `power7` int(10) UNSIGNED NOT NULL default '0',
-  `specCount` tinyint(3) UNSIGNED NOT NULL default '1',
-  `activeSpec` tinyint(3) UNSIGNED NOT NULL default '0',
-  `exploredZones` longtext,
-  `equipmentCache` longtext,
-  `ammoId` int(10) UNSIGNED NOT NULL default '0',
-  `knownTitles` longtext,
-  `actionBars` tinyint(3) UNSIGNED NOT NULL default '0',
-  `deleteInfos_Account` int(11) UNSIGNED default NULL,
-  `deleteInfos_Name` varchar(12) default NULL,
-  `deleteDate` bigint(20) unsigned default NULL,
-  PRIMARY KEY  (`guid`),
-  KEY `idx_account` (`account`),
-  KEY `idx_online` (`online`),
-  KEY `idx_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
-
---
--- Dumping data for table `characters`
---
-
-LOCK TABLES `characters` WRITE;
-/*!40000 ALTER TABLE `characters` DISABLE KEYS */;
-/*!40000 ALTER TABLE `characters` ENABLE KEYS */;
+LOCK TABLES `calendar_invites` WRITE;
+/*!40000 ALTER TABLE `calendar_invites` DISABLE KEYS */;
+/*!40000 ALTER TABLE `calendar_invites` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
@@ -316,11 +245,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_account_data`;
 CREATE TABLE `character_account_data` (
-  `guid` int(11) unsigned NOT NULL default '0',
-  `type` int(11) unsigned NOT NULL default '0',
-  `time` bigint(11) unsigned NOT NULL default '0',
+  `guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `type` int(11) unsigned NOT NULL DEFAULT '0',
+  `time` bigint(11) unsigned NOT NULL DEFAULT '0',
   `data` longblob NOT NULL,
-  PRIMARY KEY  (`guid`,`type`)
+  PRIMARY KEY (`guid`,`type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -339,9 +268,9 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `character_achievement`;
 CREATE TABLE `character_achievement` (
   `guid` int(11) unsigned NOT NULL,
-  `achievement` int(11) unsigned  NOT NULL,
-  `date` bigint(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`achievement`)
+  `achievement` int(11) unsigned NOT NULL,
+  `date` bigint(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`achievement`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -362,8 +291,8 @@ CREATE TABLE `character_achievement_progress` (
   `guid` int(11) unsigned NOT NULL,
   `criteria` int(11) unsigned NOT NULL,
   `counter` int(11) unsigned NOT NULL,
-  `date` bigint(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`criteria`)
+  `date` bigint(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`criteria`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -381,12 +310,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_action`;
 CREATE TABLE `character_action` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `spec` tinyint(3) unsigned NOT NULL default '0',
-  `button` tinyint(3) unsigned NOT NULL default '0',
-  `action` int(11) unsigned NOT NULL default '0',
-  `type` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`spec`,`button`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `spec` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `button` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `action` int(11) unsigned NOT NULL DEFAULT '0',
+  `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`spec`,`button`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -404,21 +333,21 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_aura`;
 CREATE TABLE `character_aura` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `caster_guid` bigint(20) unsigned NOT NULL default '0' COMMENT 'Full Global Unique Identifier',
-  `item_guid` int(11) unsigned NOT NULL default '0',
-  `spell` int(11) unsigned NOT NULL default '0',
-  `stackcount` INT(11) UNSIGNED NOT NULL DEFAULT '1',
-  `remaincharges` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `basepoints0` INT(11) NOT NULL DEFAULT '0',
-  `basepoints1` INT(11) NOT NULL DEFAULT '0',
-  `basepoints2` INT(11) NOT NULL DEFAULT '0',
-  `periodictime0` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `periodictime1` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `periodictime2` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `maxduration` INT(11) NOT NULL DEFAULT '0',
-  `remaintime` INT(11) NOT NULL DEFAULT '0',
-  `effIndexMask` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `caster_guid` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'Full Global Unique Identifier',
+  `item_guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `spell` int(11) unsigned NOT NULL DEFAULT '0',
+  `stackcount` int(11) unsigned NOT NULL DEFAULT '1',
+  `remaincharges` int(11) unsigned NOT NULL DEFAULT '0',
+  `basepoints0` int(11) NOT NULL DEFAULT '0',
+  `basepoints1` int(11) NOT NULL DEFAULT '0',
+  `basepoints2` int(11) NOT NULL DEFAULT '0',
+  `periodictime0` int(11) unsigned NOT NULL DEFAULT '0',
+  `periodictime1` int(11) unsigned NOT NULL DEFAULT '0',
+  `periodictime2` int(11) unsigned NOT NULL DEFAULT '0',
+  `maxduration` int(11) NOT NULL DEFAULT '0',
+  `remaintime` int(11) NOT NULL DEFAULT '0',
+  `effIndexMask` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guid`,`caster_guid`,`item_guid`,`spell`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
@@ -437,18 +366,18 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_battleground_data`;
 CREATE TABLE `character_battleground_data` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `instance_id` int(11) unsigned NOT NULL default '0',
-  `team` int(11) unsigned NOT NULL default '0',
-  `join_x` float NOT NULL default '0',
-  `join_y` float NOT NULL default '0',
-  `join_z` float NOT NULL default '0',
-  `join_o` float NOT NULL default '0',
-  `join_map` int(11) NOT NULL default '0',
-  `taxi_start` int(11) NOT NULL default '0',
-  `taxi_end` int(11) NOT NULL default '0',
-  `mount_spell` int(11) NOT NULL default '0',
-  PRIMARY KEY  (`guid`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `instance_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `team` int(11) unsigned NOT NULL DEFAULT '0',
+  `join_x` float NOT NULL DEFAULT '0',
+  `join_y` float NOT NULL DEFAULT '0',
+  `join_z` float NOT NULL DEFAULT '0',
+  `join_o` float NOT NULL DEFAULT '0',
+  `join_map` int(11) NOT NULL DEFAULT '0',
+  `taxi_start` int(11) NOT NULL DEFAULT '0',
+  `taxi_end` int(11) NOT NULL DEFAULT '0',
+  `mount_spell` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -466,13 +395,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_declinedname`;
 CREATE TABLE `character_declinedname` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `genitive` varchar(15) NOT NULL default '',
-  `dative` varchar(15) NOT NULL default '',
-  `accusative` varchar(15) NOT NULL default '',
-  `instrumental` varchar(15) NOT NULL default '',
-  `prepositional` varchar(15) NOT NULL default '',
-  PRIMARY KEY  (`guid`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `genitive` varchar(15) NOT NULL DEFAULT '',
+  `dative` varchar(15) NOT NULL DEFAULT '',
+  `accusative` varchar(15) NOT NULL DEFAULT '',
+  `instrumental` varchar(15) NOT NULL DEFAULT '',
+  `prepositional` varchar(15) NOT NULL DEFAULT '',
+  PRIMARY KEY (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
 
 --
@@ -490,34 +419,34 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_equipmentsets`;
 CREATE TABLE `character_equipmentsets` (
-  `guid` int(11) NOT NULL default '0',
-  `setguid` bigint(20) unsigned NOT NULL auto_increment,
-  `setindex` tinyint(4) NOT NULL default '0',
+  `guid` int(11) NOT NULL DEFAULT '0',
+  `setguid` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `setindex` tinyint(4) NOT NULL DEFAULT '0',
   `name` varchar(100) NOT NULL,
   `iconname` varchar(100) NOT NULL,
-  `ignore_mask` int(11) unsigned NOT NULL default '0',
-  `item0` int(11) unsigned NOT NULL default '0',
-  `item1` int(11) unsigned NOT NULL default '0',
-  `item2` int(11) unsigned NOT NULL default '0',
-  `item3` int(11) unsigned NOT NULL default '0',
-  `item4` int(11) unsigned NOT NULL default '0',
-  `item5` int(11) unsigned NOT NULL default '0',
-  `item6` int(11) unsigned NOT NULL default '0',
-  `item7` int(11) unsigned NOT NULL default '0',
-  `item8` int(11) unsigned NOT NULL default '0',
-  `item9` int(11) unsigned NOT NULL default '0',
-  `item10` int(11) unsigned NOT NULL default '0',
-  `item11` int(11) unsigned NOT NULL default '0',
-  `item12` int(11) unsigned NOT NULL default '0',
-  `item13` int(11) unsigned NOT NULL default '0',
-  `item14` int(11) unsigned NOT NULL default '0',
-  `item15` int(11) unsigned NOT NULL default '0',
-  `item16` int(11) unsigned NOT NULL default '0',
-  `item17` int(11) unsigned NOT NULL default '0',
-  `item18` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`setguid`),
+  `ignore_mask` int(11) unsigned NOT NULL DEFAULT '0',
+  `item0` int(11) unsigned NOT NULL DEFAULT '0',
+  `item1` int(11) unsigned NOT NULL DEFAULT '0',
+  `item2` int(11) unsigned NOT NULL DEFAULT '0',
+  `item3` int(11) unsigned NOT NULL DEFAULT '0',
+  `item4` int(11) unsigned NOT NULL DEFAULT '0',
+  `item5` int(11) unsigned NOT NULL DEFAULT '0',
+  `item6` int(11) unsigned NOT NULL DEFAULT '0',
+  `item7` int(11) unsigned NOT NULL DEFAULT '0',
+  `item8` int(11) unsigned NOT NULL DEFAULT '0',
+  `item9` int(11) unsigned NOT NULL DEFAULT '0',
+  `item10` int(11) unsigned NOT NULL DEFAULT '0',
+  `item11` int(11) unsigned NOT NULL DEFAULT '0',
+  `item12` int(11) unsigned NOT NULL DEFAULT '0',
+  `item13` int(11) unsigned NOT NULL DEFAULT '0',
+  `item14` int(11) unsigned NOT NULL DEFAULT '0',
+  `item15` int(11) unsigned NOT NULL DEFAULT '0',
+  `item16` int(11) unsigned NOT NULL DEFAULT '0',
+  `item17` int(11) unsigned NOT NULL DEFAULT '0',
+  `item18` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`setguid`),
   UNIQUE KEY `idx_set` (`guid`,`setguid`,`setindex`),
-  INDEX `Idx_setindex` (`setindex`)
+  KEY `Idx_setindex` (`setindex`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -535,11 +464,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_gifts`;
 CREATE TABLE `character_gifts` (
-  `guid` int(20) unsigned NOT NULL default '0',
-  `item_guid` int(11) unsigned NOT NULL default '0',
-  `entry` int(20) unsigned NOT NULL default '0',
-  `flags` int(20) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`item_guid`),
+  `guid` int(20) unsigned NOT NULL DEFAULT '0',
+  `item_guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `entry` int(20) unsigned NOT NULL DEFAULT '0',
+  `flags` int(20) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`item_guid`),
   KEY `idx_guid` (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -580,13 +509,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_homebind`;
 CREATE TABLE `character_homebind` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `map` int(11) unsigned NOT NULL default '0' COMMENT 'Map Identifier',
-  `zone` int(11) unsigned NOT NULL default '0' COMMENT 'Zone Identifier',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  PRIMARY KEY  (`guid`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `map` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Map Identifier',
+  `zone` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Zone Identifier',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -604,10 +533,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_instance`;
 CREATE TABLE `character_instance` (
-  `guid` int(11) unsigned NOT NULL default '0',
-  `instance` int(11) unsigned NOT NULL default '0',
-  `permanent` tinyint(1) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`instance`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `instance` int(11) unsigned NOT NULL DEFAULT '0',
+  `permanent` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`instance`),
   KEY `instance` (`instance`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -626,12 +555,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_inventory`;
 CREATE TABLE `character_inventory` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `bag` int(11) unsigned NOT NULL default '0',
-  `slot` tinyint(3) unsigned NOT NULL default '0',
-  `item` int(11) unsigned NOT NULL default '0' COMMENT 'Item Global Unique Identifier',
-  `item_template` int(11) unsigned NOT NULL default '0' COMMENT 'Item Identifier',
-  PRIMARY KEY  (`item`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `bag` int(11) unsigned NOT NULL DEFAULT '0',
+  `slot` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `item` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Item Global Unique Identifier',
+  `item_template` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Item Identifier',
+  PRIMARY KEY (`item`),
   KEY `idx_guid` (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
@@ -650,26 +579,26 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_pet`;
 CREATE TABLE `character_pet` (
-  `id` int(11) unsigned NOT NULL default '0',
-  `entry` int(11) unsigned NOT NULL default '0',
-  `owner` int(11) unsigned NOT NULL default '0',
-  `modelid` int(11) unsigned default '0',
-  `CreatedBySpell` int(11) unsigned NOT NULL default '0',
-  `PetType` tinyint(3) unsigned NOT NULL default '0',
-  `level` int(11) unsigned NOT NULL default '1',
-  `exp` int(11) unsigned NOT NULL default '0',
-  `Reactstate` tinyint(1) unsigned NOT NULL default '0',
-  `name` varchar(100) default 'Pet',
-  `renamed` tinyint(1) unsigned NOT NULL default '0',
-  `slot` int(11) unsigned NOT NULL default '0',
-  `curhealth` int(11) unsigned NOT NULL default '1',
-  `curmana` int(11) unsigned NOT NULL default '0',
-  `curhappiness` int(11) unsigned NOT NULL default '0',
-  `savetime` bigint(20) unsigned NOT NULL default '0',
-  `resettalents_cost` int(11) unsigned NOT NULL default '0',
-  `resettalents_time` bigint(20) unsigned NOT NULL default '0',
+  `id` int(11) unsigned NOT NULL DEFAULT '0',
+  `entry` int(11) unsigned NOT NULL DEFAULT '0',
+  `owner` int(11) unsigned NOT NULL DEFAULT '0',
+  `modelid` int(11) unsigned DEFAULT '0',
+  `CreatedBySpell` int(11) unsigned NOT NULL DEFAULT '0',
+  `PetType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `level` int(11) unsigned NOT NULL DEFAULT '1',
+  `exp` int(11) unsigned NOT NULL DEFAULT '0',
+  `Reactstate` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `name` varchar(100) DEFAULT 'Pet',
+  `renamed` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `slot` int(11) unsigned NOT NULL DEFAULT '0',
+  `curhealth` int(11) unsigned NOT NULL DEFAULT '1',
+  `curmana` int(11) unsigned NOT NULL DEFAULT '0',
+  `curhappiness` int(11) unsigned NOT NULL DEFAULT '0',
+  `savetime` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `resettalents_cost` int(11) unsigned NOT NULL DEFAULT '0',
+  `resettalents_time` bigint(20) unsigned NOT NULL DEFAULT '0',
   `abdata` longtext,
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   KEY `owner` (`owner`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Pet System';
 
@@ -688,15 +617,15 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_pet_declinedname`;
 CREATE TABLE `character_pet_declinedname` (
-  `id` int(11) unsigned NOT NULL default '0',
-  `owner` int(11) unsigned NOT NULL default '0',
-  `genitive` varchar(12) NOT NULL default '',
-  `dative` varchar(12) NOT NULL default '',
-  `accusative` varchar(12) NOT NULL default '',
-  `instrumental` varchar(12) NOT NULL default '',
-  `prepositional` varchar(12) NOT NULL default '',
-  PRIMARY KEY  (`id`),
-  KEY owner_key (`owner`)
+  `id` int(11) unsigned NOT NULL DEFAULT '0',
+  `owner` int(11) unsigned NOT NULL DEFAULT '0',
+  `genitive` varchar(12) NOT NULL DEFAULT '',
+  `dative` varchar(12) NOT NULL DEFAULT '',
+  `accusative` varchar(12) NOT NULL DEFAULT '',
+  `instrumental` varchar(12) NOT NULL DEFAULT '',
+  `prepositional` varchar(12) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `owner_key` (`owner`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
 
 --
@@ -714,23 +643,23 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_queststatus`;
 CREATE TABLE `character_queststatus` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `quest` int(11) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  `status` int(11) unsigned NOT NULL default '0',
-  `rewarded` tinyint(1) unsigned NOT NULL default '0',
-  `explored` tinyint(1) unsigned NOT NULL default '0',
-  `timer` bigint(20) unsigned NOT NULL default '0',
-  `mobcount1` int(11) unsigned NOT NULL default '0',
-  `mobcount2` int(11) unsigned NOT NULL default '0',
-  `mobcount3` int(11) unsigned NOT NULL default '0',
-  `mobcount4` int(11) unsigned NOT NULL default '0',
-  `itemcount1` int(11) unsigned NOT NULL default '0',
-  `itemcount2` int(11) unsigned NOT NULL default '0',
-  `itemcount3` int(11) unsigned NOT NULL default '0',
-  `itemcount4` int(11) unsigned NOT NULL default '0',
-  `itemcount5` int(11) unsigned NOT NULL default '0',
-  `itemcount6` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`quest`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  `status` int(11) unsigned NOT NULL DEFAULT '0',
+  `rewarded` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `explored` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `timer` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `mobcount1` int(11) unsigned NOT NULL DEFAULT '0',
+  `mobcount2` int(11) unsigned NOT NULL DEFAULT '0',
+  `mobcount3` int(11) unsigned NOT NULL DEFAULT '0',
+  `mobcount4` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemcount1` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemcount2` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemcount3` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemcount4` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemcount5` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemcount6` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`quest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -748,9 +677,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_queststatus_daily`;
 CREATE TABLE `character_queststatus_daily` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `quest` int(11) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`guid`,`quest`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`guid`,`quest`),
   KEY `idx_guid` (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
@@ -769,9 +698,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_queststatus_monthly`;
 CREATE TABLE `character_queststatus_monthly` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `quest` int(11) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`guid`,`quest`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`guid`,`quest`),
   KEY `idx_guid` (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
@@ -790,9 +719,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_queststatus_weekly`;
 CREATE TABLE `character_queststatus_weekly` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `quest` int(11) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`guid`,`quest`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`guid`,`quest`),
   KEY `idx_guid` (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
@@ -811,11 +740,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_reputation`;
 CREATE TABLE `character_reputation` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `faction` int(11) unsigned NOT NULL default '0',
-  `standing` int(11) NOT NULL default '0',
-  `flags` int(11) NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`faction`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `faction` int(11) unsigned NOT NULL DEFAULT '0',
+  `standing` int(11) NOT NULL DEFAULT '0',
+  `flags` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`faction`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -837,7 +766,7 @@ CREATE TABLE `character_skills` (
   `skill` mediumint(9) unsigned NOT NULL,
   `value` mediumint(9) unsigned NOT NULL,
   `max` mediumint(9) unsigned NOT NULL,
-  PRIMARY KEY  (`guid`,`skill`)
+  PRIMARY KEY (`guid`,`skill`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -855,11 +784,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_social`;
 CREATE TABLE `character_social` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Character Global Unique Identifier',
-  `friend` int(11) unsigned NOT NULL default '0' COMMENT 'Friend Global Unique Identifier',
-  `flags` tinyint(1) unsigned NOT NULL default '0' COMMENT 'Friend Flags',
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Character Global Unique Identifier',
+  `friend` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Friend Global Unique Identifier',
+  `flags` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Friend Flags',
   `note` varchar(48) NOT NULL DEFAULT '' COMMENT 'Friend Note',
-  PRIMARY KEY  (`guid`,`friend`,`flags`),
+  PRIMARY KEY (`guid`,`friend`,`flags`),
   KEY `guid` (`guid`),
   KEY `friend` (`friend`),
   KEY `guid_flags` (`guid`,`flags`),
@@ -881,11 +810,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_spell`;
 CREATE TABLE `character_spell` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `spell` int(11) unsigned NOT NULL default '0' COMMENT 'Spell Identifier',
-  `active` tinyint(3) unsigned NOT NULL default '1',
-  `disabled` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`spell`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `spell` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Spell Identifier',
+  `active` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `disabled` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`spell`),
   KEY `Idx_spell` (`spell`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
@@ -904,11 +833,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_spell_cooldown`;
 CREATE TABLE `character_spell_cooldown` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier, Low part',
-  `spell` int(11) unsigned NOT NULL default '0' COMMENT 'Spell Identifier',
-  `item` int(11) unsigned NOT NULL default '0' COMMENT 'Item Identifier',
-  `time` bigint(20) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`spell`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier, Low part',
+  `spell` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Spell Identifier',
+  `item` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Item Identifier',
+  `time` bigint(20) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`spell`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -926,37 +855,37 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_stats`;
 CREATE TABLE `character_stats` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier, Low part',
-  `maxhealth` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower1` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower2` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower3` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower4` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower5` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower6` int(10) UNSIGNED NOT NULL default '0',
-  `maxpower7` int(10) UNSIGNED NOT NULL default '0',
-  `strength` int(10) UNSIGNED NOT NULL default '0',
-  `agility` int(10) UNSIGNED NOT NULL default '0',
-  `stamina` int(10) UNSIGNED NOT NULL default '0',
-  `intellect` int(10) UNSIGNED NOT NULL default '0',
-  `spirit` int(10) UNSIGNED NOT NULL default '0',
-  `armor` int(10) UNSIGNED NOT NULL default '0',
-  `resHoly` int(10) UNSIGNED NOT NULL default '0',
-  `resFire` int(10) UNSIGNED NOT NULL default '0',
-  `resNature` int(10) UNSIGNED NOT NULL default '0',
-  `resFrost` int(10) UNSIGNED NOT NULL default '0',
-  `resShadow` int(10) UNSIGNED NOT NULL default '0',
-  `resArcane` int(10) UNSIGNED NOT NULL default '0',
-  `blockPct` float UNSIGNED NOT NULL default '0',
-  `dodgePct` float UNSIGNED NOT NULL default '0',
-  `parryPct` float UNSIGNED NOT NULL default '0',
-  `critPct` float UNSIGNED NOT NULL default '0',
-  `rangedCritPct` float UNSIGNED NOT NULL default '0',
-  `spellCritPct` float UNSIGNED NOT NULL default '0',
-  `attackPower` int(10) UNSIGNED NOT NULL default '0',
-  `rangedAttackPower` int(10) UNSIGNED NOT NULL default '0',
-  `spellPower` int(10) UNSIGNED NOT NULL default '0',
-  PRIMARY KEY  (`guid`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier, Low part',
+  `maxhealth` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower1` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower2` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower3` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower4` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower5` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower6` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxpower7` int(10) unsigned NOT NULL DEFAULT '0',
+  `strength` int(10) unsigned NOT NULL DEFAULT '0',
+  `agility` int(10) unsigned NOT NULL DEFAULT '0',
+  `stamina` int(10) unsigned NOT NULL DEFAULT '0',
+  `intellect` int(10) unsigned NOT NULL DEFAULT '0',
+  `spirit` int(10) unsigned NOT NULL DEFAULT '0',
+  `armor` int(10) unsigned NOT NULL DEFAULT '0',
+  `resHoly` int(10) unsigned NOT NULL DEFAULT '0',
+  `resFire` int(10) unsigned NOT NULL DEFAULT '0',
+  `resNature` int(10) unsigned NOT NULL DEFAULT '0',
+  `resFrost` int(10) unsigned NOT NULL DEFAULT '0',
+  `resShadow` int(10) unsigned NOT NULL DEFAULT '0',
+  `resArcane` int(10) unsigned NOT NULL DEFAULT '0',
+  `blockPct` float unsigned NOT NULL DEFAULT '0',
+  `dodgePct` float unsigned NOT NULL DEFAULT '0',
+  `parryPct` float unsigned NOT NULL DEFAULT '0',
+  `critPct` float unsigned NOT NULL DEFAULT '0',
+  `rangedCritPct` float unsigned NOT NULL DEFAULT '0',
+  `spellCritPct` float unsigned NOT NULL DEFAULT '0',
+  `attackPower` int(10) unsigned NOT NULL DEFAULT '0',
+  `rangedAttackPower` int(10) unsigned NOT NULL DEFAULT '0',
+  `spellPower` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -979,9 +908,9 @@ CREATE TABLE `character_talent` (
   `current_rank` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `spec` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guid`,`talent_id`,`spec`),
-  KEY guid_key (`guid`),
-  KEY talent_key (`talent_id`),
-  KEY spec_key (`spec`)
+  KEY `guid_key` (`guid`),
+  KEY `talent_key` (`talent_id`),
+  KEY `spec_key` (`spec`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -999,12 +928,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_ticket`;
 CREATE TABLE `character_ticket` (
-  `ticket_id` int(11) unsigned NOT NULL auto_increment,
-  `guid` int(11) unsigned NOT NULL default '0',
+  `ticket_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `guid` int(11) unsigned NOT NULL DEFAULT '0',
   `ticket_text` text,
   `response_text` text,
-  `ticket_lastchange` TIMESTAMP ON  UPDATE  CURRENT_TIMESTAMP  NOT  NULL  DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY  (`ticket_id`)
+  `ticket_lastchange` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`ticket_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -1022,16 +951,16 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `character_tutorial`;
 CREATE TABLE `character_tutorial` (
-  `account` bigint(20) unsigned NOT NULL auto_increment COMMENT 'Account Identifier',
-  `tut0` int(11) unsigned NOT NULL default '0',
-  `tut1` int(11) unsigned NOT NULL default '0',
-  `tut2` int(11) unsigned NOT NULL default '0',
-  `tut3` int(11) unsigned NOT NULL default '0',
-  `tut4` int(11) unsigned NOT NULL default '0',
-  `tut5` int(11) unsigned NOT NULL default '0',
-  `tut6` int(11) unsigned NOT NULL default '0',
-  `tut7` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`account`)
+  `account` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Account Identifier',
+  `tut0` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut1` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut2` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut3` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut4` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut5` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut6` int(11) unsigned NOT NULL DEFAULT '0',
+  `tut7` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`account`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -1044,27 +973,116 @@ LOCK TABLES `character_tutorial` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `characters`
+--
+
+DROP TABLE IF EXISTS `characters`;
+CREATE TABLE `characters` (
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `account` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Account Identifier',
+  `name` varchar(12) NOT NULL DEFAULT '',
+  `race` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `gender` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `level` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `xp` int(10) unsigned NOT NULL DEFAULT '0',
+  `money` int(10) unsigned NOT NULL DEFAULT '0',
+  `playerBytes` int(10) unsigned NOT NULL DEFAULT '0',
+  `playerBytes2` int(10) unsigned NOT NULL DEFAULT '0',
+  `playerFlags` int(10) unsigned NOT NULL DEFAULT '0',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `map` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Map Identifier',
+  `dungeon_difficulty` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `taximask` longtext,
+  `online` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `cinematic` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `totaltime` int(11) unsigned NOT NULL DEFAULT '0',
+  `leveltime` int(11) unsigned NOT NULL DEFAULT '0',
+  `logout_time` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `is_logout_resting` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `rest_bonus` float NOT NULL DEFAULT '0',
+  `resettalents_cost` int(11) unsigned NOT NULL DEFAULT '0',
+  `resettalents_time` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `trans_x` float NOT NULL DEFAULT '0',
+  `trans_y` float NOT NULL DEFAULT '0',
+  `trans_z` float NOT NULL DEFAULT '0',
+  `trans_o` float NOT NULL DEFAULT '0',
+  `transguid` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `extra_flags` int(11) unsigned NOT NULL DEFAULT '0',
+  `stable_slots` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `at_login` int(11) unsigned NOT NULL DEFAULT '0',
+  `zone` int(11) unsigned NOT NULL DEFAULT '0',
+  `death_expire_time` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `taxi_path` text,
+  `arenaPoints` int(10) unsigned NOT NULL DEFAULT '0',
+  `totalHonorPoints` int(10) unsigned NOT NULL DEFAULT '0',
+  `todayHonorPoints` int(10) unsigned NOT NULL DEFAULT '0',
+  `yesterdayHonorPoints` int(10) unsigned NOT NULL DEFAULT '0',
+  `totalKills` int(10) unsigned NOT NULL DEFAULT '0',
+  `todayKills` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `yesterdayKills` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `chosenTitle` int(10) unsigned NOT NULL DEFAULT '0',
+  `knownCurrencies` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `watchedFaction` int(10) unsigned NOT NULL DEFAULT '0',
+  `drunk` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `health` int(10) unsigned NOT NULL DEFAULT '0',
+  `power1` int(10) unsigned NOT NULL DEFAULT '0',
+  `power2` int(10) unsigned NOT NULL DEFAULT '0',
+  `power3` int(10) unsigned NOT NULL DEFAULT '0',
+  `power4` int(10) unsigned NOT NULL DEFAULT '0',
+  `power5` int(10) unsigned NOT NULL DEFAULT '0',
+  `power6` int(10) unsigned NOT NULL DEFAULT '0',
+  `power7` int(10) unsigned NOT NULL DEFAULT '0',
+  `specCount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `activeSpec` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `exploredZones` longtext,
+  `equipmentCache` longtext,
+  `ammoId` int(10) unsigned NOT NULL DEFAULT '0',
+  `knownTitles` longtext,
+  `actionBars` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `deleteInfos_Account` int(11) unsigned DEFAULT NULL,
+  `deleteInfos_Name` varchar(12) DEFAULT NULL,
+  `deleteDate` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`guid`),
+  KEY `idx_account` (`account`),
+  KEY `idx_online` (`online`),
+  KEY `idx_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
+
+--
+-- Dumping data for table `characters`
+--
+
+LOCK TABLES `characters` WRITE;
+/*!40000 ALTER TABLE `characters` DISABLE KEYS */;
+/*!40000 ALTER TABLE `characters` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `corpse`
 --
 
 DROP TABLE IF EXISTS `corpse`;
 CREATE TABLE `corpse` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `player` int(11) unsigned NOT NULL default '0' COMMENT 'Character Global Unique Identifier',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `map` int(11) unsigned NOT NULL default '0' COMMENT 'Map Identifier',
-  `phaseMask` smallint(5) unsigned NOT NULL default '1',
-  `time` bigint(20) unsigned NOT NULL default '0',
-  `corpse_type` tinyint(3) unsigned NOT NULL default '0',
-  `instance` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `player` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Character Global Unique Identifier',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `map` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Map Identifier',
+  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
+  `time` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `corpse_type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `instance` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`),
   KEY `idx_type` (`corpse_type`),
   KEY `instance` (`instance`),
-  INDEX `Idx_player`(`player`),
-  INDEX `Idx_time`(`time`)
+  KEY `Idx_player` (`player`),
+  KEY `Idx_time` (`time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Death System';
 
 --
@@ -1082,10 +1100,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `creature_respawn`;
 CREATE TABLE `creature_respawn` (
-  `guid` int(10) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `respawntime` bigint(20) unsigned NOT NULL default '0',
-  `instance` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`instance`),
+  `guid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `respawntime` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `instance` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`instance`),
   KEY `instance` (`instance`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Grid Loading System';
 
@@ -1104,8 +1122,8 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_event_status`;
 CREATE TABLE `game_event_status` (
-  `event` smallint(6) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`event`)
+  `event` smallint(6) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`event`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Game event system';
 
 --
@@ -1123,10 +1141,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject_respawn`;
 CREATE TABLE `gameobject_respawn` (
-  `guid` int(10) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `respawntime` bigint(20) unsigned NOT NULL default '0',
-  `instance` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`instance`),
+  `guid` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `respawntime` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `instance` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`instance`),
   KEY `instance` (`instance`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Grid Loading System';
 
@@ -1137,6 +1155,51 @@ CREATE TABLE `gameobject_respawn` (
 LOCK TABLES `gameobject_respawn` WRITE;
 /*!40000 ALTER TABLE `gameobject_respawn` DISABLE KEYS */;
 /*!40000 ALTER TABLE `gameobject_respawn` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `group_instance`
+--
+
+DROP TABLE IF EXISTS `group_instance`;
+CREATE TABLE `group_instance` (
+  `leaderGuid` int(11) unsigned NOT NULL DEFAULT '0',
+  `instance` int(11) unsigned NOT NULL DEFAULT '0',
+  `permanent` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`leaderGuid`,`instance`),
+  KEY `instance` (`instance`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `group_instance`
+--
+
+LOCK TABLES `group_instance` WRITE;
+/*!40000 ALTER TABLE `group_instance` DISABLE KEYS */;
+/*!40000 ALTER TABLE `group_instance` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `group_member`
+--
+
+DROP TABLE IF EXISTS `group_member`;
+CREATE TABLE `group_member` (
+  `groupId` int(11) unsigned NOT NULL,
+  `memberGuid` int(11) unsigned NOT NULL,
+  `assistant` tinyint(1) unsigned NOT NULL,
+  `subgroup` smallint(6) unsigned NOT NULL,
+  PRIMARY KEY (`groupId`,`memberGuid`),
+  KEY `Idx_memberGuid` (`memberGuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Groups';
+
+--
+-- Dumping data for table `group_member`
+--
+
+LOCK TABLES `group_member` WRITE;
+/*!40000 ALTER TABLE `group_member` DISABLE KEYS */;
+/*!40000 ALTER TABLE `group_member` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
@@ -1161,10 +1224,10 @@ CREATE TABLE `groups` (
   `icon7` int(11) unsigned NOT NULL,
   `icon8` int(11) unsigned NOT NULL,
   `groupType` tinyint(1) unsigned NOT NULL,
-  `difficulty` tinyint(3) unsigned NOT NULL default '0',
-  `raiddifficulty` int(11) UNSIGNED NOT NULL default '0',
-  PRIMARY KEY  (`groupId`),
-  UNIQUE KEY  (`leaderGuid`)
+  `difficulty` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `raiddifficulty` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`groupId`),
+  UNIQUE KEY `leaderGuid` (`leaderGuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Groups';
 
 --
@@ -1176,69 +1239,25 @@ LOCK TABLES `groups` WRITE;
 /*!40000 ALTER TABLE `groups` ENABLE KEYS */;
 UNLOCK TABLES;
 
--- ----------------------------
--- Table structure for group_instance
--- ----------------------------
-DROP TABLE IF EXISTS `group_instance`;
-CREATE TABLE `group_instance` (
-  `leaderGuid` int(11) unsigned NOT NULL default '0',
-  `instance` int(11) unsigned NOT NULL default '0',
-  `permanent` tinyint(1) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`leaderGuid`,`instance`),
-  KEY `instance` (`instance`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
---
--- Dumping data for table `group_instance`
---
-
-LOCK TABLES `group_instance` WRITE;
-/*!40000 ALTER TABLE `group_instance` DISABLE KEYS */;
-/*!40000 ALTER TABLE `group_instance` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `group_member`
---
-
-DROP TABLE IF EXISTS `group_member`;
-CREATE TABLE `group_member` (
-  `groupId` int(11) unsigned NOT NULL,
-  `memberGuid` int(11) unsigned NOT NULL,
-  `assistant` tinyint(1) unsigned NOT NULL,
-  `subgroup` smallint(6) unsigned NOT NULL,
-  PRIMARY KEY  (`groupId`,`memberGuid`),
-  INDEX `Idx_memberGuid`(`memberGuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Groups';
-
---
--- Dumping data for table `group_member`
---
-
-LOCK TABLES `group_member` WRITE;
-/*!40000 ALTER TABLE `group_member` DISABLE KEYS */;
-/*!40000 ALTER TABLE `group_member` ENABLE KEYS */;
-UNLOCK TABLES;
-
 --
 -- Table structure for table `guild`
 --
 
 DROP TABLE IF EXISTS `guild`;
 CREATE TABLE `guild` (
-  `guildid` int(6) unsigned NOT NULL default '0',
-  `name` varchar(255) NOT NULL default '',
-  `leaderguid` int(6) unsigned NOT NULL default '0',
-  `EmblemStyle` int(5) NOT NULL default '0',
-  `EmblemColor` int(5) NOT NULL default '0',
-  `BorderStyle` int(5) NOT NULL default '0',
-  `BorderColor` int(5) NOT NULL default '0',
-  `BackgroundColor` int(5) NOT NULL default '0',
+  `guildid` int(6) unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `leaderguid` int(6) unsigned NOT NULL DEFAULT '0',
+  `EmblemStyle` int(5) NOT NULL DEFAULT '0',
+  `EmblemColor` int(5) NOT NULL DEFAULT '0',
+  `BorderStyle` int(5) NOT NULL DEFAULT '0',
+  `BorderColor` int(5) NOT NULL DEFAULT '0',
+  `BackgroundColor` int(5) NOT NULL DEFAULT '0',
   `info` text NOT NULL,
-  `motd` varchar(255) NOT NULL default '',
-  `createdate` bigint(20) unsigned NOT NULL default '0',
-  `BankMoney` bigint(20) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guildid`)
+  `motd` varchar(255) NOT NULL DEFAULT '',
+  `createdate` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `BankMoney` bigint(20) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guildid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Guild System';
 
 --
@@ -1256,19 +1275,19 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `guild_bank_eventlog`;
 CREATE TABLE `guild_bank_eventlog` (
-  `guildid` int(11) unsigned NOT NULL default '0' COMMENT 'Guild Identificator',
-  `LogGuid` int(11) unsigned NOT NULL default '0' COMMENT 'Log record identificator - auxiliary column',
-  `TabId` tinyint(3) unsigned NOT NULL default '0' COMMENT 'Guild bank TabId',
-  `EventType` tinyint(3) unsigned NOT NULL default '0' COMMENT 'Event type',
-  `PlayerGuid` int(11) unsigned NOT NULL default '0',
-  `ItemOrMoney` int(11) unsigned NOT NULL default '0',
-  `ItemStackCount` tinyint(3) unsigned NOT NULL default '0',
-  `DestTabId` tinyint(1) unsigned NOT NULL default '0' COMMENT 'Destination Tab Id',
-  `TimeStamp` bigint(20) unsigned NOT NULL default '0' COMMENT 'Event UNIX time',
-  PRIMARY KEY  (`guildid`,`LogGuid`,`TabId`),
+  `guildid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Guild Identificator',
+  `LogGuid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Log record identificator - auxiliary column',
+  `TabId` tinyint(3) unsigned NOT NULL DEFAULT '0' COMMENT 'Guild bank TabId',
+  `EventType` tinyint(3) unsigned NOT NULL DEFAULT '0' COMMENT 'Event type',
+  `PlayerGuid` int(11) unsigned NOT NULL DEFAULT '0',
+  `ItemOrMoney` int(11) unsigned NOT NULL DEFAULT '0',
+  `ItemStackCount` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `DestTabId` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Destination Tab Id',
+  `TimeStamp` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'Event UNIX time',
+  PRIMARY KEY (`guildid`,`LogGuid`,`TabId`),
   KEY `guildid_key` (`guildid`),
-  INDEX `Idx_PlayerGuid`(`PlayerGuid`),
-  INDEX `Idx_LogGuid`(`LogGuid`)
+  KEY `Idx_PlayerGuid` (`PlayerGuid`),
+  KEY `Idx_LogGuid` (`LogGuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1286,14 +1305,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `guild_bank_item`;
 CREATE TABLE `guild_bank_item` (
-  `guildid` int(11) unsigned NOT NULL default '0',
-  `TabId` tinyint(1) unsigned NOT NULL default '0',
-  `SlotId` tinyint(3) unsigned NOT NULL default '0',
-  `item_guid` int(11) unsigned NOT NULL default '0',
-  `item_entry` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guildid`,`tabid`,`slotid`),
+  `guildid` int(11) unsigned NOT NULL DEFAULT '0',
+  `TabId` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `SlotId` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `item_guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `item_entry` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guildid`,`TabId`,`SlotId`),
   KEY `guildid_key` (`guildid`),
-  INDEX `Idx_item_guid`(`item_guid`)
+  KEY `Idx_item_guid` (`item_guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1311,12 +1330,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `guild_bank_right`;
 CREATE TABLE `guild_bank_right` (
-  `guildid` int(11) unsigned NOT NULL default '0',
-  `TabId` tinyint(1) unsigned NOT NULL default '0',
-  `rid` int(11) unsigned NOT NULL default '0',
-  `gbright` tinyint(3) unsigned NOT NULL default '0',
-  `SlotPerDay` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guildid`,`TabId`,`rid`),
+  `guildid` int(11) unsigned NOT NULL DEFAULT '0',
+  `TabId` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `rid` int(11) unsigned NOT NULL DEFAULT '0',
+  `gbright` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `SlotPerDay` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guildid`,`TabId`,`rid`),
   KEY `guildid_key` (`guildid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1335,12 +1354,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `guild_bank_tab`;
 CREATE TABLE `guild_bank_tab` (
-  `guildid` int(11) unsigned NOT NULL default '0',
-  `TabId` tinyint(1) unsigned NOT NULL default '0',
-  `TabName` varchar(100) NOT NULL default '',
-  `TabIcon` varchar(100) NOT NULL default '',
+  `guildid` int(11) unsigned NOT NULL DEFAULT '0',
+  `TabId` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `TabName` varchar(100) NOT NULL DEFAULT '',
+  `TabIcon` varchar(100) NOT NULL DEFAULT '',
   `TabText` text,
-  PRIMARY KEY  (`guildid`,`TabId`),
+  PRIMARY KEY (`guildid`,`TabId`),
   KEY `guildid_key` (`guildid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1366,11 +1385,11 @@ CREATE TABLE `guild_eventlog` (
   `PlayerGuid2` int(11) unsigned NOT NULL COMMENT 'Player 2',
   `NewRank` tinyint(2) unsigned NOT NULL COMMENT 'New rank(in case promotion/demotion)',
   `TimeStamp` bigint(20) unsigned NOT NULL COMMENT 'Event UNIX time',
-  PRIMARY KEY (`guildid`, `LogGuid`),
-  INDEX `Idx_PlayerGuid1`(`PlayerGuid1`),
-  INDEX `Idx_PlayerGuid2`(`PlayerGuid2`),
-  INDEX `Idx_LogGuid`(`LogGuid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT 'Guild Eventlog';
+  PRIMARY KEY (`guildid`,`LogGuid`),
+  KEY `Idx_PlayerGuid1` (`PlayerGuid1`),
+  KEY `Idx_PlayerGuid2` (`PlayerGuid2`),
+  KEY `Idx_LogGuid` (`LogGuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Guild Eventlog';
 
 --
 -- Dumping data for table `guild_eventlog`
@@ -1387,28 +1406,28 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `guild_member`;
 CREATE TABLE `guild_member` (
-  `guildid` int(6) unsigned NOT NULL default '0',
-  `guid` int(11) unsigned NOT NULL default '0',
-  `rank` tinyint(2) unsigned NOT NULL default '0',
-  `pnote` varchar(255) NOT NULL default '',
-  `offnote` varchar(255) NOT NULL default '',
-  `BankResetTimeMoney` int(11) unsigned NOT NULL default '0',
-  `BankRemMoney` int(11) unsigned NOT NULL default '0',
-  `BankResetTimeTab0` int(11) unsigned NOT NULL default '0',
-  `BankRemSlotsTab0` int(11) unsigned NOT NULL default '0',
-  `BankResetTimeTab1` int(11) unsigned NOT NULL default '0',
-  `BankRemSlotsTab1` int(11) unsigned NOT NULL default '0',
-  `BankResetTimeTab2` int(11) unsigned NOT NULL default '0',
-  `BankRemSlotsTab2` int(11) unsigned NOT NULL default '0',
-  `BankResetTimeTab3` int(11) unsigned NOT NULL default '0',
-  `BankRemSlotsTab3` int(11) unsigned NOT NULL default '0',
-  `BankResetTimeTab4` int(11) unsigned NOT NULL default '0',
-  `BankRemSlotsTab4` int(11) unsigned NOT NULL default '0',
-  `BankResetTimeTab5` int(11) unsigned NOT NULL default '0',
-  `BankRemSlotsTab5` int(11) unsigned NOT NULL default '0',
+  `guildid` int(6) unsigned NOT NULL DEFAULT '0',
+  `guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `rank` tinyint(2) unsigned NOT NULL DEFAULT '0',
+  `pnote` varchar(255) NOT NULL DEFAULT '',
+  `offnote` varchar(255) NOT NULL DEFAULT '',
+  `BankResetTimeMoney` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemMoney` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankResetTimeTab0` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemSlotsTab0` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankResetTimeTab1` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemSlotsTab1` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankResetTimeTab2` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemSlotsTab2` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankResetTimeTab3` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemSlotsTab3` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankResetTimeTab4` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemSlotsTab4` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankResetTimeTab5` int(11) unsigned NOT NULL DEFAULT '0',
+  `BankRemSlotsTab5` int(11) unsigned NOT NULL DEFAULT '0',
+  UNIQUE KEY `guid_key` (`guid`),
   KEY `guildid_key` (`guildid`),
-  KEY `guildid_rank_key` (`guildid`,`rank`),
-  UNIQUE KEY `guid_key` (`guid`)
+  KEY `guildid_rank_key` (`guildid`,`rank`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Guild System';
 
 --
@@ -1426,13 +1445,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `guild_rank`;
 CREATE TABLE `guild_rank` (
-  `guildid` int(6) unsigned NOT NULL default '0',
+  `guildid` int(6) unsigned NOT NULL DEFAULT '0',
   `rid` int(11) unsigned NOT NULL,
-  `rname` varchar(255) NOT NULL default '',
-  `rights` int(3) unsigned NOT NULL default '0',
-  `BankMoneyPerDay` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guildid`,`rid`),
-  INDEX `Idx_rid`(`rid`)
+  `rname` varchar(255) NOT NULL DEFAULT '',
+  `rights` int(3) unsigned NOT NULL DEFAULT '0',
+  `BankMoneyPerDay` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guildid`,`rid`),
+  KEY `Idx_rid` (`rid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Guild System';
 
 --
@@ -1450,13 +1469,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `instance`;
 CREATE TABLE `instance` (
-  `id` int(11) unsigned NOT NULL default '0',
-  `map` int(11) unsigned NOT NULL default '0',
-  `resettime` bigint(40) unsigned NOT NULL default '0',
-  `difficulty` tinyint(1) unsigned NOT NULL default '0',
-  `encountersMask` int(10) unsigned NOT NULL default '0',
+  `id` int(11) unsigned NOT NULL DEFAULT '0',
+  `map` int(11) unsigned NOT NULL DEFAULT '0',
+  `resettime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `difficulty` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `encountersMask` int(10) unsigned NOT NULL DEFAULT '0',
   `data` longtext,
-  PRIMARY KEY  (`id`),
+  PRIMARY KEY (`id`),
   KEY `map` (`map`),
   KEY `resettime` (`resettime`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -1470,15 +1489,16 @@ LOCK TABLES `instance` WRITE;
 /*!40000 ALTER TABLE `instance` ENABLE KEYS */;
 UNLOCK TABLES;
 
--- ----------------------------
--- Table structure for instance_reset
--- ----------------------------
+--
+-- Table structure for table `instance_reset`
+--
+
 DROP TABLE IF EXISTS `instance_reset`;
 CREATE TABLE `instance_reset` (
-  `mapid` int(11) unsigned NOT NULL default '0',
-  `difficulty` tinyint(1) unsigned NOT NULL default '0',
-  `resettime` bigint(40) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`mapid`,`difficulty`)
+  `mapid` int(11) unsigned NOT NULL DEFAULT '0',
+  `difficulty` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `resettime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`mapid`,`difficulty`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1496,11 +1516,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_instance`;
 CREATE TABLE `item_instance` (
-  `guid` int(11) unsigned NOT NULL default '0',
-  `owner_guid` int(11) unsigned NOT NULL default '0',
+  `guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `owner_guid` int(11) unsigned NOT NULL DEFAULT '0',
   `data` longtext,
   `text` longtext,
-  PRIMARY KEY  (`guid`),
+  PRIMARY KEY (`guid`),
   KEY `idx_owner_guid` (`owner_guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Item System';
 
@@ -1519,13 +1539,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_loot`;
 CREATE TABLE `item_loot` (
-  `guid` int(11) unsigned NOT NULL default '0',
-  `owner_guid` int(11) unsigned NOT NULL default '0',
-  `itemid` int(11) unsigned NOT NULL default '0',
-  `amount` int(11) unsigned NOT NULL default '0',
-  `suffix` int(11) unsigned NOT NULL default '0',
-  `property` int(11) NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`itemid`),
+  `guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `owner_guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `itemid` int(11) unsigned NOT NULL DEFAULT '0',
+  `amount` int(11) unsigned NOT NULL DEFAULT '0',
+  `suffix` int(11) unsigned NOT NULL DEFAULT '0',
+  `property` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`itemid`),
   KEY `idx_owner_guid` (`owner_guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Item System';
 
@@ -1544,21 +1564,21 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `mail`;
 CREATE TABLE `mail` (
-  `id` int(11) unsigned NOT NULL default '0' COMMENT 'Identifier',
-  `messageType` tinyint(3) unsigned NOT NULL default '0',
-  `stationery` tinyint(3) NOT NULL default '41',
-  `mailTemplateId` mediumint(8) unsigned NOT NULL default '0',
-  `sender` int(11) unsigned NOT NULL default '0' COMMENT 'Character Global Unique Identifier',
-  `receiver` int(11) unsigned NOT NULL default '0' COMMENT 'Character Global Unique Identifier',
+  `id` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
+  `messageType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stationery` tinyint(3) NOT NULL DEFAULT '41',
+  `mailTemplateId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `sender` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Character Global Unique Identifier',
+  `receiver` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Character Global Unique Identifier',
   `subject` longtext,
   `body` longtext,
-  `has_items` tinyint(3) unsigned NOT NULL default '0',
-  `expire_time` bigint(40) unsigned NOT NULL default '0',
-  `deliver_time` bigint(40) unsigned NOT NULL default '0',
-  `money` int(11) unsigned NOT NULL default '0',
-  `cod` int(11) unsigned NOT NULL default '0',
-  `checked` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`id`),
+  `has_items` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `expire_time` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `deliver_time` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `money` int(11) unsigned NOT NULL DEFAULT '0',
+  `cod` int(11) unsigned NOT NULL DEFAULT '0',
+  `checked` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
   KEY `idx_receiver` (`receiver`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Mail System';
 
@@ -1577,11 +1597,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `mail_items`;
 CREATE TABLE `mail_items` (
-  `mail_id` int(11) NOT NULL default '0',
-  `item_guid` int(11) NOT NULL default '0',
-  `item_template` int(11) NOT NULL default '0',
-  `receiver` int(11) unsigned NOT NULL default '0' COMMENT 'Character Global Unique Identifier',
-  PRIMARY KEY  (`mail_id`,`item_guid`),
+  `mail_id` int(11) NOT NULL DEFAULT '0',
+  `item_guid` int(11) NOT NULL DEFAULT '0',
+  `item_template` int(11) NOT NULL DEFAULT '0',
+  `receiver` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Character Global Unique Identifier',
+  PRIMARY KEY (`mail_id`,`item_guid`),
   KEY `idx_receiver` (`receiver`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
 
@@ -1600,21 +1620,21 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pet_aura`;
 CREATE TABLE `pet_aura` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `caster_guid` bigint(20) unsigned NOT NULL default '0' COMMENT 'Full Global Unique Identifier',
-  `item_guid` int(11) unsigned NOT NULL default '0',
-  `spell` int(11) unsigned NOT NULL default '0',
-  `stackcount` INT(11) UNSIGNED NOT NULL DEFAULT '1',
-  `remaincharges` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `basepoints0` INT(11) NOT NULL DEFAULT '0',
-  `basepoints1` INT(11) NOT NULL DEFAULT '0',
-  `basepoints2` INT(11) NOT NULL DEFAULT '0',
-  `periodictime0` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `periodictime1` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `periodictime2` INT(11) UNSIGNED NOT NULL DEFAULT '0',
-  `maxduration` INT(11) NOT NULL DEFAULT '0',
-  `remaintime` INT(11) NOT NULL DEFAULT '0',
-  `effIndexMask` INT(11) UNSIGNED NOT NULL DEFAULT '0',
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `caster_guid` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'Full Global Unique Identifier',
+  `item_guid` int(11) unsigned NOT NULL DEFAULT '0',
+  `spell` int(11) unsigned NOT NULL DEFAULT '0',
+  `stackcount` int(11) unsigned NOT NULL DEFAULT '1',
+  `remaincharges` int(11) unsigned NOT NULL DEFAULT '0',
+  `basepoints0` int(11) NOT NULL DEFAULT '0',
+  `basepoints1` int(11) NOT NULL DEFAULT '0',
+  `basepoints2` int(11) NOT NULL DEFAULT '0',
+  `periodictime0` int(11) unsigned NOT NULL DEFAULT '0',
+  `periodictime1` int(11) unsigned NOT NULL DEFAULT '0',
+  `periodictime2` int(11) unsigned NOT NULL DEFAULT '0',
+  `maxduration` int(11) NOT NULL DEFAULT '0',
+  `remaintime` int(11) NOT NULL DEFAULT '0',
+  `effIndexMask` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guid`,`caster_guid`,`item_guid`,`spell`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Pet System';
 
@@ -1633,10 +1653,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pet_spell`;
 CREATE TABLE `pet_spell` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier',
-  `spell` int(11) unsigned NOT NULL default '0' COMMENT 'Spell Identifier',
-  `active` int(11) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`spell`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
+  `spell` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Spell Identifier',
+  `active` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`spell`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Pet System';
 
 --
@@ -1654,10 +1674,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pet_spell_cooldown`;
 CREATE TABLE `pet_spell_cooldown` (
-  `guid` int(11) unsigned NOT NULL default '0' COMMENT 'Global Unique Identifier, Low part',
-  `spell` int(11) unsigned NOT NULL default '0' COMMENT 'Spell Identifier',
-  `time` bigint(20) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`spell`)
+  `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier, Low part',
+  `spell` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Spell Identifier',
+  `time` bigint(20) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`spell`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1676,10 +1696,10 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `petition`;
 CREATE TABLE `petition` (
   `ownerguid` int(10) unsigned NOT NULL,
-  `petitionguid` int(10) unsigned default '0',
-  `name` varchar(255) NOT NULL default '',
-  `type` int(10) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`ownerguid`,`type`),
+  `petitionguid` int(10) unsigned DEFAULT '0',
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `type` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ownerguid`,`type`),
   UNIQUE KEY `index_ownerguid_petitionguid` (`ownerguid`,`petitionguid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Guild System';
 
@@ -1699,13 +1719,13 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `petition_sign`;
 CREATE TABLE `petition_sign` (
   `ownerguid` int(10) unsigned NOT NULL,
-  `petitionguid` int(11) unsigned NOT NULL default '0',
-  `playerguid` int(11) unsigned NOT NULL default '0',
-  `player_account` int(11) unsigned NOT NULL default '0',
-  `type` int(10) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`petitionguid`,`playerguid`),
-  INDEX `Idx_playerguid`(`playerguid`),
-  INDEX `Idx_ownerguid`(`ownerguid`)
+  `petitionguid` int(11) unsigned NOT NULL DEFAULT '0',
+  `playerguid` int(11) unsigned NOT NULL DEFAULT '0',
+  `player_account` int(11) unsigned NOT NULL DEFAULT '0',
+  `type` int(10) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`petitionguid`,`playerguid`),
+  KEY `Idx_playerguid` (`playerguid`),
+  KEY `Idx_ownerguid` (`ownerguid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Guild System';
 
 --
@@ -1716,7 +1736,6 @@ LOCK TABLES `petition_sign` WRITE;
 /*!40000 ALTER TABLE `petition_sign` DISABLE KEYS */;
 /*!40000 ALTER TABLE `petition_sign` ENABLE KEYS */;
 UNLOCK TABLES;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 --
 -- Table structure for table `saved_variables`
@@ -1724,11 +1743,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `saved_variables`;
 CREATE TABLE `saved_variables` (
-    `NextArenaPointDistributionTime` bigint(40) UNSIGNED NOT NULL DEFAULT '0',
-    `NextDailyQuestResetTime` bigint(40) unsigned NOT NULL default '0',
-    `NextWeeklyQuestResetTime` bigint(40) unsigned NOT NULL default '0',
-    `NextMonthlyQuestResetTime` bigint(40) unsigned NOT NULL default '0',
-    `cleaning_flags` int(11) unsigned NOT NULL default '0'
+  `NextArenaPointDistributionTime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `NextDailyQuestResetTime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `NextWeeklyQuestResetTime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `NextMonthlyQuestResetTime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `cleaning_flags` int(11) unsigned NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Variable Saves';
 
 --
@@ -1739,7 +1758,6 @@ LOCK TABLES `saved_variables` WRITE;
 /*!40000 ALTER TABLE `saved_variables` DISABLE KEYS */;
 /*!40000 ALTER TABLE `saved_variables` ENABLE KEYS */;
 UNLOCK TABLES;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 --
 -- Table structure for table `world`
@@ -1747,9 +1765,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `world`;
 CREATE TABLE `world` (
-  `map` int(11) unsigned NOT NULL default '0',
+  `map` int(11) unsigned NOT NULL DEFAULT '0',
   `data` longtext,
-  PRIMARY KEY  (`map`)
+  PRIMARY KEY (`map`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1760,6 +1778,7 @@ LOCK TABLES `world` WRITE;
 /*!40000 ALTER TABLE `world` DISABLE KEYS */;
 /*!40000 ALTER TABLE `world` ENABLE KEYS */;
 UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
@@ -1769,4 +1788,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2008-01-10 11:37:06
+-- Dump completed on 2013-05-13 11:54:24

--- a/sql/mangos.sql
+++ b/sql/mangos.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.11
+-- MySQL dump 10.13
 --
 -- Host: localhost    Database: mangos
 -- ------------------------------------------------------
--- Server version    5.0.56-nt
+-- Server version	5.5.15
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -21,10 +21,10 @@
 
 DROP TABLE IF EXISTS `db_version`;
 CREATE TABLE `db_version` (
-  `version` varchar(120) default NULL,
-  `creature_ai_version` varchar(120) default NULL,
-  `cache_id` int(10) default '0',
-  `required_12465_01_mangos_spell_template` bit(1) default NULL
+  `version` varchar(120) DEFAULT NULL,
+  `creature_ai_version` varchar(120) DEFAULT NULL,
+  `cache_id` int(10) DEFAULT '0',
+  `required_12465_01_mangos_spell_template` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Used DB version notes';
 
 --
@@ -66,15 +66,15 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `achievement_reward`;
 CREATE TABLE `achievement_reward` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `gender` tinyint(3) default '2',
-  `title_A` mediumint(8) unsigned NOT NULL default '0',
-  `title_H` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `sender` mediumint(8) unsigned NOT NULL default '0',
-  `subject` varchar(255) default NULL,
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `gender` tinyint(3) NOT NULL DEFAULT '2',
+  `title_A` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `title_H` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `sender` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `subject` varchar(255) DEFAULT NULL,
   `text` text,
-  PRIMARY KEY  (`entry`,`gender`)
+  PRIMARY KEY (`entry`,`gender`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Achievment system';
 
 --
@@ -92,9 +92,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `areatrigger_involvedrelation`;
 CREATE TABLE `areatrigger_involvedrelation` (
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Identifier',
-  `quest` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`id`)
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Trigger System';
 
 --
@@ -112,9 +112,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `areatrigger_tavern`;
 CREATE TABLE `areatrigger_tavern` (
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Identifier',
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
   `name` text,
-  PRIMARY KEY  (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Trigger System';
 
 --
@@ -132,21 +132,21 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `areatrigger_teleport`;
 CREATE TABLE `areatrigger_teleport` (
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Identifier',
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
   `name` text,
-  `required_level` tinyint(3) unsigned NOT NULL default '0',
-  `required_item` mediumint(8) unsigned NOT NULL default '0',
-  `required_item2` mediumint(8) unsigned NOT NULL default '0',
-  `heroic_key` mediumint(8) unsigned NOT NULL default '0',
-  `heroic_key2` mediumint(8) unsigned NOT NULL default '0',
-  `required_quest_done` int(11) unsigned NOT NULL default '0',
-  `required_quest_done_heroic` int(11) unsigned NOT NULL default '0',
-  `target_map` smallint(5) unsigned NOT NULL default '0',
-  `target_position_x` float NOT NULL default '0',
-  `target_position_y` float NOT NULL default '0',
-  `target_position_z` float NOT NULL default '0',
-  `target_orientation` float NOT NULL default '0',
-  PRIMARY KEY  (`id`)
+  `required_level` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `required_item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `required_item2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `heroic_key` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `heroic_key2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `required_quest_done` int(11) unsigned NOT NULL DEFAULT '0',
+  `required_quest_done_heroic` int(11) unsigned NOT NULL DEFAULT '0',
+  `target_map` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `target_position_x` float NOT NULL DEFAULT '0',
+  `target_position_y` float NOT NULL DEFAULT '0',
+  `target_position_z` float NOT NULL DEFAULT '0',
+  `target_orientation` float NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Trigger System';
 
 --
@@ -168,7 +168,7 @@ CREATE TABLE `battleground_events` (
   `event1` tinyint(3) unsigned NOT NULL,
   `event2` tinyint(3) unsigned NOT NULL,
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (`map`,`event1`,`event2`)
+  PRIMARY KEY (`map`,`event1`,`event2`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -177,234 +177,203 @@ CREATE TABLE `battleground_events` (
 
 LOCK TABLES `battleground_events` WRITE;
 /*!40000 ALTER TABLE `battleground_events` DISABLE KEYS */;
-INSERT INTO battleground_events (map, event1, event2, description) VALUES
+INSERT INTO `battleground_events` VALUES
 -- WS
-(489, 0, 0, 'Alliance Flag'),
-(489, 1, 0, 'Horde Flag'),
-(489, 2, 0, 'Spirit Guides'),
-(489, 254, 0, 'Doors'),
+(489,0,0,'Alliance Flag'),
+(489,1,0,'Horde Flag'),
+(489,2,0,'Spirit Guides'),
+(489,254,0,'Doors'),
 -- AB
-(529, 0, 0, 'Stables - neutral'),
-(529, 0, 1, 'Stables - alliance contested'),
-(529, 0, 2, 'Stables - horde contested'),
-(529, 0, 3, 'Stables - alliance owned'),
-(529, 0, 4, 'Stables - horde owned'),
-(529, 1, 0, 'Blacksmith - neutral'),
-(529, 1, 1, 'Blacksmith - alliance contested'),
-(529, 1, 2, 'Blacksmith - horde contested'),
-(529, 1, 3, 'Blacksmith - alliance owned'),
-(529, 1, 4, 'Blacksmith - horde owned'),
-(529, 2, 0, 'Farm - neutral'),
-(529, 2, 1, 'Farm - alliance contested'),
-(529, 2, 2, 'Farm - horde contested'),
-(529, 2, 3, 'Farm - alliance owned'),
-(529, 2, 4, 'Farm - horde owned'),
-(529, 3, 0, 'Lumber Mill - neutral'),
-(529, 3, 1, 'Lumber Mill - alliance contested'),
-(529, 3, 2, 'Lumber Mill - horde contested'),
-(529, 3, 3, 'Lumber Mill - alliance owned'),
-(529, 3, 4, 'Lumber Mill - horde owned'),
-(529, 4, 0, 'Gold Mine - neutral'),
-(529, 4, 1, 'Gold Mine - alliance contested'),
-(529, 4, 2, 'Gold Mine - horde contested'),
-(529, 4, 3, 'Gold Mine - alliance owned'),
-(529, 4, 4, 'Gold Mine - horde owned'),
-(529, 254, 0, 'doors'),
+(529,0,0,'Stables - neutral'),
+(529,0,1,'Stables - alliance contested'),
+(529,0,2,'Stables - horde contested'),
+(529,0,3,'Stables - alliance owned'),
+(529,0,4,'Stables - horde owned'),
+(529,1,0,'Blacksmith - neutral'),
+(529,1,1,'Blacksmith - alliance contested'),
+(529,1,2,'Blacksmith - horde contested'),
+(529,1,3,'Blacksmith - alliance owned'),
+(529,1,4,'Blacksmith - horde owned'),
+(529,2,0,'Farm - neutral'),
+(529,2,1,'Farm - alliance contested'),
+(529,2,2,'Farm - horde contested'),
+(529,2,3,'Farm - alliance owned'),
+(529,2,4,'Farm - horde owned'),
+(529,3,0,'Lumber Mill - neutral'),
+(529,3,1,'Lumber Mill - alliance contested'),
+(529,3,2,'Lumber Mill - horde contested'),
+(529,3,3,'Lumber Mill - alliance owned'),
+(529,3,4,'Lumber Mill - horde owned'),
+(529,4,0,'Gold Mine - neutral'),
+(529,4,1,'Gold Mine - alliance contested'),
+(529,4,2,'Gold Mine - horde contested'),
+(529,4,3,'Gold Mine - alliance owned'),
+(529,4,4,'Gold Mine - horde owned'),
+(529,254,0,'doors'),
 -- EY
-(566, 0, 0, 'Fel Reaver - alliance'),
-(566, 0, 1, 'Fel Reaver - horde'),
-(566, 0, 2, 'Fel Reaver - neutral'),
-(566, 1, 0, 'Blood Elf - alliance'),
-(566, 1, 1, 'Blood Elf - horde'),
-(566, 1, 2, 'Blood Elf - neutral'),
-(566, 2, 0, 'Draenei Ruins - alliance'),
-(566, 2, 1, 'Draenei Ruins - horde'),
-(566, 2, 2, 'Draenei Ruins - neutral'),
-(566, 3, 0, 'Mage Tower - alliance'),
-(566, 3, 1, 'Mage Tower - horde'),
-(566, 3, 2, 'Mage Tower - neutral'),
-(566, 4, 0, 'capture flag - Fel Reaver'),
-(566, 4, 1, 'capture flag - Blood Elf'),
-(566, 4, 2, 'capture flag - Draenei Ruins'),
-(566, 4, 3, 'capture flag - Mage Tower'),
-(566, 4, 4, 'capture flag - center'),
-(566, 254, 0, 'doors'),
--- arenas
-(559, 253, 0, 'buffs'),
-(559, 254, 0, 'doors'),
-(572, 253, 0, 'buffs'),
-(572, 254, 0, 'doors'),
-(562, 253, 0, 'buffs'),
-(562, 254, 0, 'doors'),
--- alterac valley
-(30, 254, 0, 'Doors'),
-
-(30, 0, 0, 'Firstaid Station - Alliance assaulted'),
-(30, 0, 1, 'Firstaid Station - ALliance control'),
-(30, 0, 2, 'Firstaid Station - Horde assaulted'),
-(30, 0, 3, 'Firstaid Station - Horde control'),
-
-(30, 1, 0, 'Stormpike Grave - Alliance assaulted'),
-(30, 1, 1, 'Stormpike Grave - ALliance control'),
-(30, 1, 2, 'Stormpike Grave - Horde assaulted'),
-(30, 1, 3, 'Stormpike Grave - Horde control'),
-
-(30, 2, 0, 'Stoneheart Grave - Alliance assaulted'),
-(30, 2, 1, 'Stoneheart Grave - ALliance control'),
-(30, 2, 2, 'Stoneheart Grave - Horde assaulted'),
-(30, 2, 3, 'Stoneheart Grave - Horde control'),
-
-(30, 3, 0, 'Snowfall Grave - Alliance assaulted'),
-(30, 3, 1, 'Snowfall Grave - ALliance control'),
-(30, 3, 2, 'Snowfall Grave - Horde assaulted'),
-(30, 3, 3, 'Snowfall Grave - Horde control'),
-(30, 3, 5, 'Snowfall Grave - Neutral control'),
-
-(30, 4, 0, 'Iceblood Grave - Alliance assaulted'),
-(30, 4, 1, 'Iceblood Grave - ALliance control'),
-(30, 4, 2, 'Iceblood Grave - Horde assaulted'),
-(30, 4, 3, 'Iceblood Grave - Horde control'),
-
-(30, 5, 0, 'Frostwolf Grave - Alliance assaulted'),
-(30, 5, 1, 'Frostwolf Grave - ALliance control'),
-(30, 5, 2, 'Frostwolf Grave - Horde assaulted'),
-(30, 5, 3, 'Frostwolf Grave - Horde control'),
-
-(30, 6, 0, 'Frostwolf Hut - Alliance assaulted'),
-(30, 6, 1, 'Frostwolf Hut - ALliance control'),
-(30, 6, 2, 'Frostwolf Hut - Horde assaulted'),
-(30, 6, 3, 'Frostwolf Hut - Horde control'),
-
-(30, 7, 1, 'Dunbaldar South - ALliance control'),
-(30, 7, 2, 'Dunbaldar South - Horde assaulted'),
-(30, 7, 3, 'Dunbaldar South - Horde control'),
-
-(30, 8, 1, 'Dunbaldar North - ALliance control'),
-(30, 8, 2, 'Dunbaldar North - Horde assaulted'),
-(30, 8, 3, 'Dunbaldar North - Horde control'),
-
-(30, 9, 1, 'Icewing Bunker - ALliance control'),
-(30, 9, 2, 'Icewing Bunker - Horde assaulted'),
-(30, 9, 3, 'Icewing Bunker - Horde control'),
-
-(30, 10, 1, 'Stoneheart Bunker - ALliance control'),
-(30, 10, 2, 'Stoneheart Bunker - Horde assaulted'),
-(30, 10, 3, 'Stoneheart Bunker - Horde control'),
-
-(30, 11, 0, 'Iceblood Tower - Alliance assaulted'),
-(30, 11, 1, 'Iceblood Tower - ALliance control'),
-(30, 11, 3, 'Iceblood Tower - Horde control'),
-
-(30, 12, 0, 'Tower Point - Alliance assaulted'),
-(30, 12, 1, 'Tower Point - ALliance control'),
-(30, 12, 3, 'Tower Point - Horde control'),
-
-(30, 13, 0, 'Frostwolf east Tower - Alliance assaulted'),
-(30, 13, 1, 'Frostwolf east Tower - ALliance control'),
-(30, 13, 3, 'Frostwolf east Tower - Horde control'),
-
-(30, 14, 0, 'Frostwolf west Tower - Alliance assaulted'),
-(30, 14, 1, 'Frostwolf west Tower - ALliance control'),
-(30, 14, 3, 'Frostwolf west Tower - Horde control'),
-
-
-(30, 15, 0, 'Firstaid Station - Alliance Defender Quest0'),
-(30, 15, 1, 'Firstaid Station - Alliance Defender Quest1'),
-(30, 15, 2, 'Firstaid Station - Alliance Defender Quest2'),
-(30, 15, 3, 'Firstaid Station - Alliance Defender Quest3'),
-(30, 15, 4, 'Firstaid Station - Horde Defender Quest0'),
-(30, 15, 5, 'Firstaid Station - Horde Defender Quest1'),
-(30, 15, 6, 'Firstaid Station - Horde Defender Quest2'),
-(30, 15, 7, 'Firstaid Station - Horde Defender Quest3'),
-
-(30, 16, 0, 'Stormpike Grave - Alliance Defender Quest0'),
-(30, 16, 1, 'Stormpike Grave - Alliance Defender Quest1'),
-(30, 16, 2, 'Stormpike Grave - Alliance Defender Quest2'),
-(30, 16, 3, 'Stormpike Grave - Alliance Defender Quest3'),
-(30, 16, 4, 'Stormpike Grave - Horde Defender Quest0'),
-(30, 16, 5, 'Stormpike Grave - Horde Defender Quest1'),
-(30, 16, 6, 'Stormpike Grave - Horde Defender Quest2'),
-(30, 16, 7, 'Stormpike Grave - Horde Defender Quest3'),
-
-(30, 17, 0, 'Stoneheart Grave - Alliance Defender Quest0'),
-(30, 17, 1, 'Stoneheart Grave - Alliance Defender Quest1'),
-(30, 17, 2, 'Stoneheart Grave - Alliance Defender Quest2'),
-(30, 17, 3, 'Stoneheart Grave - Alliance Defender Quest3'),
-(30, 17, 4, 'Stoneheart Grave - Horde Defender Quest0'),
-(30, 17, 5, 'Stoneheart Grave - Horde Defender Quest1'),
-(30, 17, 6, 'Stoneheart Grave - Horde Defender Quest2'),
-(30, 17, 7, 'Stoneheart Grave - Horde Defender Quest3'),
-
-(30, 18, 0, 'Snowfall Grave - Alliance Defender Quest0'),
-(30, 18, 1, 'Snowfall Grave - Alliance Defender Quest1'),
-(30, 18, 2, 'Snowfall Grave - Alliance Defender Quest2'),
-(30, 18, 3, 'Snowfall Grave - Alliance Defender Quest3'),
-(30, 18, 4, 'Snowfall Grave - Horde Defender Quest0'),
-(30, 18, 5, 'Snowfall Grave - Horde Defender Quest1'),
-(30, 18, 6, 'Snowfall Grave - Horde Defender Quest2'),
-(30, 18, 7, 'Snowfall Grave - Horde Defender Quest3'),
-
-(30, 19, 0, 'Iceblood Grave - Alliance Defender Quest0'),
-(30, 19, 1, 'Iceblood Grave - Alliance Defender Quest1'),
-(30, 19, 2, 'Iceblood Grave - Alliance Defender Quest2'),
-(30, 19, 3, 'Iceblood Grave - Alliance Defender Quest3'),
-(30, 19, 4, 'Iceblood Grave - Horde Defender Quest0'),
-(30, 19, 5, 'Iceblood Grave - Horde Defender Quest1'),
-(30, 19, 6, 'Iceblood Grave - Horde Defender Quest2'),
-(30, 19, 7, 'Iceblood Grave - Horde Defender Quest3'),
-
-(30, 20, 0, 'Frostwolf Grave - Alliance Defender Quest0'),
-(30, 20, 1, 'Frostwolf Grave - Alliance Defender Quest1'),
-(30, 20, 2, 'Frostwolf Grave - Alliance Defender Quest2'),
-(30, 20, 3, 'Frostwolf Grave - Alliance Defender Quest3'),
-(30, 20, 4, 'Frostwolf Grave - Horde Defender Quest0'),
-(30, 20, 5, 'Frostwolf Grave - Horde Defender Quest1'),
-(30, 20, 6, 'Frostwolf Grave - Horde Defender Quest2'),
-(30, 20, 7, 'Frostwolf Grave - Horde Defender Quest3'),
-
-(30, 21, 0, 'Frostwolf Hut - Alliance Defender Quest0'),
-(30, 21, 1, 'Frostwolf Hut - Alliance Defender Quest1'),
-(30, 21, 2, 'Frostwolf Hut - Alliance Defender Quest2'),
-(30, 21, 3, 'Frostwolf Hut - Alliance Defender Quest3'),
-(30, 21, 4, 'Frostwolf Hut - Horde Defender Quest0'),
-(30, 21, 5, 'Frostwolf Hut - Horde Defender Quest1'),
-(30, 21, 6, 'Frostwolf Hut - Horde Defender Quest2'),
-(30, 21, 7, 'Frostwolf Hut - Horde Defender Quest3'),
-
-(30, 46, 0, 'North Mine - Alliance Boss'),
-(30, 46, 1, 'North Mine - Horde Boss'),
-(30, 46, 2, 'North Mine - Neutral Boss'),
-(30, 47, 0, 'South Mine - Alliance Boss'),
-(30, 47, 1, 'South Mine - Horde Boss'),
-(30, 47, 2, 'South Mine - Neutral Boss'),
-
-(30, 48, 0, 'Alliance Captain'),
-(30, 49, 0, 'Horde Captain'),
-
-(30, 50, 0, 'North Mine - Alliance Control'),
-(30, 50, 1, 'North Mine - Horde Control'),
-(30, 50, 2, 'North Mine - Neutral Control'),
-(30, 51, 0, 'South Mine - Alliance Control'),
-(30, 51, 1, 'South Mine - Horde Control'),
-(30, 51, 2, 'South Mine - Neutral Control'),
-
-(30, 52, 0, 'Alliance Marshal - Dunbaldar South'),
-(30, 53, 0, 'Alliance Marshal - Dunbaldar North'),
-(30, 54, 0, 'Alliance Marshal - Icewing Bunker'),
-(30, 55, 0, 'Alliance Marshal - Stoneheart Bunker'),
-
-(30, 56, 0, 'Horde Marshal - Iceblood Tower'),
-(30, 57, 0, 'Horde Marshal - Towerpoint'),
-(30, 58, 0, 'Horde Marshal - East Frostwolf Tower'),
-(30, 59, 0, 'Horde Marshal - West Frostwolf Tower'),
-
-(30, 60, 0, 'Herald - that guy who yells all the time ;)'),
-
-(30, 61, 0, 'Alliance - Boss'),
-(30, 62, 0, 'Horde - Boss'),
-
-(30, 63, 0, 'Alliance - Captain Dead'),
-(30, 64, 0, 'Horde - Captain Dead');
+(566,0,0,'Fel Reaver - alliance'),
+(566,0,1,'Fel Reaver - horde'),
+(566,0,2,'Fel Reaver - neutral'),
+(566,1,0,'Blood Elf - alliance'),
+(566,1,1,'Blood Elf - horde'),
+(566,1,2,'Blood Elf - neutral'),
+(566,2,0,'Draenei Ruins - alliance'),
+(566,2,1,'Draenei Ruins - horde'),
+(566,2,2,'Draenei Ruins - neutral'),
+(566,3,0,'Mage Tower - alliance'),
+(566,3,1,'Mage Tower - horde'),
+(566,3,2,'Mage Tower - neutral'),
+(566,4,0,'capture flag - Fel Reaver'),
+(566,4,1,'capture flag - Blood Elf'),
+(566,4,2,'capture flag - Draenei Ruins'),
+(566,4,3,'capture flag - Mage Tower'),
+(566,4,4,'capture flag - center'),
+(566,254,0,'doors'),
+-- Arenas
+(559,253,0,'buffs'),
+(559,254,0,'doors'),
+(572,253,0,'buffs'),
+(572,254,0,'doors'),
+(562,253,0,'buffs'),
+(562,254,0,'doors'),
+-- AV
+(30,254,0,'Doors'),
+(30,0,0,'Firstaid Station - Alliance assaulted'),
+(30,0,1,'Firstaid Station - ALliance control'),
+(30,0,2,'Firstaid Station - Horde assaulted'),
+(30,0,3,'Firstaid Station - Horde control'),
+(30,1,0,'Stormpike Grave - Alliance assaulted'),
+(30,1,1,'Stormpike Grave - ALliance control'),
+(30,1,2,'Stormpike Grave - Horde assaulted'),
+(30,1,3,'Stormpike Grave - Horde control'),
+(30,2,0,'Stoneheart Grave - Alliance assaulted'),
+(30,2,1,'Stoneheart Grave - ALliance control'),
+(30,2,2,'Stoneheart Grave - Horde assaulted'),
+(30,2,3,'Stoneheart Grave - Horde control'),
+(30,3,0,'Snowfall Grave - Alliance assaulted'),
+(30,3,1,'Snowfall Grave - ALliance control'),
+(30,3,2,'Snowfall Grave - Horde assaulted'),
+(30,3,3,'Snowfall Grave - Horde control'),
+(30,3,5,'Snowfall Grave - Neutral control'),
+(30,4,0,'Iceblood Grave - Alliance assaulted'),
+(30,4,1,'Iceblood Grave - ALliance control'),
+(30,4,2,'Iceblood Grave - Horde assaulted'),
+(30,4,3,'Iceblood Grave - Horde control'),
+(30,5,0,'Frostwolf Grave - Alliance assaulted'),
+(30,5,1,'Frostwolf Grave - ALliance control'),
+(30,5,2,'Frostwolf Grave - Horde assaulted'),
+(30,5,3,'Frostwolf Grave - Horde control'),
+(30,6,0,'Frostwolf Hut - Alliance assaulted'),
+(30,6,1,'Frostwolf Hut - ALliance control'),
+(30,6,2,'Frostwolf Hut - Horde assaulted'),
+(30,6,3,'Frostwolf Hut - Horde control'),
+(30,7,1,'Dunbaldar South - ALliance control'),
+(30,7,2,'Dunbaldar South - Horde assaulted'),
+(30,7,3,'Dunbaldar South - Horde control'),
+(30,8,1,'Dunbaldar North - ALliance control'),
+(30,8,2,'Dunbaldar North - Horde assaulted'),
+(30,8,3,'Dunbaldar North - Horde control'),
+(30,9,1,'Icewing Bunker - ALliance control'),
+(30,9,2,'Icewing Bunker - Horde assaulted'),
+(30,9,3,'Icewing Bunker - Horde control'),
+(30,10,1,'Stoneheart Bunker - ALliance control'),
+(30,10,2,'Stoneheart Bunker - Horde assaulted'),
+(30,10,3,'Stoneheart Bunker - Horde control'),
+(30,11,0,'Iceblood Tower - Alliance assaulted'),
+(30,11,1,'Iceblood Tower - ALliance control'),
+(30,11,3,'Iceblood Tower - Horde control'),
+(30,12,0,'Tower Point - Alliance assaulted'),
+(30,12,1,'Tower Point - ALliance control'),
+(30,12,3,'Tower Point - Horde control'),
+(30,13,0,'Frostwolf east Tower - Alliance assaulted'),
+(30,13,1,'Frostwolf east Tower - ALliance control'),
+(30,13,3,'Frostwolf east Tower - Horde control'),
+(30,14,0,'Frostwolf west Tower - Alliance assaulted'),
+(30,14,1,'Frostwolf west Tower - ALliance control'),
+(30,14,3,'Frostwolf west Tower - Horde control'),
+(30,15,0,'Firstaid Station - Alliance Defender Quest0'),
+(30,15,1,'Firstaid Station - Alliance Defender Quest1'),
+(30,15,2,'Firstaid Station - Alliance Defender Quest2'),
+(30,15,3,'Firstaid Station - Alliance Defender Quest3'),
+(30,15,4,'Firstaid Station - Horde Defender Quest0'),
+(30,15,5,'Firstaid Station - Horde Defender Quest1'),
+(30,15,6,'Firstaid Station - Horde Defender Quest2'),
+(30,15,7,'Firstaid Station - Horde Defender Quest3'),
+(30,16,0,'Stormpike Grave - Alliance Defender Quest0'),
+(30,16,1,'Stormpike Grave - Alliance Defender Quest1'),
+(30,16,2,'Stormpike Grave - Alliance Defender Quest2'),
+(30,16,3,'Stormpike Grave - Alliance Defender Quest3'),
+(30,16,4,'Stormpike Grave - Horde Defender Quest0'),
+(30,16,5,'Stormpike Grave - Horde Defender Quest1'),
+(30,16,6,'Stormpike Grave - Horde Defender Quest2'),
+(30,16,7,'Stormpike Grave - Horde Defender Quest3'),
+(30,17,0,'Stoneheart Grave - Alliance Defender Quest0'),
+(30,17,1,'Stoneheart Grave - Alliance Defender Quest1'),
+(30,17,2,'Stoneheart Grave - Alliance Defender Quest2'),
+(30,17,3,'Stoneheart Grave - Alliance Defender Quest3'),
+(30,17,4,'Stoneheart Grave - Horde Defender Quest0'),
+(30,17,5,'Stoneheart Grave - Horde Defender Quest1'),
+(30,17,6,'Stoneheart Grave - Horde Defender Quest2'),
+(30,17,7,'Stoneheart Grave - Horde Defender Quest3'),
+(30,18,0,'Snowfall Grave - Alliance Defender Quest0'),
+(30,18,1,'Snowfall Grave - Alliance Defender Quest1'),
+(30,18,2,'Snowfall Grave - Alliance Defender Quest2'),
+(30,18,3,'Snowfall Grave - Alliance Defender Quest3'),
+(30,18,4,'Snowfall Grave - Horde Defender Quest0'),
+(30,18,5,'Snowfall Grave - Horde Defender Quest1'),
+(30,18,6,'Snowfall Grave - Horde Defender Quest2'),
+(30,18,7,'Snowfall Grave - Horde Defender Quest3'),
+(30,19,0,'Iceblood Grave - Alliance Defender Quest0'),
+(30,19,1,'Iceblood Grave - Alliance Defender Quest1'),
+(30,19,2,'Iceblood Grave - Alliance Defender Quest2'),
+(30,19,3,'Iceblood Grave - Alliance Defender Quest3'),
+(30,19,4,'Iceblood Grave - Horde Defender Quest0'),
+(30,19,5,'Iceblood Grave - Horde Defender Quest1'),
+(30,19,6,'Iceblood Grave - Horde Defender Quest2'),
+(30,19,7,'Iceblood Grave - Horde Defender Quest3'),
+(30,20,0,'Frostwolf Grave - Alliance Defender Quest0'),
+(30,20,1,'Frostwolf Grave - Alliance Defender Quest1'),
+(30,20,2,'Frostwolf Grave - Alliance Defender Quest2'),
+(30,20,3,'Frostwolf Grave - Alliance Defender Quest3'),
+(30,20,4,'Frostwolf Grave - Horde Defender Quest0'),
+(30,20,5,'Frostwolf Grave - Horde Defender Quest1'),
+(30,20,6,'Frostwolf Grave - Horde Defender Quest2'),
+(30,20,7,'Frostwolf Grave - Horde Defender Quest3'),
+(30,21,0,'Frostwolf Hut - Alliance Defender Quest0'),
+(30,21,1,'Frostwolf Hut - Alliance Defender Quest1'),
+(30,21,2,'Frostwolf Hut - Alliance Defender Quest2'),
+(30,21,3,'Frostwolf Hut - Alliance Defender Quest3'),
+(30,21,4,'Frostwolf Hut - Horde Defender Quest0'),
+(30,21,5,'Frostwolf Hut - Horde Defender Quest1'),
+(30,21,6,'Frostwolf Hut - Horde Defender Quest2'),
+(30,21,7,'Frostwolf Hut - Horde Defender Quest3'),
+(30,46,0,'North Mine - Alliance Boss'),
+(30,46,1,'North Mine - Horde Boss'),
+(30,46,2,'North Mine - Neutral Boss'),
+(30,47,0,'South Mine - Alliance Boss'),
+(30,47,1,'South Mine - Horde Boss'),
+(30,47,2,'South Mine - Neutral Boss'),
+(30,48,0,'Alliance Captain'),
+(30,49,0,'Horde Captain'),
+(30,50,0,'North Mine - Alliance Control'),
+(30,50,1,'North Mine - Horde Control'),
+(30,50,2,'North Mine - Neutral Control'),
+(30,51,0,'South Mine - Alliance Control'),
+(30,51,1,'South Mine - Horde Control'),
+(30,51,2,'South Mine - Neutral Control'),
+(30,52,0,'Alliance Marshal - Dunbaldar South'),
+(30,53,0,'Alliance Marshal - Dunbaldar North'),
+(30,54,0,'Alliance Marshal - Icewing Bunker'),
+(30,55,0,'Alliance Marshal - Stoneheart Bunker'),
+(30,56,0,'Horde Marshal - Iceblood Tower'),
+(30,57,0,'Horde Marshal - Towerpoint'),
+(30,58,0,'Horde Marshal - East Frostwolf Tower'),
+(30,59,0,'Horde Marshal - West Frostwolf Tower'),
+(30,60,0,'Herald - that guy who yells all the time ;)'),
+(30,61,0,'Alliance - Boss'),
+(30,62,0,'Horde - Boss'),
+(30,63,0,'Alliance - Captain Dead'),
+(30,64,0,'Horde - Captain Dead');
 /*!40000 ALTER TABLE `battleground_events` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -415,13 +384,13 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `battleground_template`;
 CREATE TABLE `battleground_template` (
   `id` mediumint(8) unsigned NOT NULL,
-  `MinPlayersPerTeam` smallint(5) unsigned NOT NULL default '0',
-  `MaxPlayersPerTeam` smallint(5) unsigned NOT NULL default '0',
+  `MinPlayersPerTeam` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `MaxPlayersPerTeam` smallint(5) unsigned NOT NULL DEFAULT '0',
   `AllianceStartLoc` mediumint(8) unsigned NOT NULL,
   `AllianceStartO` float NOT NULL,
   `HordeStartLoc` mediumint(8) unsigned NOT NULL,
   `HordeStartO` float NOT NULL,
-  PRIMARY KEY  (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -453,9 +422,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `battlemaster_entry`;
 CREATE TABLE `battlemaster_entry` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Entry of a creature',
-  `bg_template` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Battleground template id',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Entry of a creature',
+  `bg_template` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Battleground template id',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -473,10 +442,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `command`;
 CREATE TABLE `command` (
-  `name` varchar(50) NOT NULL default '',
-  `security` tinyint(3) unsigned NOT NULL default '0',
+  `name` varchar(50) NOT NULL DEFAULT '',
+  `security` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `help` longtext,
-  PRIMARY KEY  (`name`)
+  PRIMARY KEY (`name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Chat System';
 
 --
@@ -494,7 +463,7 @@ INSERT INTO `command` VALUES
 ('account onlinelist',4,'Syntax: .account onlinelist\r\n\r\nShow list of online accounts.'),
 ('account password',0,'Syntax: .account password $old_password $new_password $new_password\r\n\r\nChange your account password.'),
 ('account set addon',3,'Syntax: .account set addon [#accountId|$accountName] #addon\r\n\r\nSet user (possible targeted) expansion addon level allowed. Addon values: 0 - normal, 1 - tbc, 2 - wotlk.'),
-('account set gmlevel',4,'Syntax: .account set gmlevel [#accountId|$accountName] #level\r\n\r\nSet the security level for targeted player (can''t be used at self) or for #accountId or $accountName to a level of #level.\r\n\r\n#level may range from 0 to 3.'),
+('account set gmlevel',4,'Syntax: .account set gmlevel [#accountId|$accountName] #level\r\n\r\nSet the security level for targeted player (can\'t be used at self) or for #accountId or $accountName to a level of #level.\r\n\r\n#level may range from 0 to 3.'),
 ('account set password',4,'Syntax: .account set password (#accountId|$accountName) $password $password\r\n\r\nSet password for account.'),
 ('achievement',3,'Syntax: .achievement $playername #achivementid\r\n\r\nShow state achievment #achivmentid (can be shift link) and list of achievement criteria with progress data for selected player in game or by player name.'),
 ('achievement add',3,'Syntax: .achievement add $playername #achivementid\r\n\r\nComplete achievement and all it\'s criteria for selected player in game or by player name. Command can\'t be used for counter achievements.'),
@@ -515,9 +484,9 @@ INSERT INTO `command` VALUES
 ('ahbot items ratio alliance',3,'Syntax: .ahbot items ratio alliance $allianceratio\r\n\r\nSet ratio of items in alliance auction house.'),
 ('ahbot items ratio horde',3,'Syntax: .ahbot items ratio horde $horderatio\r\n\r\nSet ratio of items in horde auction house.'),
 ('ahbot items ratio neutral',3,'Syntax: .ahbot items ratio neutral $neutralratio\r\n\r\nSet ratio of items in $neutral auction house.'),
-('ahbot rebuild',3,'Syntax: .ahbot rebuild [all]\r\n\r\nExpire all actual auction of ahbot except bided by player. Binded auctions included to expire if "all" option used. Ahbot re-fill auctions base at current settings then.'),
+('ahbot rebuild',3,'Syntax: .ahbot rebuild [all]\r\n\r\nExpire all actual auction of ahbot except bided by player. Binded auctions included to expire if \"all\" option used. Ahbot re-fill auctions base at current settings then.'),
 ('ahbot reload',3,'Syntax: .ahbot reload\r\n\r\nReload AHBot settings from configuration file.'),
-('ahbot status',3,'Syntax: .ahbot status [all]\r\n\r\nShow current ahbot state data in short form, and with "all" with details.'),
+('ahbot status',3,'Syntax: .ahbot status [all]\r\n\r\nShow current ahbot state data in short form, and with \"all\" with details.'),
 ('announce',1,'Syntax: .announce $MessageToBroadcast\r\n\r\nSend a global message to all players online in chat log.'),
 ('auction',3,'Syntax: .auction\r\n\r\nShow your team auction store.'),
 ('auction alliance',3,'Syntax: .auction alliance\r\n\r\nShow alliance auction store independent from your team.'),
@@ -542,10 +511,10 @@ INSERT INTO `command` VALUES
 ('cast target',3,'Syntax: .cast target #spellid [triggered]\r\n  Selected target will cast #spellid to his victim. If \'trigered\' or part provided then spell casted with triggered flag.'),
 ('character achievements',2,'Syntax: .character achievements [$player_name]\r\n\r\nShow completed achievments for selected player or player find by $player_name.'),
 ('character customize',2,'Syntax: .character customize [$name]\r\n\r\nMark selected in game or by $name in command character for customize at next login.'),
-('character deleted delete', 4, 'Syntax: .character deleted delete #guid|$name\r\n\r\nCompletely deletes the selected characters.\r\nIf $name is supplied, only characters with that string in their name will be deleted, if #guid is supplied, only the character with that GUID will be deleted.'),
-('character deleted list', 3, 'Syntax: .character deleted list [#guid|$name]\r\n\r\nShows a list with all deleted characters.\r\nIf $name is supplied, only characters with that string in their name will be selected, if #guid is supplied, only the character with that GUID will be selected.'),
-('character deleted old', 4, 'Syntax: .character deleted old [#keepDays]\r\n\r\nCompletely deletes all characters with deleted time longer #keepDays. If #keepDays not provided the  used value from mangosd.conf option \'CharDelete.KeepDays\'. If referenced config option disabled (use 0 value) then command can\'t be used without #keepDays.'),
-('character deleted restore', 3, 'Syntax: .character deleted restore #guid|$name [$newname] [#new account]\r\n\r\nRestores deleted characters.\r\nIf $name is supplied, only characters with that string in their name will be restored, if $guid is supplied, only the character with that GUID will be restored.\r\nIf $newname is set, the character will be restored with that name instead of the original one. If #newaccount is set, the character will be restored to specific account character list. This works only with one character!'),
+('character deleted delete',4,'Syntax: .character deleted delete #guid|$name\r\n\r\nCompletely deletes the selected characters.\r\nIf $name is supplied, only characters with that string in their name will be deleted, if #guid is supplied, only the character with that GUID will be deleted.'),
+('character deleted list',3,'Syntax: .character deleted list [#guid|$name]\r\n\r\nShows a list with all deleted characters.\r\nIf $name is supplied, only characters with that string in their name will be selected, if #guid is supplied, only the character with that GUID will be selected.'),
+('character deleted old',4,'Syntax: .character deleted old [#keepDays]\r\n\r\nCompletely deletes all characters with deleted time longer #keepDays. If #keepDays not provided the  used value from mangosd.conf option \'CharDelete.KeepDays\'. If referenced config option disabled (use 0 value) then command can\'t be used without #keepDays.'),
+('character deleted restore',3,'Syntax: .character deleted restore #guid|$name [$newname] [#new account]\r\n\r\nRestores deleted characters.\r\nIf $name is supplied, only characters with that string in their name will be restored, if $guid is supplied, only the character with that GUID will be restored.\r\nIf $newname is set, the character will be restored with that name instead of the original one. If #newaccount is set, the character will be restored to specific account character list. This works only with one character!'),
 ('character erase',4,'Syntax: .character erase $name\r\n\r\nDelete character $name. Character finally deleted in case any deleting options.'),
 ('character level',3,'Syntax: .character level [$playername] [#level]\r\n\r\nSet the level of character with $playername (or the selected if not name provided) by #numberoflevels Or +1 if no #numberoflevels provided). If #numberoflevels is omitted, the level will be increase by 1. If #numberoflevels is 0, the same level will be restarted. If no character is selected and name not provided, increase your level. Command can be used for offline character. All stats and dependent values recalculated. At level decrease talents can be reset if need. Also at level decrease equipped items with greater level requirement can be lost.'),
 ('character rename',2,'Syntax: .character rename [$name]\r\n\r\nMark selected in game or by $name in command character for rename at next login.'),
@@ -579,7 +548,7 @@ INSERT INTO `command` VALUES
 ('event start',2,'Syntax: .event start #event_id\r\nStart event #event_id. Set start time for event to current moment (change not saved in DB).'),
 ('event stop',2,'Syntax: .event stop #event_id\r\nStop event #event_id. Set start time for event to time in past that make current moment is event stop time (change not saved in DB).'),
 ('explorecheat',3,'Syntax: .explorecheat #flag\r\n\r\nReveal  or hide all maps for the selected player. If no player is selected, hide or reveal maps to you.\r\n\r\nUse a #flag of value 1 to reveal, use a #flag value of 0 to hide all maps.'),
-('flusharenapoints','3','Syntax: .flusharenapoints\r\n\r\nUse it to distribute arena points based on arena team ratings, and start a new week.'),
+('flusharenapoints',3,'Syntax: .flusharenapoints\r\n\r\nUse it to distribute arena points based on arena team ratings, and start a new week.'),
 ('gearscore',3,'Syntax: .gearscore [#withBags] [#withBank]\r\n\r\nShow selected player\'s gear score. Check items in bags if #withBags != 0 and check items in Bank if #withBank != 0. Default: 1 for bags and 0 for bank'),
 ('gm',1,'Syntax: .gm [on/off]\r\n\r\nEnable or Disable in game GM MODE or show current state of on/off not provided.'),
 ('gm chat',1,'Syntax: .gm chat [on/off]\r\n\r\nEnable or disable chat GM MODE (show gm badge in messages) or show current state of on/off not provided.'),
@@ -594,7 +563,7 @@ INSERT INTO `command` VALUES
 ('go grid',1,'Syntax: .go grid #gridX #gridY [#mapId]\r\n\r\nTeleport the gm to center of grid with provided indexes at map #mapId (or current map if it not provided).'),
 ('go object',1,'Syntax: .go object (#gameobject_guid|$gameobject_name|id #gameobject_id)\r\nTeleport your character to gameobject with guid #gameobject_guid, or teleport your character to gameobject with name including as part $gameobject_name substring, or teleport your character to a gameobject that was spawned from the template with this entry #gameobject_id.'),
 ('go taxinode',1,'Syntax: .go taxinode #taxinode\r\n\r\nTeleport player to taxinode coordinates. You can look up zone using .lookup taxinode $namepart'),
-('go trigger',1,'Syntax: .go trigger (#trigger_id|$trigger_shift-link|$trigger_target_shift-link) [target]\r\n\r\nTeleport your character to areatrigger with id #trigger_id or trigger id associated with shift-link. If additional arg "target" provided then character will teleported to areatrigger target point.'),
+('go trigger',1,'Syntax: .go trigger (#trigger_id|$trigger_shift-link|$trigger_target_shift-link) [target]\r\n\r\nTeleport your character to areatrigger with id #trigger_id or trigger id associated with shift-link. If additional arg \"target\" provided then character will teleported to areatrigger target point.'),
 ('go xy',1,'Syntax: .go xy #x #y [#mapid]\r\n\r\nTeleport player to point with (#x,#y) coordinates at ground(water) level at map #mapid or same map if #mapid not provided.'),
 ('go xyz',1,'Syntax: .go xyz #x #y #z [#mapid]\r\n\r\nTeleport player to point with (#x,#y,#z) coordinates at ground(water) level at map #mapid or same map if #mapid not provided.'),
 ('go zonexy',1,'Syntax: .go zonexy #x #y [#zone]\r\n\r\nTeleport player to point with (#x,#y) client coordinates at ground(water) level in zone #zoneid or current zone if #zoneid not provided. You can look up zone using .lookup area $namepart'),
@@ -609,9 +578,9 @@ INSERT INTO `command` VALUES
 ('gps',1,'Syntax: .gps [$name|$shift-link]\r\n\r\nDisplay the position information for a selected character or creature (also if player name $name provided then for named player, or if creature/gameobject shift-link provided then pointed creature/gameobject if it loaded). Position information includes X, Y, Z, and orientation, map Id and zone Id'),
 ('groupgo',1,'Syntax: .groupgo [$charactername]\r\n\r\nTeleport the given character and his group to you. Teleported only online characters but original selected group member can be offline.'),
 ('guid',2,'Syntax: .guid\r\n\r\nDisplay the GUID for the selected character.'),
-('guild create',2,'Syntax: .guild create [$GuildLeaderName] "$GuildName"\r\n\r\nCreate a guild named $GuildName with the player $GuildLeaderName (or selected) as leader.  Guild name must in quotes.'),
-('guild delete',2,'Syntax: .guild delete "$GuildName"\r\n\r\nDelete guild $GuildName. Guild name must in quotes.'),
-('guild invite',2,'Syntax: .guild invite [$CharacterName] "$GuildName"\r\n\r\nAdd player $CharacterName (or selected) into a guild $GuildName. Guild name must in quotes.'),
+('guild create',2,'Syntax: .guild create [$GuildLeaderName] \"$GuildName\"\r\n\r\nCreate a guild named $GuildName with the player $GuildLeaderName (or selected) as leader.  Guild name must in quotes.'),
+('guild delete',2,'Syntax: .guild delete \"$GuildName\"\r\n\r\nDelete guild $GuildName. Guild name must in quotes.'),
+('guild invite',2,'Syntax: .guild invite [$CharacterName] \"$GuildName\"\r\n\r\nAdd player $CharacterName (or selected) into a guild $GuildName. Guild name must in quotes.'),
 ('guild rank',2,'Syntax: .guild rank $CharacterName #Rank\r\n\r\nSet for $CharacterName rank #Rank in a guild.'),
 ('guild uninvite',2,'Syntax: .guild uninvite [$CharacterName]\r\n\r\nRemove player $CharacterName (or selected) from a guild.'),
 ('help',0,'Syntax: .help [$command]\r\n\r\nDisplay usage instructions for the given $command. If no $command provided show list available commands.'),
@@ -672,7 +641,7 @@ INSERT INTO `command` VALUES
 ('modify drunk',1,'Syntax: .modify drunk #value\r\n Set drunk level to #value (0..100). Value 0 remove drunk state, 100 is max drunked state.'),
 ('modify energy',1,'Syntax: .modify energy #energy\r\n\r\nModify the energy of the selected player. If no player is selected, modify your energy.'),
 ('modify faction',1,'Syntax: .modify faction #factionid #flagid #npcflagid #dynamicflagid\r\n\r\nModify the faction and flags of the selected creature. Without arguments, display the faction and flags of the selected creature.'),
-('modify fly', 1, 'Syntax: .modify fly #rate\r\n.fly #rate\r\n\r\nModify the flying speed of the selected player to \"normal base fly speed\"*rate. If no player is selected, modify your fly.\r\n\r\n #rate may range from 0.1 to 10.'),
+('modify fly',1,'Syntax: .modify fly #rate\r\n.fly #rate\r\n\r\nModify the flying speed of the selected player to \"normal base fly speed\"*rate. If no player is selected, modify your fly.\r\n\r\n #rate may range from 0.1 to 10.'),
 ('modify gender',2,'Syntax: .modify gender male/female\r\n\r\nChange gender of selected player.'),
 ('modify honor',1,'Syntax: .modify honor $amount\r\n\r\nAdd $amount honor points to the selected player.'),
 ('modify hp',1,'Syntax: .modify hp #newhp\r\n\r\nModify the hp of the selected player. If no player is selected, modify your hp.'),
@@ -710,7 +679,7 @@ INSERT INTO `command` VALUES
 ('npc move',2,'Syntax: .npc move [#creature_guid]\r\n\r\nMove the targeted creature spawn point to your coordinates.'),
 ('npc name',2,'Syntax: .npc name $name\r\n\r\nChange the name of the selected creature or character to $name.\r\n\r\nCommand disabled.'),
 ('npc playemote',3,'Syntax: .npc playemote #emoteid\r\n\r\nMake the selected creature emote with an emote of id #emoteid.'),
-('npc say', 1, 'Syntax: .npc say #text\r\nMake the selected npc says #text.'),
+('npc say',1,'Syntax: .npc say #text\r\nMake the selected npc says #text.'),
 ('npc setdeathstate',2,'Syntax: .npc setdeathstate on/off\r\n\r\nSet default death state (dead/alive) for npc at spawn.'),
 ('npc setmodel',2,'Syntax: .npc setmodel #displayid\r\n\r\nChange the model id of the selected creature to #displayid.'),
 ('npc setmovetype',2,'Syntax: .npc setmovetype [#creature_guid] stay/random/way [NODEL]\r\n\r\nSet for creature pointed by #creature_guid (or selected if #creature_guid not provided) movement type and move it to respawn position (if creature alive). Any existing waypoints for creature will be removed from the database if you do not use NODEL. If the creature is dead then movement type will applied at creature respawn.\r\nMake sure you use NODEL, if you want to keep the waypoints.'),
@@ -718,11 +687,11 @@ INSERT INTO `command` VALUES
 ('npc spawndist',2,'Syntax: .npc spawndist #dist\r\n\r\nAdjust spawndistance of selected creature to dist.'),
 ('npc spawntime',2,'Syntax: .npc spawntime #time \r\n\r\nAdjust spawntime of selected creature to time.'),
 ('npc subname',2,'Syntax: .npc subname $Name\r\n\r\nChange the subname of the selected creature or player to $Name.\r\n\r\nCommand disabled.'),
-('npc tame',2,'Syntax: .npc tame\r\n\r\nTame selected creature (tameable non pet creature). You don''t must have pet.'),
+('npc tame',2,'Syntax: .npc tame\r\n\r\nTame selected creature (tameable non pet creature). You don\'t must have pet.'),
 ('npc textemote',1,'Syntax: .npc textemote #emoteid\r\n\r\nMake the selected creature to do textemote with an emote of id #emoteid.'),
 ('npc whisper',1,'Syntax: .npc whisper #playerguid #text\r\nMake the selected npc whisper #text to  #playerguid.'),
 ('npc unfollow',2,'Syntax: .npc unfollow\r\n\r\nSelected creature (non pet) stop follow you.'),
-('npc yell', 1, 'Syntax: .npc yell #text\r\nMake the selected npc yells #text.'),
+('npc yell',1,'Syntax: .npc yell #text\r\nMake the selected npc yells #text.'),
 ('pdump write',3,'Syntax: .pdump write $filename $playerNameOrGUID\r\nWrite character dump with name/guid $playerNameOrGUID to file $filename.'),
 ('pdump load',3,'Syntax: .pdump load $filename $account [$newname] [$newguid]\r\nLoad character dump from dump file into character list of $account with saved or $newname, with saved (or first free) or $newguid guid.'),
 ('pinfo',2,'Syntax: .pinfo [$player_name]\r\n\r\nOutput account information for selected player or player find by $player_name.'),
@@ -746,7 +715,7 @@ INSERT INTO `command` VALUES
 ('reload all_spell',3,'Syntax: .reload all_spell\r\n\r\nReload all `spell_*` tables with reload support added and that can be _safe_ reloaded.'),
 ('reload all_scripts',3,'Syntax: .reload all_scripts\r\n\r\nReload `dbscripts_on_*` tables.'),
 ('reload config',3,'Syntax: .reload config\r\n\r\nReload config settings (by default stored in mangosd.conf). Not all settings can be change at reload: some new setting values will be ignored until restart, some values will applied with delay or only to new objects/maps, some values will explicitly rejected to change at reload.'),
-('repairitems',2,'Syntax: .repairitems\r\n\r\nRepair all selected player''s items.'),
+('repairitems',2,'Syntax: .repairitems\r\n\r\nRepair all selected player\'s items.'),
 ('reset achievements',3,'Syntax: .reset achievements [$playername]\r\n\r\nReset achievements data for selected or named (online or offline) character. Achievements for persistance progress data like completed quests/etc re-filled at reset. Achievements for events like kills/casts/etc will lost.'),
 ('reset all',3,'Syntax: .reset all spells\r\n\r\nSyntax: .reset all talents\r\n\r\nRequest reset spells or talents (including talents for all character\'s pets if any) at next login each existed character.'),
 ('reset honor',3,'Syntax: .reset honor [Playername]\r\n  Reset all honor data for targeted character.'),
@@ -759,13 +728,13 @@ INSERT INTO `command` VALUES
 ('revive',3,'Syntax: .revive\r\n\r\nRevive the selected player. If no player is selected, it will revive you.'),
 ('save',0,'Syntax: .save\r\n\r\nSaves your character.'),
 ('saveall',1,'Syntax: .saveall\r\n\r\nSave all characters in game.'),
-('send items',3,'Syntax: .send items #playername "#subject" "#text" itemid1[:count1] itemid2[:count2] ... itemidN[:countN]\r\n\r\nSend a mail to a player. Subject and mail text must be in "". If for itemid not provided related count values then expected 1, if count > max items in stack then items will be send in required amount stacks. All stacks amount in mail limited to 12.'),
-('send mail',1,'Syntax: .send mail #playername "#subject" "#text"\r\n\r\nSend a mail to a player. Subject and mail text must be in "".'),
-('send mass items',3,'Syntax: .send mass items #racemask|$racename|alliance|horde|all "#subject" "#text" itemid1[:count1] itemid2[:count2] ... itemidN[:countN]\r\n\r\nSend a mail to players. Subject and mail text must be in "". If for itemid not provided related count values then expected 1, if count > max items in stack then items will be send in required amount stacks. All stacks amount in mail limited to 12.'),
-('send mass mail',3,'Syntax: .send mass mail #racemask|$racename|alliance|horde|all "#subject" "#text"\r\n\r\nSend a mail to players. Subject and mail text must be in "".'),
-('send mass money','3','Syntax: .send mass money #racemask|$racename|alliance|horde|all "#subject" "#text" #money\r\n\r\nSend mail with money to players. Subject and mail text must be in "".'),
+('send items',3,'Syntax: .send items #playername \"#subject\" \"#text\" itemid1[:count1] itemid2[:count2] ... itemidN[:countN]\r\n\r\nSend a mail to a player. Subject and mail text must be in \"\". If for itemid not provided related count values then expected 1, if count > max items in stack then items will be send in required amount stacks. All stacks amount in mail limited to 12.'),
+('send mail',1,'Syntax: .send mail #playername \"#subject\" \"#text\"\r\n\r\nSend a mail to a player. Subject and mail text must be in \"\".'),
+('send mass items',3,'Syntax: .send mass items #racemask|$racename|alliance|horde|all \"#subject\" \"#text\" itemid1[:count1] itemid2[:count2] ... itemidN[:countN]\r\n\r\nSend a mail to players. Subject and mail text must be in \"\". If for itemid not provided related count values then expected 1, if count > max items in stack then items will be send in required amount stacks. All stacks amount in mail limited to 12.'),
+('send mass mail',3,'Syntax: .send mass mail #racemask|$racename|alliance|horde|all \"#subject\" \"#text\"\r\n\r\nSend a mail to players. Subject and mail text must be in \"\".'),
+('send mass money',3,'Syntax: .send mass money #racemask|$racename|alliance|horde|all \"#subject\" \"#text\" #money\r\n\r\nSend mail with money to players. Subject and mail text must be in \"\".'),
 ('send message',3,'Syntax: .send message $playername $message\r\n\r\nSend screen message to player from ADMINISTRATOR.'),
-('send money','3','Syntax: .send money #playername "#subject" "#text" #money\r\n\r\nSend mail with money to a player. Subject and mail text must be in "".'),
+('send money',3,'Syntax: .send money #playername \"#subject\" \"#text\" #money\r\n\r\nSend mail with money to a player. Subject and mail text must be in \"\".'),
 ('server corpses',2,'Syntax: .server corpses\r\n\r\nTriggering corpses expire check in world.'),
 ('server exit',4,'Syntax: .server exit\r\n\r\nTerminate mangosd NOW. Exit code 0.'),
 ('server info',0,'Syntax: .server info\r\n\r\nDisplay server version and the number of connected players.'),
@@ -773,7 +742,7 @@ INSERT INTO `command` VALUES
 ('server idleshutdown cancel',3,'Syntax: .server idleshutdown cancel\r\n\r\nCancel the restart/shutdown timer if any.'),
 ('server idlerestart',3,'Syntax: .server idlerestart #delay\r\n\r\nRestart the server after #delay seconds if no active connections are present (no players). Use #exist_code or 2 as program exist code.'),
 ('server idlerestart cancel',3,'Syntax: .server idlerestart cancel\r\n\r\nCancel the restart/shutdown timer if any.'),
-('server log filter',4,'Syntax: .server log filter [($filtername|all) (on|off)]\r\n\r\nShow or set server log filters. If used "all" then all filters will be set to on/off state.'),
+('server log filter',4,'Syntax: .server log filter [($filtername|all) (on|off)]\r\n\r\nShow or set server log filters. If used \"all\" then all filters will be set to on/off state.'),
 ('server log level',4,'Syntax: .server log level [#level]\r\n\r\nShow or set server log level (0 - errors only, 1 - basic, 2 - detail, 3 - debug).'),
 ('server motd',0,'Syntax: .server motd\r\n\r\nShow server Message of the day.'),
 ('server plimit',3,'Syntax: .server plimit [#num|-1|-2|-3|reset|player|moderator|gamemaster|administrator]\r\n\r\nWithout arg show current player amount and security level limitations for login to server, with arg set player linit ($num > 0) or securiti limitation ($num < 0 or security leme name. With `reset` sets player limit to the one in the config file'),
@@ -820,19 +789,21 @@ UNLOCK TABLES;
 --
 -- Table structure for table `conditions`
 --
+
 DROP TABLE IF EXISTS `conditions`;
 CREATE TABLE `conditions` (
-  `condition_entry` mediumint(8) unsigned NOT NULL auto_increment COMMENT 'Identifier',
-  `type` tinyint(3) signed NOT NULL DEFAULT '0' COMMENT 'Type of the condition',
+  `condition_entry` mediumint(8) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Identifier',
+  `type` tinyint(3) NOT NULL DEFAULT '0' COMMENT 'Type of the condition',
   `value1` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'data field one for the condition',
   `value2` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'data field two for the condition',
-  PRIMARY KEY  (`condition_entry`),
-  CONSTRAINT unique_conditions UNIQUE (type,value1,value2)
+  PRIMARY KEY (`condition_entry`),
+  UNIQUE KEY `unique_conditions` (`type`,`value1`,`value2`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Condition System';
 
 --
 -- Dumping data for table `conditions`
 --
+
 LOCK TABLES `conditions` WRITE;
 /*!40000 ALTER TABLE `conditions` DISABLE KEYS */;
 /*!40000 ALTER TABLE `conditions` ENABLE KEYS */;
@@ -844,25 +815,25 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `creature`;
 CREATE TABLE `creature` (
-  `guid` int(10) unsigned NOT NULL auto_increment COMMENT 'Global Unique Identifier',
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Creature Identifier',
-  `map` smallint(5) unsigned NOT NULL default '0' COMMENT 'Map Identifier',
-  `spawnMask` tinyint(3) unsigned NOT NULL default '1',
-  `phaseMask` smallint(5) unsigned NOT NULL default '1',
-  `modelid` mediumint(8) unsigned NOT NULL default '0',
-  `equipment_id` mediumint(9) NOT NULL default '0',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `spawntimesecs` int(10) unsigned NOT NULL default '120',
-  `spawndist` float NOT NULL default '5',
-  `currentwaypoint` mediumint(8) unsigned NOT NULL default '0',
-  `curhealth` int(10) unsigned NOT NULL default '1',
-  `curmana` int(10) unsigned NOT NULL default '0',
-  `DeathState` tinyint(3) unsigned NOT NULL default '0',
-  `MovementType` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`),
+  `guid` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Global Unique Identifier',
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Creature Identifier',
+  `map` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Map Identifier',
+  `spawnMask` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
+  `modelid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `equipment_id` mediumint(9) NOT NULL DEFAULT '0',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `spawntimesecs` int(10) unsigned NOT NULL DEFAULT '120',
+  `spawndist` float NOT NULL DEFAULT '5',
+  `currentwaypoint` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `curhealth` int(10) unsigned NOT NULL DEFAULT '1',
+  `curmana` int(10) unsigned NOT NULL DEFAULT '0',
+  `DeathState` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `MovementType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`),
   KEY `idx_map` (`map`),
   KEY `index_id` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Creature System';
@@ -882,15 +853,15 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `creature_addon`;
 CREATE TABLE `creature_addon` (
-  `guid` int(10) unsigned NOT NULL default '0',
-  `mount` mediumint(8) unsigned NOT NULL default '0',
-  `bytes1` int(10) unsigned NOT NULL default '0',
+  `guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `mount` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `bytes1` int(10) unsigned NOT NULL DEFAULT '0',
   `b2_0_sheath` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `b2_1_pvp_state` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `emote` int(10) unsigned NOT NULL default '0',
-  `moveflags` int(10) unsigned NOT NULL default '0',
+  `emote` int(10) unsigned NOT NULL DEFAULT '0',
+  `moveflags` int(10) unsigned NOT NULL DEFAULT '0',
   `auras` text,
-  PRIMARY KEY  (`guid`)
+  PRIMARY KEY (`guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -903,609 +874,34 @@ LOCK TABLES `creature_addon` WRITE;
 UNLOCK TABLES;
 
 --
--- Table structure for table `creature_battleground`
---
-
-DROP TABLE IF EXISTS `creature_battleground`;
-CREATE TABLE `creature_battleground` (
-    `guid` int(10) unsigned NOT NULL COMMENT 'Creature\'s GUID',
-    `event1` tinyint(3) unsigned NOT NULL COMMENT 'main event',
-    `event2` tinyint(3) unsigned NOT NULL COMMENT 'sub event',
-    PRIMARY KEY  (`guid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Creature battleground indexing system';
-
---
--- Dumping data for table `creature_battleground`
---
-
-LOCK TABLES `creature_battleground` WRITE;
-/*!40000 ALTER TABLE `creature_battleground` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_battleground` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_equip_template`
---
-
-DROP TABLE IF EXISTS `creature_equip_template`;
-CREATE TABLE `creature_equip_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Unique entry',
-  `equipentry1` mediumint(8) unsigned NOT NULL default '0',
-  `equipentry2` mediumint(8) unsigned NOT NULL default '0',
-  `equipentry3` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Creature System (Equipment)';
-
---
--- Dumping data for table `creature_equip_template`
---
-
-LOCK TABLES `creature_equip_template` WRITE;
-/*!40000 ALTER TABLE `creature_equip_template` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_equip_template` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_involvedrelation`
---
-
-DROP TABLE IF EXISTS `creature_involvedrelation`;
-CREATE TABLE `creature_involvedrelation` (
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Identifier',
-  `quest` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`id`,`quest`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
-
---
--- Dumping data for table `creature_involvedrelation`
---
-
-LOCK TABLES `creature_involvedrelation` WRITE;
-/*!40000 ALTER TABLE `creature_involvedrelation` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_involvedrelation` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_linking`
---
-
-DROP TABLE IF EXISTS creature_linking;
-CREATE TABLE `creature_linking` (
-  `guid` int(10) UNSIGNED NOT NULL COMMENT 'creature.guid of the slave mob that is linked',
-  `master_guid` int(10) UNSIGNED NOT NULL COMMENT 'master to trigger events',
-  `flag` mediumint(8) UNSIGNED NOT NULL COMMENT 'flag - describing what should happen when',
-  PRIMARY KEY  (`guid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature Linking System';
-
-
---
--- Dumping data for table `creature_linking`
---
-
-LOCK TABLES `creature_linking` WRITE;
-/*!40000 ALTER TABLE `creature_linking` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_linking` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_linking_template`
---
-
-DROP TABLE IF EXISTS creature_linking_template;
-CREATE TABLE `creature_linking_template` (
-  `entry` mediumint(8) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'creature_template.entry of the slave mob that is linked',
-  `map` SMALLINT(5) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Id of map of the mobs',
-  `master_entry` mediumint(8) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'master to trigger events',
-  `flag` mediumint(8) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'flag - describing what should happen when',
-  `search_range` mediumint(8) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'search_range - describing in which range (spawn-coords) master and slave are linked together',
-  PRIMARY KEY  (`entry`,`map`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature Linking System';
-
-
---
--- Dumping data for table `creature_linking_template`
---
-
-LOCK TABLES `creature_linking_template` WRITE;
-/*!40000 ALTER TABLE `creature_linking_template` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_linking_template` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_loot_template`
---
-
-DROP TABLE IF EXISTS `creature_loot_template`;
-CREATE TABLE `creature_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'entry 0 used for player insignia loot',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
-
---
--- Dumping data for table `creature_loot_template`
---
-
-LOCK TABLES `creature_loot_template` WRITE;
-/*!40000 ALTER TABLE `creature_loot_template` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_loot_template` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_model_info`
---
-
-DROP TABLE IF EXISTS `creature_model_info`;
-CREATE TABLE `creature_model_info` (
-  `modelid` mediumint(8) unsigned NOT NULL default '0',
-  `bounding_radius` float NOT NULL default '0',
-  `combat_reach` float NOT NULL default '0',
-  `gender` tinyint(3) unsigned NOT NULL default '2',
-  `modelid_other_gender` mediumint(8) unsigned NOT NULL default '0',
-  `modelid_alternative` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`modelid`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Creature System (Model related info)';
-
---
--- Dumping data for table `creature_model_info`
---
-
-LOCK TABLES `creature_model_info` WRITE;
-/*!40000 ALTER TABLE `creature_model_info` DISABLE KEYS */;
-INSERT INTO `creature_model_info` VALUES
-(49, 0.3060, 1.5, 0, 50, 0),
-(50, 0.2080, 1.5, 1, 49, 0),
-(51, 0.3720, 1.5, 0, 52, 0),
-(52, 0.2360, 1.5, 1, 51, 0),
-(53, 0.3470, 1.5, 0, 54, 0),
-(54, 0.3470, 1.5, 1, 53, 0),
-(55, 0.3890, 1.5, 0, 56, 0),
-(56, 0.3060, 1.5, 1, 55, 0),
-(57, 0.3830, 1.5, 0, 58, 0),
-(58, 0.3830, 1.5, 1, 57, 0),
-(59, 0.9747, 1.5, 0, 60, 0),
-(60, 0.8725, 1.5, 1, 59, 0),
-(1478, 0.3060, 1.5, 0, 1479, 0),
-(1479, 0.3060, 1.5, 1, 1478, 0),
-(1563, 0.3519, 1.5, 0, 1564, 0),
-(1564, 0.3519, 1.5, 1, 1563, 0),
-(10045, 1.0000, 1.5, 2, 0, 0),
-(15475, 0.3830, 1.5, 1, 15476, 0),
-(15476, 0.3830, 1.5, 0, 15475, 0),
-(16125, 1.0000, 1.5, 0, 16126, 0),
-(16126, 1.0000, 1.5, 1, 16125, 0);
-/*!40000 ALTER TABLE `creature_model_info` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_model_race`
---
-
-DROP TABLE IF EXISTS `creature_model_race`;
-CREATE TABLE `creature_model_race` (
-  `modelid` mediumint(8) unsigned NOT NULL default '0',
-  `racemask` mediumint(8) unsigned NOT NULL default '0',
-  `creature_entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'option 1, modelid_N from creature_template',
-  `modelid_racial` mediumint(8) unsigned NOT NULL default '0' COMMENT 'option 2, explicit modelid',
-  PRIMARY KEY  (`modelid`,`racemask`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Model system';
-
---
--- Dumping data for table `creature_model_race`
---
-
-LOCK TABLES `creature_model_race` WRITE;
-/*!40000 ALTER TABLE `creature_model_race` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_model_race` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_movement`
---
-
-DROP TABLE IF EXISTS `creature_movement`;
-CREATE TABLE `creature_movement` (
-  `id` int(10) unsigned NOT NULL COMMENT 'Creature GUID',
-  `point` mediumint(8) unsigned NOT NULL default '0',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `waittime` int(10) unsigned NOT NULL default '0',
-  `script_id` mediumint(8) unsigned NOT NULL default '0',
-  `textid1` int(11) NOT NULL default '0',
-  `textid2` int(11) NOT NULL default '0',
-  `textid3` int(11) NOT NULL default '0',
-  `textid4` int(11) NOT NULL default '0',
-  `textid5` int(11) NOT NULL default '0',
-  `emote` mediumint(8) unsigned NOT NULL default '0',
-  `spell` mediumint(8) unsigned NOT NULL default '0',
-  `wpguid` int(11) NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `model1` mediumint(9) NOT NULL default '0',
-  `model2` mediumint(9) NOT NULL default '0',
-  PRIMARY KEY  (`id`,`point`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
-
---
--- Dumping data for table `creature_movement`
---
-
-LOCK TABLES `creature_movement` WRITE;
-/*!40000 ALTER TABLE `creature_movement` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_movement` ENABLE KEYS */;
-UNLOCK TABLES;
-
-
---
--- Table structure for table `creature_movement_template`
---
-
-DROP TABLE IF EXISTS `creature_movement_template`;
-CREATE TABLE `creature_movement_template` (
-  `entry` mediumint(8) unsigned NOT NULL COMMENT 'Creature entry',
-  `point` mediumint(8) unsigned NOT NULL default '0',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `waittime` int(10) unsigned NOT NULL default '0',
-  `script_id` mediumint(8) unsigned NOT NULL default '0',
-  `textid1` int(11) NOT NULL default '0',
-  `textid2` int(11) NOT NULL default '0',
-  `textid3` int(11) NOT NULL default '0',
-  `textid4` int(11) NOT NULL default '0',
-  `textid5` int(11) NOT NULL default '0',
-  `emote` mediumint(8) unsigned NOT NULL default '0',
-  `spell` mediumint(8) unsigned NOT NULL default '0',
-  `wpguid` int(11) NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `model1` mediumint(9) NOT NULL default '0',
-  `model2` mediumint(9) NOT NULL default '0',
-  PRIMARY KEY  (`entry`,`point`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature waypoint system';
-
---
--- Dumping data for table `creature_movement_template`
---
-
-LOCK TABLES `creature_movement_template` WRITE;
-/*!40000 ALTER TABLE `creature_movement_template` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_movement_template` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_onkill_reputation`
---
-
-DROP TABLE IF EXISTS `creature_onkill_reputation`;
-CREATE TABLE `creature_onkill_reputation` (
-  `creature_id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Creature Identifier',
-  `RewOnKillRepFaction1` smallint(6) NOT NULL default '0',
-  `RewOnKillRepFaction2` smallint(6) NOT NULL default '0',
-  `MaxStanding1` tinyint(4) NOT NULL default '0',
-  `IsTeamAward1` tinyint(4) NOT NULL default '0',
-  `RewOnKillRepValue1` mediumint(9) NOT NULL default '0',
-  `MaxStanding2` tinyint(4) NOT NULL default '0',
-  `IsTeamAward2` tinyint(4) NOT NULL default '0',
-  `RewOnKillRepValue2` mediumint(9) NOT NULL default '0',
-  `TeamDependent` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`creature_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Creature OnKill Reputation gain';
-
---
--- Dumping data for table `creature_onkill_reputation`
---
-
-LOCK TABLES `creature_onkill_reputation` WRITE;
-/*!40000 ALTER TABLE `creature_onkill_reputation` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_onkill_reputation` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_questrelation`
---
-
-DROP TABLE IF EXISTS `creature_questrelation`;
-CREATE TABLE `creature_questrelation` (
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Identifier',
-  `quest` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`id`,`quest`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
-
---
--- Dumping data for table `creature_questrelation`
---
-
-LOCK TABLES `creature_questrelation` WRITE;
-/*!40000 ALTER TABLE `creature_questrelation` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_questrelation` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_template`
---
-
-DROP TABLE IF EXISTS `creature_template`;
-CREATE TABLE `creature_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `difficulty_entry_1` mediumint(8) unsigned NOT NULL default '0',
-  `difficulty_entry_2` mediumint(8) unsigned NOT NULL default '0',
-  `difficulty_entry_3` mediumint(8) unsigned NOT NULL default '0',
-  `KillCredit1` int(11) unsigned NOT NULL default '0',
-  `KillCredit2` int(11) unsigned NOT NULL default '0',
-  `modelid_1` mediumint(8) unsigned NOT NULL default '0',
-  `modelid_2` mediumint(8) unsigned NOT NULL default '0',
-  `modelid_3` mediumint(8) unsigned NOT NULL default '0',
-  `modelid_4` mediumint(8) unsigned NOT NULL default '0',
-  `name` char(100) NOT NULL default '0',
-  `subname` char(100) default NULL,
-  `IconName` char(100) default NULL,
-  `gossip_menu_id` mediumint(8) unsigned NOT NULL default '0',
-  `minlevel` tinyint(3) unsigned NOT NULL default '1',
-  `maxlevel` tinyint(3) unsigned NOT NULL default '1',
-  `minhealth` int(10) unsigned NOT NULL default '0',
-  `maxhealth` int(10) unsigned NOT NULL default '0',
-  `minmana` int(10) unsigned NOT NULL default '0',
-  `maxmana` int(10) unsigned NOT NULL default '0',
-  `armor` mediumint(8) unsigned NOT NULL default '0',
-  `faction_A` smallint(5) unsigned NOT NULL default '0',
-  `faction_H` smallint(5) unsigned NOT NULL default '0',
-  `npcflag` int(10) unsigned NOT NULL default '0',
-  `speed_walk` float NOT NULL default '1' COMMENT 'Result of 2.5/2.5, most common value',
-  `speed_run` float NOT NULL default '1.14286' COMMENT 'Result of 8.0/7.0, most common value',
-  `scale` float NOT NULL default '1',
-  `rank` tinyint(3) unsigned NOT NULL default '0',
-  `mindmg` float NOT NULL default '0',
-  `maxdmg` float NOT NULL default '0',
-  `dmgschool` tinyint(4) NOT NULL default '0',
-  `attackpower` int(10) unsigned NOT NULL default '0',
-  `dmg_multiplier` float NOT NULL default '1',
-  `baseattacktime` int(10) unsigned NOT NULL default '0',
-  `rangeattacktime` int(10) unsigned NOT NULL default '0',
-  `unit_class` tinyint(3) unsigned NOT NULL default '0',
-  `unit_flags` int(10) unsigned NOT NULL default '0',
-  `dynamicflags` int(10) unsigned NOT NULL default '0',
-  `family` tinyint(4) NOT NULL default '0',
-  `trainer_type` tinyint(4) NOT NULL default '0',
-  `trainer_spell` mediumint(8) unsigned NOT NULL default '0',
-  `trainer_class` tinyint(3) unsigned NOT NULL default '0',
-  `trainer_race` tinyint(3) unsigned NOT NULL default '0',
-  `minrangedmg` float NOT NULL default '0',
-  `maxrangedmg` float NOT NULL default '0',
-  `rangedattackpower` smallint(5) unsigned NOT NULL default '0',
-  `type` tinyint(3) unsigned NOT NULL default '0',
-  `type_flags` int(10) unsigned NOT NULL default '0',
-  `lootid` mediumint(8) unsigned NOT NULL default '0',
-  `pickpocketloot` mediumint(8) unsigned NOT NULL default '0',
-  `skinloot` mediumint(8) unsigned NOT NULL default '0',
-  `resistance1` smallint(5) NOT NULL default '0',
-  `resistance2` smallint(5) NOT NULL default '0',
-  `resistance3` smallint(5) NOT NULL default '0',
-  `resistance4` smallint(5) NOT NULL default '0',
-  `resistance5` smallint(5) NOT NULL default '0',
-  `resistance6` smallint(5) NOT NULL default '0',
-  `PetSpellDataId` mediumint(8) unsigned NOT NULL default '0',
-  `mingold` mediumint(8) unsigned NOT NULL default '0',
-  `maxgold` mediumint(8) unsigned NOT NULL default '0',
-  `AIName` char(64) NOT NULL default '',
-  `MovementType` tinyint(3) unsigned NOT NULL default '0',
-  `InhabitType` tinyint(3) unsigned NOT NULL default '3',
-  `unk16` float NOT NULL default '1',
-  `unk17` float NOT NULL default '1',
-  `RacialLeader` tinyint(3) unsigned NOT NULL default '0',
-  `questItem1` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem2` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem3` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem4` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem5` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem6` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `movementId` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `RegenHealth` tinyint(3) unsigned NOT NULL default '1',
-  `vehicle_id` mediumint(8) unsigned NOT NULL default '0',
-  `equipment_id` mediumint(8) unsigned NOT NULL default '0',
-  `trainer_id` mediumint(8) unsigned NOT NULL default '0',
-  `vendor_id` mediumint(8) unsigned NOT NULL default '0',
-  `mechanic_immune_mask` int(10) unsigned NOT NULL default '0',
-  `flags_extra` int(10) unsigned NOT NULL default '0',
-  `ScriptName` char(64) NOT NULL default '',
-  PRIMARY KEY  (`entry`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
-
---
--- Dumping data for table `creature_template`
---
-
-LOCK TABLES `creature_template` WRITE;
-/*!40000 ALTER TABLE `creature_template` DISABLE KEYS */;
-INSERT INTO `creature_template` VALUES
-(1,0,0,0,0,0,10045,0,0,0,'Waypoint(Only GM can see it)','Visual',NULL,0,1,1,64,64,0,0,5,35,35,0,0.91,1.14286,1,0,2,3,0,10,1,2000,2200,8,4096,0,0,0,0,0,0,1,2,100,8,5242886,0,0,0,0,0,0,0,0,0,0,0,0,'',0,7,1,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,130,'');
-/*!40000 ALTER TABLE `creature_template` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_template_addon`
---
-
-DROP TABLE IF EXISTS `creature_template_addon`;
-CREATE TABLE `creature_template_addon` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `mount` mediumint(8) unsigned NOT NULL default '0',
-  `bytes1` int(10) unsigned NOT NULL default '0',
-  `b2_0_sheath` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `b2_1_pvp_state` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `emote` mediumint(8) unsigned NOT NULL default '0',
-  `moveflags` int(10) unsigned NOT NULL default '0',
-  `auras` text,
-  PRIMARY KEY  (`entry`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-
---
--- Dumping data for table `creature_template_addon`
---
-LOCK TABLES `creature_template_addon` WRITE;
-/*!40000 ALTER TABLE `creature_template_addon` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_template_addon` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `creature_template_spells`
---
-DROP TABLE IF EXISTS `creature_template_spells`;
-CREATE TABLE `creature_template_spells` (
-  `entry` mediumint(8) unsigned NOT NULL,
-  `spell1` mediumint(8) unsigned NOT NULL,
-  `spell2` mediumint(8) unsigned NOT NULL default '0',
-  `spell3` mediumint(8) unsigned NOT NULL default '0',
-  `spell4` mediumint(8) unsigned NOT NULL default '0',
-  `spell5` mediumint(8) unsigned NOT NULL default '0',
-  `spell6` mediumint(8) unsigned NOT NULL default '0',
-  `spell7` mediumint(8) unsigned NOT NULL default '0',
-  `spell8` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System (Spells used by creature)';
-
---
--- Dumping data for table `creature_template_spells`
---
-LOCK TABLES `creature_template_spells` WRITE;
-/*!40000 ALTER TABLE `creature_template_spells` DISABLE KEYS */;
-/*!40000 ALTER TABLE `creature_template_spells` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `db_script_string`
---
-
-DROP TABLE IF EXISTS `db_script_string`;
-CREATE TABLE `db_script_string` (
-  `entry` int(11) unsigned NOT NULL default '0',
-  `content_default` text NOT NULL,
-  `content_loc1` text,
-  `content_loc2` text,
-  `content_loc3` text,
-  `content_loc4` text,
-  `content_loc5` text,
-  `content_loc6` text,
-  `content_loc7` text,
-  `content_loc8` text,
-  PRIMARY KEY  (`entry`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-
---
--- Dumping data for table `db_script_string`
---
-
-LOCK TABLES `db_script_string` WRITE;
-/*!40000 ALTER TABLE `db_script_string` DISABLE KEYS */;
-/*!40000 ALTER TABLE `db_script_string` ENABLE KEYS */;
-UNLOCK TABLES;
-
-
---
--- Table structure for table `dbscripts_on_creature_movement`
---
-
-DROP TABLE IF EXISTS `dbscripts_on_creature_movement`;
-CREATE TABLE `dbscripts_on_creature_movement` (
-  `id` mediumint(8) unsigned NOT NULL default '0',
-  `delay` int(10) unsigned NOT NULL default '0',
-  `command` mediumint(8) unsigned NOT NULL default '0',
-  `datalong` mediumint(8) unsigned NOT NULL default '0',
-  `datalong2` int(10) unsigned NOT NULL default '0',
-  `buddy_entry` int(10) unsigned NOT NULL default '0',
-  `search_radius` int(10) unsigned NOT NULL default '0',
-  `data_flags` tinyint(3) unsigned NOT NULL default '0',
-  `dataint` int(11) NOT NULL default '0',
-  `dataint2` int(11) NOT NULL default '0',
-  `dataint3` int(11) NOT NULL default '0',
-  `dataint4` int(11) NOT NULL default '0',
-  `x` float NOT NULL default '0',
-  `y` float NOT NULL default '0',
-  `z` float NOT NULL default '0',
-  `o` float NOT NULL default '0',
-  `comments` varchar(255) NOT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-
---
--- Table structure of `dbscripts_on_event`, `dbscripts_on_go_use`, `dbscripts_on_go_template_use`,
---                    `dbscripts_on_gossip`, `dbscripts_on_quest_end`, `dbscripts_on_quest_start`,
---                    `dbscripts_on_spell`, `dbscripts_on_creature_death`
-DROP TABLE IF EXISTS dbscripts_on_event;
-CREATE TABLE dbscripts_on_event LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_go_use;
-CREATE TABLE dbscripts_on_go_use LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_go_template_use;
-CREATE TABLE dbscripts_on_go_template_use LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_gossip;
-CREATE TABLE dbscripts_on_gossip LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_quest_end;
-CREATE TABLE dbscripts_on_quest_end LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_quest_start;
-CREATE TABLE dbscripts_on_quest_start LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_spell;
-CREATE TABLE dbscripts_on_spell LIKE dbscripts_on_creature_movement;
-DROP TABLE IF EXISTS dbscripts_on_creature_death;
-CREATE TABLE dbscripts_on_creature_death LIKE dbscripts_on_creature_movement;
-
-
---
--- Table structure for table `disenchant_loot_template`
---
-
-DROP TABLE IF EXISTS `disenchant_loot_template`;
-CREATE TABLE `disenchant_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Recommended id selection: item_level*100 + item_quality',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
-
---
--- Dumping data for table `disenchant_loot_template`
---
-
-LOCK TABLES `disenchant_loot_template` WRITE;
-/*!40000 ALTER TABLE `disenchant_loot_template` DISABLE KEYS */;
-/*!40000 ALTER TABLE `disenchant_loot_template` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `creature_ai_scripts`
 --
 
 DROP TABLE IF EXISTS `creature_ai_scripts`;
 CREATE TABLE `creature_ai_scripts` (
-  `id` int(11) unsigned NOT NULL COMMENT 'Identifier' AUTO_INCREMENT,
-  `creature_id` int(11) unsigned NOT NULL default '0' COMMENT 'Creature Template Identifier',
-  `event_type` tinyint(5) unsigned NOT NULL default '0' COMMENT 'Event Type',
-  `event_inverse_phase_mask` int(11) signed NOT NULL default '0' COMMENT 'Mask which phases this event will not trigger in',
-  `event_chance` int(3) unsigned NOT NULL default '100',
-  `event_flags` int(3) unsigned NOT NULL default '0',
-  `event_param1` int(11) signed NOT NULL default '0',
-  `event_param2` int(11) signed NOT NULL default '0',
-  `event_param3` int(11) signed NOT NULL default '0',
-  `event_param4` int(11) signed NOT NULL default '0',
-  `action1_type` tinyint(5) unsigned NOT NULL default '0' COMMENT 'Action Type',
-  `action1_param1` int(11) signed NOT NULL default '0',
-  `action1_param2` int(11) signed NOT NULL default '0',
-  `action1_param3` int(11) signed NOT NULL default '0',
-  `action2_type` tinyint(5) unsigned NOT NULL default '0' COMMENT 'Action Type',
-  `action2_param1` int(11) signed NOT NULL default '0',
-  `action2_param2` int(11) signed NOT NULL default '0',
-  `action2_param3` int(11) signed NOT NULL default '0',
-  `action3_type` tinyint(5) unsigned NOT NULL default '0' COMMENT 'Action Type',
-  `action3_param1` int(11) signed NOT NULL default '0',
-  `action3_param2` int(11) signed NOT NULL default '0',
-  `action3_param3` int(11) signed NOT NULL default '0',
-  `comment` varchar(255) NOT NULL default '' COMMENT 'Event Comment',
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Identifier',
+  `creature_id` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Creature Template Identifier',
+  `event_type` tinyint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Event Type',
+  `event_inverse_phase_mask` int(11) NOT NULL DEFAULT '0' COMMENT 'Mask which phases this event will not trigger in',
+  `event_chance` int(3) unsigned NOT NULL DEFAULT '100',
+  `event_flags` int(3) unsigned NOT NULL DEFAULT '0',
+  `event_param1` int(11) NOT NULL DEFAULT '0',
+  `event_param2` int(11) NOT NULL DEFAULT '0',
+  `event_param3` int(11) NOT NULL DEFAULT '0',
+  `event_param4` int(11) NOT NULL DEFAULT '0',
+  `action1_type` tinyint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Action Type',
+  `action1_param1` int(11) NOT NULL DEFAULT '0',
+  `action1_param2` int(11) NOT NULL DEFAULT '0',
+  `action1_param3` int(11) NOT NULL DEFAULT '0',
+  `action2_type` tinyint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Action Type',
+  `action2_param1` int(11) NOT NULL DEFAULT '0',
+  `action2_param2` int(11) NOT NULL DEFAULT '0',
+  `action2_param3` int(11) NOT NULL DEFAULT '0',
+  `action3_type` tinyint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Action Type',
+  `action3_param1` int(11) NOT NULL DEFAULT '0',
+  `action3_param2` int(11) NOT NULL DEFAULT '0',
+  `action3_param3` int(11) NOT NULL DEFAULT '0',
+  `comment` varchar(255) NOT NULL DEFAULT '' COMMENT 'Event Comment',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='EventAI Scripts';
 
@@ -1524,13 +920,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `creature_ai_summons`;
 CREATE TABLE `creature_ai_summons` (
-  `id` int(11) unsigned NOT NULL COMMENT 'Location Identifier' AUTO_INCREMENT,
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `spawntimesecs` int(11) unsigned NOT NULL default '120',
-  `comment` varchar(255) NOT NULL default '' COMMENT 'Summon Comment',
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Location Identifier',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `spawntimesecs` int(11) unsigned NOT NULL DEFAULT '120',
+  `comment` varchar(255) NOT NULL DEFAULT '' COMMENT 'Summon Comment',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='EventAI Summoning Locations';
 
@@ -1576,6 +972,838 @@ LOCK TABLES `creature_ai_texts` WRITE;
 /*!40000 ALTER TABLE `creature_ai_texts` ENABLE KEYS */;
 UNLOCK TABLES;
 
+--
+-- Table structure for table `creature_battleground`
+--
+
+DROP TABLE IF EXISTS `creature_battleground`;
+CREATE TABLE `creature_battleground` (
+  `guid` int(10) unsigned NOT NULL COMMENT 'Creature''s GUID',
+  `event1` tinyint(3) unsigned NOT NULL COMMENT 'main event',
+  `event2` tinyint(3) unsigned NOT NULL COMMENT 'sub event',
+  PRIMARY KEY (`guid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Creature battleground indexing system';
+
+--
+-- Dumping data for table `creature_battleground`
+--
+
+LOCK TABLES `creature_battleground` WRITE;
+/*!40000 ALTER TABLE `creature_battleground` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_battleground` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_equip_template`
+--
+
+DROP TABLE IF EXISTS `creature_equip_template`;
+CREATE TABLE `creature_equip_template` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Unique entry',
+  `equipentry1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `equipentry2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `equipentry3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Creature System (Equipment)';
+
+--
+-- Dumping data for table `creature_equip_template`
+--
+
+LOCK TABLES `creature_equip_template` WRITE;
+/*!40000 ALTER TABLE `creature_equip_template` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_equip_template` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_involvedrelation`
+--
+
+DROP TABLE IF EXISTS `creature_involvedrelation`;
+CREATE TABLE `creature_involvedrelation` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`id`,`quest`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
+
+--
+-- Dumping data for table `creature_involvedrelation`
+--
+
+LOCK TABLES `creature_involvedrelation` WRITE;
+/*!40000 ALTER TABLE `creature_involvedrelation` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_involvedrelation` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_linking`
+--
+
+DROP TABLE IF EXISTS `creature_linking`;
+CREATE TABLE `creature_linking` (
+  `guid` int(10) unsigned NOT NULL COMMENT 'creature.guid of the slave mob that is linked',
+  `master_guid` int(10) unsigned NOT NULL COMMENT 'master to trigger events',
+  `flag` mediumint(8) unsigned NOT NULL COMMENT 'flag - describing what should happen when',
+  PRIMARY KEY (`guid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature Linking System';
+
+--
+-- Dumping data for table `creature_linking`
+--
+
+LOCK TABLES `creature_linking` WRITE;
+/*!40000 ALTER TABLE `creature_linking` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_linking` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_linking_template`
+--
+
+DROP TABLE IF EXISTS `creature_linking_template`;
+CREATE TABLE `creature_linking_template` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'creature_template.entry of the slave mob that is linked',
+  `map` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of map of the mobs',
+  `master_entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'master to trigger events',
+  `flag` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'flag - describing what should happen when',
+  `search_range` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'search_range - describing in which range (spawn-coords) master and slave are linked together',
+  PRIMARY KEY (`entry`,`map`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature Linking System';
+
+--
+-- Dumping data for table `creature_linking_template`
+--
+
+LOCK TABLES `creature_linking_template` WRITE;
+/*!40000 ALTER TABLE `creature_linking_template` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_linking_template` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_loot_template`
+--
+
+DROP TABLE IF EXISTS `creature_loot_template`;
+CREATE TABLE `creature_loot_template` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'entry 0 used for player insignia loot',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
+
+--
+-- Dumping data for table `creature_loot_template`
+--
+
+LOCK TABLES `creature_loot_template` WRITE;
+/*!40000 ALTER TABLE `creature_loot_template` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_loot_template` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_model_info`
+--
+
+DROP TABLE IF EXISTS `creature_model_info`;
+CREATE TABLE `creature_model_info` (
+  `modelid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `bounding_radius` float NOT NULL DEFAULT '0',
+  `combat_reach` float NOT NULL DEFAULT '0',
+  `gender` tinyint(3) unsigned NOT NULL DEFAULT '2',
+  `modelid_other_gender` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `modelid_alternative` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`modelid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Creature System (Model related info)';
+
+--
+-- Dumping data for table `creature_model_info`
+--
+
+LOCK TABLES `creature_model_info` WRITE;
+/*!40000 ALTER TABLE `creature_model_info` DISABLE KEYS */;
+INSERT INTO `creature_model_info` VALUES
+(49,0.306,1.5,0,50,0),
+(50,0.208,1.5,1,49,0),
+(51,0.372,1.5,0,52,0),
+(52,0.236,1.5,1,51,0),
+(53,0.347,1.5,0,54,0),
+(54,0.347,1.5,1,53,0),
+(55,0.389,1.5,0,56,0),
+(56,0.306,1.5,1,55,0),
+(57,0.383,1.5,0,58,0),
+(58,0.383,1.5,1,57,0),
+(59,0.9747,1.5,0,60,0),
+(60,0.8725,1.5,1,59,0),
+(1478,0.306,1.5,0,1479,0),
+(1479,0.306,1.5,1,1478,0),
+(1563,0.3519,1.5,0,1564,0),
+(1564,0.3519,1.5,1,1563,0),
+(10045,1,1.5,2,0,0),
+(15475,0.383,1.5,1,15476,0),
+(15476,0.383,1.5,0,15475,0),
+(16125,1,1.5,0,16126,0),
+(16126,1,1.5,1,16125,0);
+/*!40000 ALTER TABLE `creature_model_info` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_model_race`
+--
+
+DROP TABLE IF EXISTS `creature_model_race`;
+CREATE TABLE `creature_model_race` (
+  `modelid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `racemask` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `creature_entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'option 1, modelid_N from creature_template',
+  `modelid_racial` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'option 2, explicit modelid',
+  PRIMARY KEY (`modelid`,`racemask`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Model system';
+
+--
+-- Dumping data for table `creature_model_race`
+--
+
+LOCK TABLES `creature_model_race` WRITE;
+/*!40000 ALTER TABLE `creature_model_race` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_model_race` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_movement`
+--
+
+DROP TABLE IF EXISTS `creature_movement`;
+CREATE TABLE `creature_movement` (
+  `id` int(10) unsigned NOT NULL COMMENT 'Creature GUID',
+  `point` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `waittime` int(10) unsigned NOT NULL DEFAULT '0',
+  `script_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `textid1` int(11) NOT NULL DEFAULT '0',
+  `textid2` int(11) NOT NULL DEFAULT '0',
+  `textid3` int(11) NOT NULL DEFAULT '0',
+  `textid4` int(11) NOT NULL DEFAULT '0',
+  `textid5` int(11) NOT NULL DEFAULT '0',
+  `emote` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `wpguid` int(11) NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `model1` mediumint(9) NOT NULL DEFAULT '0',
+  `model2` mediumint(9) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`,`point`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
+
+--
+-- Dumping data for table `creature_movement`
+--
+
+LOCK TABLES `creature_movement` WRITE;
+/*!40000 ALTER TABLE `creature_movement` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_movement` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_movement_template`
+--
+
+DROP TABLE IF EXISTS `creature_movement_template`;
+CREATE TABLE `creature_movement_template` (
+  `entry` mediumint(8) unsigned NOT NULL COMMENT 'Creature entry',
+  `point` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `waittime` int(10) unsigned NOT NULL DEFAULT '0',
+  `script_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `textid1` int(11) NOT NULL DEFAULT '0',
+  `textid2` int(11) NOT NULL DEFAULT '0',
+  `textid3` int(11) NOT NULL DEFAULT '0',
+  `textid4` int(11) NOT NULL DEFAULT '0',
+  `textid5` int(11) NOT NULL DEFAULT '0',
+  `emote` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `wpguid` int(11) NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `model1` mediumint(9) NOT NULL DEFAULT '0',
+  `model2` mediumint(9) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`point`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature waypoint system';
+
+--
+-- Dumping data for table `creature_movement_template`
+--
+
+LOCK TABLES `creature_movement_template` WRITE;
+/*!40000 ALTER TABLE `creature_movement_template` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_movement_template` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_onkill_reputation`
+--
+
+DROP TABLE IF EXISTS `creature_onkill_reputation`;
+CREATE TABLE `creature_onkill_reputation` (
+  `creature_id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Creature Identifier',
+  `RewOnKillRepFaction1` smallint(6) NOT NULL DEFAULT '0',
+  `RewOnKillRepFaction2` smallint(6) NOT NULL DEFAULT '0',
+  `MaxStanding1` tinyint(4) NOT NULL DEFAULT '0',
+  `IsTeamAward1` tinyint(4) NOT NULL DEFAULT '0',
+  `RewOnKillRepValue1` mediumint(9) NOT NULL DEFAULT '0',
+  `MaxStanding2` tinyint(4) NOT NULL DEFAULT '0',
+  `IsTeamAward2` tinyint(4) NOT NULL DEFAULT '0',
+  `RewOnKillRepValue2` mediumint(9) NOT NULL DEFAULT '0',
+  `TeamDependent` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`creature_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Creature OnKill Reputation gain';
+
+--
+-- Dumping data for table `creature_onkill_reputation`
+--
+
+LOCK TABLES `creature_onkill_reputation` WRITE;
+/*!40000 ALTER TABLE `creature_onkill_reputation` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_onkill_reputation` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_questrelation`
+--
+
+DROP TABLE IF EXISTS `creature_questrelation`;
+CREATE TABLE `creature_questrelation` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`id`,`quest`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
+
+--
+-- Dumping data for table `creature_questrelation`
+--
+
+LOCK TABLES `creature_questrelation` WRITE;
+/*!40000 ALTER TABLE `creature_questrelation` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_questrelation` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_template`
+--
+
+DROP TABLE IF EXISTS `creature_template`;
+CREATE TABLE `creature_template` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `difficulty_entry_1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `difficulty_entry_2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `difficulty_entry_3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `KillCredit1` int(11) unsigned NOT NULL DEFAULT '0',
+  `KillCredit2` int(11) unsigned NOT NULL DEFAULT '0',
+  `modelid_1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `modelid_2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `modelid_3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `modelid_4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `name` char(100) NOT NULL DEFAULT '0',
+  `subname` char(100) DEFAULT NULL,
+  `IconName` char(100) DEFAULT NULL,
+  `gossip_menu_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `minlevel` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `maxlevel` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `minhealth` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxhealth` int(10) unsigned NOT NULL DEFAULT '0',
+  `minmana` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxmana` int(10) unsigned NOT NULL DEFAULT '0',
+  `armor` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `faction_A` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `faction_H` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `npcflag` int(10) unsigned NOT NULL DEFAULT '0',
+  `speed_walk` float NOT NULL DEFAULT '1' COMMENT 'Result of 2.5/2.5, most common value',
+  `speed_run` float NOT NULL DEFAULT '1.14286' COMMENT 'Result of 8.0/7.0, most common value',
+  `scale` float NOT NULL DEFAULT '1',
+  `rank` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mindmg` float NOT NULL DEFAULT '0',
+  `maxdmg` float NOT NULL DEFAULT '0',
+  `dmgschool` tinyint(4) NOT NULL DEFAULT '0',
+  `attackpower` int(10) unsigned NOT NULL DEFAULT '0',
+  `dmg_multiplier` float NOT NULL DEFAULT '1',
+  `baseattacktime` int(10) unsigned NOT NULL DEFAULT '0',
+  `rangeattacktime` int(10) unsigned NOT NULL DEFAULT '0',
+  `unit_class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `unit_flags` int(10) unsigned NOT NULL DEFAULT '0',
+  `dynamicflags` int(10) unsigned NOT NULL DEFAULT '0',
+  `family` tinyint(4) NOT NULL DEFAULT '0',
+  `trainer_type` tinyint(4) NOT NULL DEFAULT '0',
+  `trainer_spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `trainer_class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `trainer_race` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `minrangedmg` float NOT NULL DEFAULT '0',
+  `maxrangedmg` float NOT NULL DEFAULT '0',
+  `rangedattackpower` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `type_flags` int(10) unsigned NOT NULL DEFAULT '0',
+  `lootid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `pickpocketloot` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `skinloot` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `resistance1` smallint(5) NOT NULL DEFAULT '0',
+  `resistance2` smallint(5) NOT NULL DEFAULT '0',
+  `resistance3` smallint(5) NOT NULL DEFAULT '0',
+  `resistance4` smallint(5) NOT NULL DEFAULT '0',
+  `resistance5` smallint(5) NOT NULL DEFAULT '0',
+  `resistance6` smallint(5) NOT NULL DEFAULT '0',
+  `PetSpellDataId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `mingold` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `maxgold` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `AIName` char(64) NOT NULL DEFAULT '',
+  `MovementType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `InhabitType` tinyint(3) unsigned NOT NULL DEFAULT '3',
+  `unk16` float NOT NULL DEFAULT '1',
+  `unk17` float NOT NULL DEFAULT '1',
+  `RacialLeader` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `questItem1` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem2` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem3` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem4` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem5` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem6` int(11) unsigned NOT NULL DEFAULT '0',
+  `movementId` int(11) unsigned NOT NULL DEFAULT '0',
+  `RegenHealth` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `vehicle_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `equipment_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `trainer_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `vendor_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `mechanic_immune_mask` int(10) unsigned NOT NULL DEFAULT '0',
+  `flags_extra` int(10) unsigned NOT NULL DEFAULT '0',
+  `ScriptName` char(64) NOT NULL DEFAULT '',
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System';
+
+--
+-- Dumping data for table `creature_template`
+--
+
+LOCK TABLES `creature_template` WRITE;
+/*!40000 ALTER TABLE `creature_template` DISABLE KEYS */;
+INSERT INTO `creature_template` VALUES
+(1,0,0,0,0,0,10045,0,0,0,'Waypoint(Only GM can see it)','Visual',NULL,0,1,1,64,64,0,0,5,35,35,0,0.91,1.14286,1,0,2,3,0,10,1,2000,2200,8,4096,0,0,0,0,0,0,1,2,100,8,5242886,0,0,0,0,0,0,0,0,0,0,0,0,'',0,7,1,1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,130,'');
+/*!40000 ALTER TABLE `creature_template` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_template_addon`
+--
+
+DROP TABLE IF EXISTS `creature_template_addon`;
+CREATE TABLE `creature_template_addon` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `mount` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `bytes1` int(10) unsigned NOT NULL DEFAULT '0',
+  `b2_0_sheath` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `b2_1_pvp_state` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `emote` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `moveflags` int(10) unsigned NOT NULL DEFAULT '0',
+  `auras` text,
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `creature_template_addon`
+--
+
+LOCK TABLES `creature_template_addon` WRITE;
+/*!40000 ALTER TABLE `creature_template_addon` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_template_addon` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `creature_template_spells`
+--
+
+DROP TABLE IF EXISTS `creature_template_spells`;
+CREATE TABLE `creature_template_spells` (
+  `entry` mediumint(8) unsigned NOT NULL,
+  `spell1` mediumint(8) unsigned NOT NULL,
+  `spell2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell5` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell6` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell7` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell8` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Creature System (Spells used by creature)';
+
+--
+-- Dumping data for table `creature_template_spells`
+--
+
+LOCK TABLES `creature_template_spells` WRITE;
+/*!40000 ALTER TABLE `creature_template_spells` DISABLE KEYS */;
+/*!40000 ALTER TABLE `creature_template_spells` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `db_script_string`
+--
+
+DROP TABLE IF EXISTS `db_script_string`;
+CREATE TABLE `db_script_string` (
+  `entry` int(11) unsigned NOT NULL DEFAULT '0',
+  `content_default` text NOT NULL,
+  `content_loc1` text,
+  `content_loc2` text,
+  `content_loc3` text,
+  `content_loc4` text,
+  `content_loc5` text,
+  `content_loc6` text,
+  `content_loc7` text,
+  `content_loc8` text,
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `db_script_string`
+--
+
+LOCK TABLES `db_script_string` WRITE;
+/*!40000 ALTER TABLE `db_script_string` DISABLE KEYS */;
+/*!40000 ALTER TABLE `db_script_string` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_creature_death`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_creature_death`;
+CREATE TABLE `dbscripts_on_creature_death` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_creature_death`
+--
+
+LOCK TABLES `dbscripts_on_creature_death` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_creature_death` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_creature_death` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_creature_movement`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_creature_movement`;
+CREATE TABLE `dbscripts_on_creature_movement` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_creature_movement`
+--
+
+LOCK TABLES `dbscripts_on_creature_movement` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_creature_movement` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_creature_movement` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_event`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_event`;
+CREATE TABLE `dbscripts_on_event` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_event`
+--
+
+LOCK TABLES `dbscripts_on_event` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_event` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_event` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_go_template_use`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_go_template_use`;
+CREATE TABLE `dbscripts_on_go_template_use` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_go_template_use`
+--
+
+LOCK TABLES `dbscripts_on_go_template_use` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_go_template_use` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_go_template_use` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_go_use`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_go_use`;
+CREATE TABLE `dbscripts_on_go_use` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_go_use`
+--
+
+LOCK TABLES `dbscripts_on_go_use` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_go_use` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_go_use` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_gossip`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_gossip`;
+CREATE TABLE `dbscripts_on_gossip` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_gossip`
+--
+
+LOCK TABLES `dbscripts_on_gossip` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_gossip` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_gossip` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_quest_end`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_quest_end`;
+CREATE TABLE `dbscripts_on_quest_end` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_quest_end`
+--
+
+LOCK TABLES `dbscripts_on_quest_end` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_quest_end` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_quest_end` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_quest_start`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_quest_start`;
+CREATE TABLE `dbscripts_on_quest_start` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_quest_start`
+--
+
+LOCK TABLES `dbscripts_on_quest_start` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_quest_start` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_quest_start` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `dbscripts_on_spell`
+--
+
+DROP TABLE IF EXISTS `dbscripts_on_spell`;
+CREATE TABLE `dbscripts_on_spell` (
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `delay` int(10) unsigned NOT NULL DEFAULT '0',
+  `command` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `datalong2` int(10) unsigned NOT NULL DEFAULT '0',
+  `buddy_entry` int(10) unsigned NOT NULL DEFAULT '0',
+  `search_radius` int(10) unsigned NOT NULL DEFAULT '0',
+  `data_flags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dataint` int(11) NOT NULL DEFAULT '0',
+  `dataint2` int(11) NOT NULL DEFAULT '0',
+  `dataint3` int(11) NOT NULL DEFAULT '0',
+  `dataint4` int(11) NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `z` float NOT NULL DEFAULT '0',
+  `o` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `dbscripts_on_spell`
+--
+
+LOCK TABLES `dbscripts_on_spell` WRITE;
+/*!40000 ALTER TABLE `dbscripts_on_spell` DISABLE KEYS */;
+/*!40000 ALTER TABLE `dbscripts_on_spell` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `disenchant_loot_template`
+--
+
+DROP TABLE IF EXISTS `disenchant_loot_template`;
+CREATE TABLE `disenchant_loot_template` (
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Recommended id selection: item_level*100 + item_quality',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
+
+--
+-- Dumping data for table `disenchant_loot_template`
+--
+
+LOCK TABLES `disenchant_loot_template` WRITE;
+/*!40000 ALTER TABLE `disenchant_loot_template` DISABLE KEYS */;
+/*!40000 ALTER TABLE `disenchant_loot_template` ENABLE KEYS */;
+UNLOCK TABLES;
 
 --
 -- Table structure for table `exploration_basexp`
@@ -1583,9 +1811,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `exploration_basexp`;
 CREATE TABLE `exploration_basexp` (
-  `level` tinyint(4) NOT NULL default '0',
-  `basexp` mediumint(9) NOT NULL default '0',
-  PRIMARY KEY  (`level`)
+  `level` tinyint(4) NOT NULL DEFAULT '0',
+  `basexp` mediumint(9) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`level`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Exploration System';
 
 --
@@ -1675,14 +1903,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `fishing_loot_template`;
 CREATE TABLE `fishing_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'entry 0 used for junk loot at fishing fail (if allowed by config option)',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'entry 0 used for junk loot at fishing fail (if allowed by config option)',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -1701,13 +1929,13 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `game_event`;
 CREATE TABLE `game_event` (
   `entry` mediumint(8) unsigned NOT NULL COMMENT 'Entry of the game event',
-  `start_time` timestamp NOT NULL default '0000-00-00 00:00:00' COMMENT 'Absolute start date, the event will never start before',
-  `end_time` timestamp NOT NULL default '0000-00-00 00:00:00' COMMENT 'Absolute end date, the event will never start afler',
-  `occurence` bigint(20) unsigned NOT NULL default '86400' COMMENT 'Delay in minutes between occurences of the event',
-  `length` bigint(20) unsigned NOT NULL default '43200' COMMENT 'Length in minutes of the event',
-  `holiday` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Client side holiday id',
-  `description` varchar(255) default NULL COMMENT 'Description of the event displayed in console',
-  PRIMARY KEY  (`entry`)
+  `start_time` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Absolute start date, the event will never start before',
+  `end_time` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'Absolute end date, the event will never start afler',
+  `occurence` bigint(20) unsigned NOT NULL DEFAULT '86400' COMMENT 'Delay in minutes between occurences of the event',
+  `length` bigint(20) unsigned NOT NULL DEFAULT '43200' COMMENT 'Length in minutes of the event',
+  `holiday` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Client side holiday id',
+  `description` varchar(255) DEFAULT NULL COMMENT 'Description of the event displayed in console',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -1726,8 +1954,8 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `game_event_creature`;
 CREATE TABLE `game_event_creature` (
   `guid` int(10) unsigned NOT NULL,
-  `event` smallint(6) NOT NULL default '0' COMMENT 'Negatives value to remove during event and ignore pool grouping, positive value for spawn during event and if guid is part of pool then al pool memebers must be listed as part of event spawn.',
-  PRIMARY KEY  (`guid`)
+  `event` smallint(6) NOT NULL DEFAULT '0' COMMENT 'Negatives value to remove during event and ignore pool grouping, positive value for spawn during event and if guid is part of pool then al pool memebers must be listed as part of event spawn.',
+  PRIMARY KEY (`guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -1745,14 +1973,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_event_creature_data`;
 CREATE TABLE `game_event_creature_data` (
-  `guid` int(10) unsigned NOT NULL default '0',
-  `entry_id` mediumint(8) unsigned NOT NULL default '0',
-  `modelid` mediumint(8) unsigned NOT NULL default '0',
-  `equipment_id` mediumint(8) unsigned NOT NULL default '0',
-  `spell_start` mediumint(8) unsigned NOT NULL default '0',
-  `spell_end` mediumint(8) unsigned NOT NULL default '0',
-  `event` smallint(5) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`,`event`)
+  `guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `entry_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `modelid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `equipment_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell_start` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell_end` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `event` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`,`event`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -1771,8 +1999,8 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `game_event_gameobject`;
 CREATE TABLE `game_event_gameobject` (
   `guid` int(10) unsigned NOT NULL,
-  `event` smallint(6) NOT NULL default '0' COMMENT 'Negatives value to remove during event and ignore pool grouping, positive value for spawn during event and if guid is part of pool then al pool memebers must be listed as part of event spawn.',
-  PRIMARY KEY  (`guid`)
+  `event` smallint(6) NOT NULL DEFAULT '0' COMMENT 'Negatives value to remove during event and ignore pool grouping, positive value for spawn during event and if guid is part of pool then al pool memebers must be listed as part of event spawn.',
+  PRIMARY KEY (`guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -1790,12 +2018,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_event_mail`;
 CREATE TABLE `game_event_mail` (
-  `event` smallint(6) NOT NULL default '0' COMMENT 'Negatives value to send at event stop, positive value for send at event start.',
-  `raceMask` mediumint(8) unsigned NOT NULL default '0',
-  `quest`    mediumint(8) unsigned NOT NULL default '0',
-  `mailTemplateId` mediumint(8) unsigned NOT NULL default '0',
-  `senderEntry`    mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`event`,`raceMask`,`quest`)
+  `event` smallint(6) NOT NULL DEFAULT '0' COMMENT 'Negatives value to send at event stop, positive value for send at event start.',
+  `raceMask` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `mailTemplateId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `senderEntry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`event`,`raceMask`,`quest`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Game event system';
 
 --
@@ -1813,9 +2041,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_event_quest`;
 CREATE TABLE `game_event_quest` (
-  `quest` mediumint(8) unsigned NOT NULL default '0' COMMENT 'entry from quest_template',
-  `event` smallint(5) unsigned NOT NULL default '0' COMMENT 'entry from game_event',
-  PRIMARY KEY  (`quest`,`event`)
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'entry from quest_template',
+  `event` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'entry from game_event',
+  PRIMARY KEY (`quest`,`event`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Game event system';
 
 --
@@ -1833,10 +2061,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_graveyard_zone`;
 CREATE TABLE `game_graveyard_zone` (
-  `id` mediumint(8) unsigned NOT NULL default '0',
-  `ghost_zone` mediumint(8) unsigned NOT NULL default '0',
-  `faction` smallint(5) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`id`,`ghost_zone`)
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ghost_zone` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `faction` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`,`ghost_zone`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Trigger System';
 
 --
@@ -1854,14 +2082,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_tele`;
 CREATE TABLE `game_tele` (
-  `id` mediumint(8) unsigned NOT NULL auto_increment,
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `map` smallint(5) unsigned NOT NULL default '0',
-  `name` varchar(100) NOT NULL default '',
-  PRIMARY KEY  (`id`)
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `map` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `name` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Tele Command';
 
 --
@@ -1879,20 +2107,20 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `game_weather`;
 CREATE TABLE `game_weather` (
-  `zone` mediumint(8) unsigned NOT NULL default '0',
-  `spring_rain_chance` tinyint(3) unsigned NOT NULL default '25',
-  `spring_snow_chance` tinyint(3) unsigned NOT NULL default '25',
-  `spring_storm_chance` tinyint(3) unsigned NOT NULL default '25',
-  `summer_rain_chance` tinyint(3) unsigned NOT NULL default '25',
-  `summer_snow_chance` tinyint(3) unsigned NOT NULL default '25',
-  `summer_storm_chance` tinyint(3) unsigned NOT NULL default '25',
-  `fall_rain_chance` tinyint(3) unsigned NOT NULL default '25',
-  `fall_snow_chance` tinyint(3) unsigned NOT NULL default '25',
-  `fall_storm_chance` tinyint(3) unsigned NOT NULL default '25',
-  `winter_rain_chance` tinyint(3) unsigned NOT NULL default '25',
-  `winter_snow_chance` tinyint(3) unsigned NOT NULL default '25',
-  `winter_storm_chance` tinyint(3) unsigned NOT NULL default '25',
-  PRIMARY KEY  (`zone`)
+  `zone` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spring_rain_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `spring_snow_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `spring_storm_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `summer_rain_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `summer_snow_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `summer_storm_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `fall_rain_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `fall_snow_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `fall_storm_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `winter_rain_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `winter_snow_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  `winter_storm_chance` tinyint(3) unsigned NOT NULL DEFAULT '25',
+  PRIMARY KEY (`zone`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Weather System';
 
 --
@@ -1910,23 +2138,23 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject`;
 CREATE TABLE `gameobject` (
-  `guid` int(10) unsigned NOT NULL auto_increment COMMENT 'Global Unique Identifier',
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Gameobject Identifier',
-  `map` smallint(5) unsigned NOT NULL default '0' COMMENT 'Map Identifier',
-  `spawnMask` tinyint(3) unsigned NOT NULL default '1',
-  `phaseMask` smallint(5) unsigned NOT NULL default '1',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  `rotation0` float NOT NULL default '0',
-  `rotation1` float NOT NULL default '0',
-  `rotation2` float NOT NULL default '0',
-  `rotation3` float NOT NULL default '0',
-  `spawntimesecs` int(11) NOT NULL default '0',
-  `animprogress` tinyint(3) unsigned NOT NULL default '0',
-  `state` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`guid`),
+  `guid` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Global Unique Identifier',
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Gameobject Identifier',
+  `map` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Map Identifier',
+  `spawnMask` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `phaseMask` smallint(5) unsigned NOT NULL DEFAULT '1',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  `rotation0` float NOT NULL DEFAULT '0',
+  `rotation1` float NOT NULL DEFAULT '0',
+  `rotation2` float NOT NULL DEFAULT '0',
+  `rotation3` float NOT NULL DEFAULT '0',
+  `spawntimesecs` int(11) NOT NULL DEFAULT '0',
+  `animprogress` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `state` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`guid`),
   KEY `idx_map` (`map`),
   KEY `idx_id` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Gameobject System';
@@ -1946,12 +2174,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject_addon`;
 CREATE TABLE `gameobject_addon` (
-  `guid` int(10) unsigned NOT NULL default '0',
-  `path_rotation0` float NOT NULL default '0',
-  `path_rotation1` float NOT NULL default '0',
-  `path_rotation2` float NOT NULL default '0',
-  `path_rotation3` float NOT NULL default '1',
-  PRIMARY KEY  (`guid`)
+  `guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `path_rotation0` float NOT NULL DEFAULT '0',
+  `path_rotation1` float NOT NULL DEFAULT '0',
+  `path_rotation2` float NOT NULL DEFAULT '0',
+  `path_rotation3` float NOT NULL DEFAULT '1',
+  PRIMARY KEY (`guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Gameobject System';
 
 --
@@ -1969,10 +2197,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject_battleground`;
 CREATE TABLE `gameobject_battleground` (
-    `guid` int(10) unsigned NOT NULL COMMENT 'GameObject\'s GUID',
-    `event1` tinyint(3) unsigned NOT NULL COMMENT 'main event',
-    `event2` tinyint(3) unsigned NOT NULL COMMENT 'sub event',
-    PRIMARY KEY  (`guid`)
+  `guid` int(10) unsigned NOT NULL COMMENT 'GameObject''s GUID',
+  `event1` tinyint(3) unsigned NOT NULL COMMENT 'main event',
+  `event2` tinyint(3) unsigned NOT NULL COMMENT 'sub event',
+  PRIMARY KEY (`guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='GameObject battleground indexing system';
 
 --
@@ -1990,9 +2218,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject_involvedrelation`;
 CREATE TABLE `gameobject_involvedrelation` (
-  `id` mediumint(8) unsigned NOT NULL default '0',
-  `quest` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`id`,`quest`)
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`id`,`quest`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2010,14 +2238,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject_loot_template`;
 CREATE TABLE `gameobject_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -2035,9 +2263,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `gameobject_questrelation`;
 CREATE TABLE `gameobject_questrelation` (
-  `id` mediumint(8) unsigned NOT NULL default '0',
-  `quest` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY  (`id`,`quest`)
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
+  PRIMARY KEY (`id`,`quest`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2049,57 +2277,56 @@ LOCK TABLES `gameobject_questrelation` WRITE;
 /*!40000 ALTER TABLE `gameobject_questrelation` ENABLE KEYS */;
 UNLOCK TABLES;
 
-
 --
 -- Table structure for table `gameobject_template`
 --
 
 DROP TABLE IF EXISTS `gameobject_template`;
 CREATE TABLE `gameobject_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `type` tinyint(3) unsigned NOT NULL default '0',
-  `displayId` mediumint(8) unsigned NOT NULL default '0',
-  `name` varchar(100) NOT NULL default '',
-  `IconName` varchar(100) NOT NULL default '',
-  `castBarCaption` varchar(100) NOT NULL default '',
-  `unk1` varchar(100) NOT NULL default '',
-  `faction` smallint(5) unsigned NOT NULL default '0',
-  `flags` int(10) unsigned NOT NULL default '0',
-  `size` float NOT NULL default '1',
-  `questItem1` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem2` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem3` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem4` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem5` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `questItem6` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `data0` int(10) unsigned NOT NULL default '0',
-  `data1` int(10) unsigned NOT NULL default '0',
-  `data2` int(10) unsigned NOT NULL default '0',
-  `data3` int(10) unsigned NOT NULL default '0',
-  `data4` int(10) unsigned NOT NULL default '0',
-  `data5` int(10) unsigned NOT NULL default '0',
-  `data6` int(10) unsigned NOT NULL default '0',
-  `data7` int(10) unsigned NOT NULL default '0',
-  `data8` int(10) unsigned NOT NULL default '0',
-  `data9` int(10) unsigned NOT NULL default '0',
-  `data10` int(10) unsigned NOT NULL default '0',
-  `data11` int(10) unsigned NOT NULL default '0',
-  `data12` int(10) unsigned NOT NULL default '0',
-  `data13` int(10) unsigned NOT NULL default '0',
-  `data14` int(10) unsigned NOT NULL default '0',
-  `data15` int(10) unsigned NOT NULL default '0',
-  `data16` int(10) unsigned NOT NULL default '0',
-  `data17` int(10) unsigned NOT NULL default '0',
-  `data18` int(10) unsigned NOT NULL default '0',
-  `data19` int(10) unsigned NOT NULL default '0',
-  `data20` int(10) unsigned NOT NULL default '0',
-  `data21` int(10) unsigned NOT NULL default '0',
-  `data22` int(10) unsigned NOT NULL default '0',
-  `data23` int(10) unsigned NOT NULL default '0',
-  `mingold` mediumint(8) unsigned NOT NULL default '0',
-  `maxgold` mediumint(8) unsigned NOT NULL default '0',
-  `ScriptName` varchar(64) NOT NULL default '',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `displayId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `name` varchar(100) NOT NULL DEFAULT '',
+  `IconName` varchar(100) NOT NULL DEFAULT '',
+  `castBarCaption` varchar(100) NOT NULL DEFAULT '',
+  `unk1` varchar(100) NOT NULL DEFAULT '',
+  `faction` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `flags` int(10) unsigned NOT NULL DEFAULT '0',
+  `size` float NOT NULL DEFAULT '1',
+  `questItem1` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem2` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem3` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem4` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem5` int(11) unsigned NOT NULL DEFAULT '0',
+  `questItem6` int(11) unsigned NOT NULL DEFAULT '0',
+  `data0` int(10) unsigned NOT NULL DEFAULT '0',
+  `data1` int(10) unsigned NOT NULL DEFAULT '0',
+  `data2` int(10) unsigned NOT NULL DEFAULT '0',
+  `data3` int(10) unsigned NOT NULL DEFAULT '0',
+  `data4` int(10) unsigned NOT NULL DEFAULT '0',
+  `data5` int(10) unsigned NOT NULL DEFAULT '0',
+  `data6` int(10) unsigned NOT NULL DEFAULT '0',
+  `data7` int(10) unsigned NOT NULL DEFAULT '0',
+  `data8` int(10) unsigned NOT NULL DEFAULT '0',
+  `data9` int(10) unsigned NOT NULL DEFAULT '0',
+  `data10` int(10) unsigned NOT NULL DEFAULT '0',
+  `data11` int(10) unsigned NOT NULL DEFAULT '0',
+  `data12` int(10) unsigned NOT NULL DEFAULT '0',
+  `data13` int(10) unsigned NOT NULL DEFAULT '0',
+  `data14` int(10) unsigned NOT NULL DEFAULT '0',
+  `data15` int(10) unsigned NOT NULL DEFAULT '0',
+  `data16` int(10) unsigned NOT NULL DEFAULT '0',
+  `data17` int(10) unsigned NOT NULL DEFAULT '0',
+  `data18` int(10) unsigned NOT NULL DEFAULT '0',
+  `data19` int(10) unsigned NOT NULL DEFAULT '0',
+  `data20` int(10) unsigned NOT NULL DEFAULT '0',
+  `data21` int(10) unsigned NOT NULL DEFAULT '0',
+  `data22` int(10) unsigned NOT NULL DEFAULT '0',
+  `data23` int(10) unsigned NOT NULL DEFAULT '0',
+  `mingold` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `maxgold` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ScriptName` varchar(64) NOT NULL DEFAULT '',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Gameobject System';
 
 --
@@ -2111,18 +2338,17 @@ LOCK TABLES `gameobject_template` WRITE;
 /*!40000 ALTER TABLE `gameobject_template` ENABLE KEYS */;
 UNLOCK TABLES;
 
-
 --
 -- Table structure for table `gossip_menu`
 --
 
-DROP TABLE IF EXISTS gossip_menu;
-CREATE TABLE gossip_menu (
-  entry smallint(6) unsigned NOT NULL default '0',
-  text_id mediumint(8) unsigned NOT NULL default '0',
-  script_id mediumint(8) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'script in `dbscripts_on_gossip` - will be executed on GossipHello',
-  condition_id MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY (entry, text_id, script_id)
+DROP TABLE IF EXISTS `gossip_menu`;
+CREATE TABLE `gossip_menu` (
+  `entry` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `text_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `script_id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'script in `dbscripts_on_gossip` - will be executed on GossipHello',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`text_id`,`script_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2138,22 +2364,22 @@ UNLOCK TABLES;
 -- Table structure for table `gossip_menu_option`
 --
 
-DROP TABLE IF EXISTS gossip_menu_option;
-CREATE TABLE gossip_menu_option (
-  menu_id smallint(6) unsigned NOT NULL default '0',
-  id smallint(6) unsigned NOT NULL default '0',
-  option_icon mediumint(8) unsigned NOT NULL default '0',
-  option_text text,
-  option_id tinyint(3) unsigned NOT NULL default '0',
-  npc_option_npcflag int(10) unsigned NOT NULL default '0',
-  action_menu_id mediumint(8) NOT NULL default '0',
-  action_poi_id mediumint(8) unsigned NOT NULL default '0',
-  action_script_id mediumint(8) unsigned NOT NULL default '0',
-  box_coded tinyint(3) unsigned NOT NULL default '0',
-  box_money int(11) unsigned NOT NULL default '0',
-  box_text text,
-  condition_id MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY (menu_id, id)
+DROP TABLE IF EXISTS `gossip_menu_option`;
+CREATE TABLE `gossip_menu_option` (
+  `menu_id` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `id` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `option_icon` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `option_text` text,
+  `option_id` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `npc_option_npcflag` int(10) unsigned NOT NULL DEFAULT '0',
+  `action_menu_id` mediumint(8) NOT NULL DEFAULT '0',
+  `action_poi_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `action_script_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `box_coded` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `box_money` int(11) unsigned NOT NULL DEFAULT '0',
+  `box_text` text,
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`menu_id`,`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2162,7 +2388,7 @@ CREATE TABLE gossip_menu_option (
 
 LOCK TABLES `gossip_menu_option` WRITE;
 /*!40000 ALTER TABLE `gossip_menu_option` DISABLE KEYS */;
-INSERT INTO gossip_menu_option VALUES
+INSERT INTO `gossip_menu_option` VALUES
 (0, 0,0,'GOSSIP_OPTION_QUESTGIVER',       2,0x000002,0,0,0,0,0,NULL,0),
 (0, 1,1,'GOSSIP_OPTION_VENDOR',           3,0x000080,0,0,0,0,0,NULL,0),
 (0, 2,2,'GOSSIP_OPTION_TAXIVENDOR',       4,0x002000,0,0,0,0,0,NULL,0),
@@ -2182,6 +2408,640 @@ INSERT INTO gossip_menu_option VALUES
 /*!40000 ALTER TABLE `gossip_menu_option` ENABLE KEYS */;
 UNLOCK TABLES;
 
+--
+-- Table structure for table `instance_encounters`
+--
+
+DROP TABLE IF EXISTS `instance_encounters`;
+CREATE TABLE `instance_encounters` (
+  `entry` int(10) unsigned NOT NULL COMMENT 'Unique entry from DungeonEncounter.dbc',
+  `creditType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `creditEntry` int(10) unsigned NOT NULL DEFAULT '0',
+  `lastEncounterDungeon` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'If not 0, LfgDungeon.dbc entry for the instance it is last encounter in',
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `instance_encounters`
+--
+
+LOCK TABLES `instance_encounters` WRITE;
+/*!40000 ALTER TABLE `instance_encounters` DISABLE KEYS */;
+INSERT INTO `instance_encounters` VALUES
+(161,0,644,0),
+(162,0,643,0),
+(163,0,1763,0),
+(164,0,646,0),
+(165,0,645,0),
+(166,0,647,0),
+(167,0,639,6),
+(201,0,18371,0),
+(202,0,18373,149),
+(203,0,18341,0),
+(204,0,18343,0),
+(205,0,18344,148),
+(206,0,18472,0),
+(207,0,18473,150),
+(208,0,18731,0),
+(209,0,18667,0),
+(210,0,18732,0),
+(211,0,18708,151),
+(212,0,29309,0),
+(213,0,29308,0),
+(214,0,29310,0),
+(215,0,29311,218),
+(216,0,28684,0),
+(217,0,28921,0),
+(218,0,29120,204),
+(219,0,4887,0),
+(220,0,4831,0),
+(221,0,6243,0),
+(222,0,12902,0),
+(224,0,4830,0),
+(225,0,4832,0),
+(226,0,4829,10),
+(227,0,9018,30),
+(228,0,9025,0),
+(229,0,9319,0),
+(230,0,10096,0),
+(231,0,9024,0),
+(232,0,9017,0),
+(233,0,9041,0),
+(234,0,9056,0),
+(235,0,9016,0),
+(236,0,9033,0),
+(237,0,8983,0),
+(238,0,9537,0),
+(239,0,9502,0),
+(240,0,9543,0),
+(241,0,9499,0),
+(242,0,9156,0),
+(243,0,9035,0),
+(244,0,9938,0),
+(245,0,9019,276),
+(246,0,18371,0),
+(247,0,18373,178),
+(248,0,18341,0),
+(249,0,18343,0),
+(250,0,22930,0),
+(251,0,18344,179),
+(252,0,18472,0),
+(253,0,23035,0),
+(254,0,18473,180),
+(255,0,18731,0),
+(256,0,18667,0),
+(257,0,18732,0),
+(258,0,18708,181),
+(259,0,29309,0),
+(260,0,29308,0),
+(261,0,29310,0),
+(262,0,30258,0),
+(263,0,29311,219),
+(264,0,28684,0),
+(265,0,28921,0),
+(266,0,29120,241),
+(267,0,9196,0),
+(268,0,9236,0),
+(269,0,9237,0),
+(270,0,10596,0),
+(271,0,10584,0),
+(272,0,9736,0),
+(273,0,10268,0),
+(274,0,10220,0),
+(275,0,9568,32),
+(276,0,9816,0),
+(277,0,10264,0),
+(278,0,10429,0),
+(279,0,10430,0),
+(280,0,10363,44),
+(281,0,18096,170),
+(282,0,18096,183),
+(283,0,17862,0),
+(284,0,17862,0),
+(285,0,17848,0),
+(286,0,17848,0),
+(287,0,17879,0),
+(288,0,17879,0),
+(289,0,17880,0),
+(290,0,17880,0),
+(291,0,17881,171),
+(292,0,17881,182),
+(293,0,26529,0),
+(294,0,26530,0),
+(295,0,26532,0),
+(296,1,58630,209),
+(297,0,26529,0),
+(298,0,26530,0),
+(299,0,26532,0),
+(300,1,58630,210),
+(301,0,17941,0),
+(302,0,17991,0),
+(303,0,17942,140),
+(304,0,17941,0),
+(305,0,17991,0),
+(306,0,17942,184),
+(314,0,17797,0),
+(315,0,17797,0),
+(316,0,17796,0),
+(317,0,17796,0),
+(318,0,17798,147),
+(319,0,17798,185),
+(320,0,17770,0),
+(321,0,17770,0),
+(322,0,18105,0),
+(323,0,18105,0),
+(329,0,17826,0),
+(330,0,17826,0),
+(331,0,17882,146),
+(332,0,17882,186),
+(334,1,68572,0),
+(336,1,68572,0),
+(338,1,68574,0),
+(339,1,68574,0),
+(340,1,68663,245),
+(341,1,68663,249),
+(343,0,11490,0),
+(344,0,13280,0),
+(345,0,14327,0),
+(346,0,11492,34),
+(347,0,11488,0),
+(348,0,11487,0),
+(349,0,11496,0),
+(350,0,11489,0),
+(361,0,11486,36),
+(362,0,14326,0),
+(363,0,14322,0),
+(364,0,14321,0),
+(365,0,14323,0),
+(366,0,14325,0),
+(367,0,14324,0),
+(368,0,11501,38),
+(369,0,26630,0),
+(370,0,26630,0),
+(371,0,26631,0),
+(372,0,26631,0),
+(373,0,27483,0),
+(374,0,27483,0),
+(375,1,61863,214),
+(376,1,61863,215),
+(378,0,7079,0),
+(379,0,7361,0),
+(380,0,6235,0),
+(381,0,6229,0),
+(382,0,7800,14),
+(383,0,29304,0),
+(384,0,29304,0),
+(385,0,29573,0),
+(386,0,29573,0),
+(387,0,29305,0),
+(388,0,29305,0),
+(389,0,29932,0),
+(390,0,29306,216),
+(391,0,29306,217),
+(392,0,17306,0),
+(393,0,17306,0),
+(394,0,17308,0),
+(395,0,17308,0),
+(396,0,17537,136),
+(397,0,17537,188),
+(401,0,17381,0),
+(402,0,17381,0),
+(403,0,17380,0),
+(404,0,17380,0),
+(405,0,17377,137),
+(406,0,17377,187),
+(407,0,16807,0),
+(408,0,16807,0),
+(409,0,20923,0),
+(410,0,16809,0),
+(411,0,16809,0),
+(412,0,16808,138),
+(413,0,16808,189),
+(414,0,24723,0),
+(415,0,24723,0),
+(416,0,24744,0),
+(417,0,24744,0),
+(418,0,24560,0),
+(419,0,24560,0),
+(420,0,24664,198),
+(421,0,24664,201),
+(422,0,13282,0),
+(423,0,12258,26),
+(424,0,12236,272),
+(425,0,12225,0),
+(426,0,12203,0),
+(427,0,13601,0),
+(428,0,13596,0),
+(429,0,12201,273),
+(430,0,11517,0),
+(431,0,11520,4),
+(432,0,11518,0),
+(433,0,11519,0),
+(434,0,7355,0),
+(435,0,7357,0),
+(436,0,8567,0),
+(437,0,7358,20),
+(438,0,6168,0),
+(439,0,4424,0),
+(440,0,4428,0),
+(441,0,4420,0),
+(443,0,4421,16),
+(444,0,3983,0),
+(445,0,4543,18),
+(446,0,3974,0),
+(447,0,6487,165),
+(448,0,3975,163),
+(449,0,4542,0),
+(450,0,3977,164),
+(451,0,10506,0),
+(452,0,10503,0),
+(453,0,11622,0),
+(454,0,10433,0),
+(455,0,10432,0),
+(456,0,10508,0),
+(457,0,10505,0),
+(458,0,11261,0),
+(459,0,10901,0),
+(460,0,10507,0),
+(461,0,10504,0),
+(462,0,10502,0),
+(463,0,1853,2),
+(464,0,3914,0),
+(465,0,3886,0),
+(466,0,3887,0),
+(467,0,4278,0),
+(468,0,4279,0),
+(469,0,4274,0),
+(470,0,3927,0),
+(471,0,4275,8),
+(472,0,10516,0),
+(473,0,10558,0),
+(474,0,10808,0),
+(475,0,10997,0),
+(476,0,11032,0),
+(477,0,10811,0),
+(478,0,10813,40),
+(479,0,10436,0),
+(480,0,10437,0),
+(481,0,10438,0),
+(482,0,10435,0),
+(483,0,10439,0),
+(484,0,10440,274),
+(485,0,8580,0),
+(486,0,5721,0),
+(487,0,5720,0),
+(488,0,5710,0),
+(490,0,5719,0),
+(491,0,5722,0),
+(492,0,8443,0),
+(493,0,5709,28),
+(494,0,20870,0),
+(495,0,20870,0),
+(496,0,20885,0),
+(497,0,20885,0),
+(498,0,20886,0),
+(499,0,20886,0),
+(500,0,20912,174),
+(501,0,20912,190),
+(502,0,17976,0),
+(504,0,17976,0),
+(505,0,17975,0),
+(506,0,17975,0),
+(507,0,17978,0),
+(508,0,17978,0),
+(509,0,17980,0),
+(510,0,17980,0),
+(511,0,17977,173),
+(512,0,17977,191),
+(513,0,19219,0),
+(514,0,19219,0),
+(515,0,19221,0),
+(516,0,19221,0),
+(517,0,19220,172),
+(518,0,19220,192),
+(519,0,26796,0),
+(520,0,26731,0),
+(521,0,26731,0),
+(522,0,26763,0),
+(523,0,26763,0),
+(524,0,26794,0),
+(525,0,26794,0),
+(526,0,26723,225),
+(527,0,26723,226),
+(528,0,27654,0),
+(529,0,27654,0),
+(530,0,27447,0),
+(531,0,27447,0),
+(532,0,27655,0),
+(533,0,27655,0),
+(534,0,27656,206),
+(535,0,27656,211),
+(536,0,1696,0),
+(537,0,1666,0),
+(538,0,1717,0),
+(539,0,1716,0),
+(540,0,1663,12),
+(541,0,29315,0),
+(542,0,29315,0),
+(543,0,29316,0),
+(544,0,29316,0),
+(545,0,31134,220),
+(546,0,31134,221),
+(547,0,6910,0),
+(548,0,6906,0),
+(549,0,7228,0),
+(551,0,7206,0),
+(552,0,7291,0),
+(553,0,4854,0),
+(554,0,2748,22),
+(555,0,28586,0),
+(556,0,28586,0),
+(557,0,28587,0),
+(558,0,28587,0),
+(559,0,28546,0),
+(560,0,28546,0),
+(561,0,28923,207),
+(562,0,28923,212),
+(563,0,27977,0),
+(564,0,27977,0),
+(565,0,27975,0),
+(566,0,27975,0),
+(567,1,59046,0),
+(568,1,59046,0),
+(569,0,27978,208),
+(570,0,27978,213),
+(571,0,23953,0),
+(572,0,23953,0),
+(573,0,24201,0),
+(574,0,24201,0),
+(575,0,23954,202),
+(576,0,23954,242),
+(577,0,26668,0),
+(578,0,26668,0),
+(579,0,26687,0),
+(580,0,26687,0),
+(581,0,26693,0),
+(582,0,26693,0),
+(583,0,26861,203),
+(584,0,26861,205),
+(585,0,3671,0),
+(586,0,3669,0),
+(587,0,3653,0),
+(588,0,3670,0),
+(589,0,3674,0),
+(590,0,3673,0),
+(591,0,5775,0),
+(592,0,3654,1),
+(593,0,7795,0),
+(594,0,7273,0),
+(595,0,8127,0),
+(596,0,7272,0),
+(597,0,7271,0),
+(598,0,7796,0),
+(599,0,7275,0),
+(600,0,7267,24),
+(601,0,22887,0),
+(602,0,22898,0),
+(603,0,22841,0),
+(604,0,22871,0),
+(605,0,22948,0),
+(606,0,23420,0),
+(607,0,22947,0),
+(608,0,23426,0),
+(609,0,22917,196),
+(610,0,12435,0),
+(611,0,13020,0),
+(612,0,12017,0),
+(613,0,11983,0),
+(614,0,14601,0),
+(615,0,11981,0),
+(616,0,14020,0),
+(617,0,11583,50),
+(618,0,17767,0),
+(619,0,17808,0),
+(620,0,17888,0),
+(621,0,17842,0),
+(622,0,17968,195),
+(623,0,21216,0),
+(624,0,21217,0),
+(625,0,21215,0),
+(626,0,21214,0),
+(627,0,21213,0),
+(628,0,21212,194),
+(629,0,34797,0),
+(630,0,34797,0),
+(631,0,34797,0),
+(632,0,34797,0),
+(633,0,34780,0),
+(634,0,34780,0),
+(635,0,34780,0),
+(636,0,34780,0),
+(637,1,68184,0),
+(638,1,68184,0),
+(639,1,68184,0),
+(640,1,68184,0),
+(641,0,34496,0),
+(642,0,34496,0),
+(643,0,34496,0),
+(644,0,34496,0),
+(645,0,34564,246),
+(646,0,34564,248),
+(647,0,34564,247),
+(648,0,34564,250),
+(649,0,18831,0),
+(650,0,19044,177),
+(651,0,17257,176),
+(652,0,15550,0),
+(653,0,15687,0),
+(654,0,16457,0),
+(655,0,16812,0),
+(656,0,15691,0),
+(657,0,15688,0),
+(658,0,16524,0),
+(659,0,15689,0),
+(660,0,22520,0),
+(661,0,15690,175),
+(662,0,17225,0),
+(663,0,12118,0),
+(664,0,11982,0),
+(665,0,12259,0),
+(666,0,12057,0),
+(667,0,12264,0),
+(668,0,12056,0),
+(669,0,12098,0),
+(670,0,11988,0),
+(671,0,12018,0),
+(672,0,11502,48),
+(673,0,15956,0),
+(674,0,15956,0),
+(677,0,15953,0),
+(678,0,15953,0),
+(679,0,15952,0),
+(680,0,15952,0),
+(681,0,15954,0),
+(682,0,15954,0),
+(683,0,15936,0),
+(684,0,15936,0),
+(685,0,16011,0),
+(686,0,16011,0),
+(687,0,16061,0),
+(689,0,16061,0),
+(690,0,16060,0),
+(691,0,16060,0),
+(692,1,59450,0),
+(693,1,59450,0),
+(694,0,16028,0),
+(695,0,16028,0),
+(696,0,15931,0),
+(697,0,15931,0),
+(698,0,15932,0),
+(699,0,15932,0),
+(700,0,15928,0),
+(701,0,15928,0),
+(702,0,15989,0),
+(703,0,15989,0),
+(704,0,15990,159),
+(706,0,15990,227),
+(707,0,10184,46),
+(708,0,10184,257),
+(709,0,15263,0),
+(710,0,15544,0),
+(711,0,15516,0),
+(712,0,15510,0),
+(713,0,15299,0),
+(714,0,15509,0),
+(715,0,15275,0),
+(716,0,15517,0),
+(717,0,15727,161),
+(718,0,15348,0),
+(719,0,15341,0),
+(720,0,15340,0),
+(721,0,15370,0),
+(722,0,15369,0),
+(723,0,15339,160),
+(724,0,24892,0),
+(725,0,24882,0),
+(726,0,25038,0),
+(727,0,25165,0),
+(728,0,25840,0),
+(729,0,25315,199),
+(730,0,19514,0),
+(731,0,19516,0),
+(732,0,18805,0),
+(733,0,19622,193),
+(734,0,28859,223),
+(735,0,28859,237),
+(736,0,30452,0),
+(737,0,30452,0),
+(738,0,30451,0),
+(739,0,30451,0),
+(740,0,30449,0),
+(741,0,30449,0),
+(742,0,28860,224),
+(743,0,28860,238),
+(744,0,33113,0),
+(745,0,33118,0),
+(746,0,33186,0),
+(747,0,33293,0),
+(748,1,65195,0),
+(749,0,32930,0),
+(750,0,33515,0),
+(751,1,64899,0),
+(752,1,64985,0),
+(753,1,65074,0),
+(754,0,33432,0),
+(755,0,33271,0),
+(756,0,33288,0),
+(757,0,32871,243),
+(758,0,33113,0),
+(759,0,33118,0),
+(760,0,33186,0),
+(761,0,33293,0),
+(762,1,65195,0),
+(763,0,32930,0),
+(764,0,33515,0),
+(765,1,64899,0),
+(766,1,64985,0),
+(767,1,65074,0),
+(768,0,33432,0),
+(769,0,33271,0),
+(770,0,33288,0),
+(771,0,32871,244),
+(772,0,31125,0),
+(773,0,31125,0),
+(774,0,33993,0),
+(775,0,33993,0),
+(776,0,35013,0),
+(777,0,35013,0),
+(778,0,23574,0),
+(779,0,23576,0),
+(780,0,23578,0),
+(781,0,23577,0),
+(782,0,24239,0),
+(783,0,23863,197),
+(784,0,14507,0),
+(785,0,14517,0),
+(786,0,14510,0),
+(787,0,11382,0),
+(788,0,15083,0),
+(789,0,14509,0),
+(790,0,15114,0),
+(791,0,14515,0),
+(792,0,11380,0),
+(793,0,14834,42),
+(829,0,36497,0),
+(830,0,36497,0),
+(831,0,36502,251),
+(832,0,36502,252),
+(833,0,36494,0),
+(834,0,36494,0),
+(835,0,36476,0),
+(836,0,36476,0),
+(837,0,36658,253),
+(838,0,36658,254),
+(839,0,38113,0),
+(840,0,38113,0),
+(841,0,38112,0),
+(842,0,38112,0),
+(843,1,72830,255),
+(844,1,72830,256),
+(845,0,36612,0),
+(846,0,36855,0),
+(847,1,72959,0),
+(848,0,37813,0),
+(849,0,36626,0),
+(850,0,36627,0),
+(851,0,36678,0),
+(852,0,37970,0),
+(853,0,37955,0),
+(854,1,72706,0),
+(855,0,36853,0),
+(856,0,36597,279),
+(857,0,36612,0),
+(858,0,36855,0),
+(859,1,72959,0),
+(860,0,37813,0),
+(861,0,36626,0),
+(862,0,36627,0),
+(863,0,36678,0),
+(864,0,37970,0),
+(865,0,37955,0),
+(866,1,72706,0),
+(867,0,36853,0),
+(868,0,36597,280),
+(883,0,4422,0),
+(885,0,38433,239),
+(886,0,38433,240),
+(887,0,39863,293),
+(888,0,39863,294),
+(889,0,39751,0),
+(890,0,39751,0),
+(891,0,39747,0),
+(892,0,39747,0),
+(893,0,39746,0),
+(894,0,39746,0);
+/*!40000 ALTER TABLE `instance_encounters` ENABLE KEYS */;
+UNLOCK TABLES;
 
 --
 -- Table structure for table `instance_template`
@@ -2190,11 +3050,11 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `instance_template`;
 CREATE TABLE `instance_template` (
   `map` smallint(5) unsigned NOT NULL,
-  `parent` smallint(5) unsigned NOT NULL default '0',
-  `levelMin` tinyint(3) unsigned NOT NULL default '0',
-  `levelMax` tinyint(3) unsigned NOT NULL default '0',
-  `ScriptName` varchar(128) NOT NULL default '',
-  PRIMARY KEY  (`map`)
+  `parent` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `levelMin` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `levelMax` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `ScriptName` varchar(128) NOT NULL DEFAULT '',
+  PRIMARY KEY (`map`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2212,9 +3072,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_convert`;
 CREATE TABLE `item_convert` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Item Convert System';
 
 --
@@ -2232,10 +3092,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_enchantment_template`;
 CREATE TABLE `item_enchantment_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `ench` mediumint(8) unsigned NOT NULL default '0',
-  `chance` float unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`,`ench`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ench` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `chance` float unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`ench`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Item Random Enchantment System';
 
 --
@@ -2253,18 +3113,18 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_expire_convert`;
 CREATE TABLE `item_expire_convert` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Item Convert System';
 
 --
--- Dumping data for table `item_convert`
+-- Dumping data for table `item_expire_convert`
 --
 
-LOCK TABLES `item_convert` WRITE;
-/*!40000 ALTER TABLE `item_convert` DISABLE KEYS */;
-/*!40000 ALTER TABLE `item_convert` ENABLE KEYS */;
+LOCK TABLES `item_expire_convert` WRITE;
+/*!40000 ALTER TABLE `item_expire_convert` DISABLE KEYS */;
+/*!40000 ALTER TABLE `item_expire_convert` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
@@ -2273,14 +3133,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_loot_template`;
 CREATE TABLE `item_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -2299,8 +3159,8 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `item_required_target`;
 CREATE TABLE `item_required_target` (
   `entry` mediumint(8) unsigned NOT NULL,
-  `type` tinyint(3) unsigned NOT NULL default '0',
-  `targetEntry` mediumint(8) unsigned NOT NULL default '0',
+  `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `targetEntry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `entry_type_target` (`entry`,`type`,`targetEntry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
 
@@ -2319,145 +3179,145 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `item_template`;
 CREATE TABLE `item_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `class` tinyint(3) unsigned NOT NULL default '0',
-  `subclass` tinyint(3) unsigned NOT NULL default '0',
-  `unk0` int(11) NOT NULL default '-1',
-  `name` varchar(255) NOT NULL default '',
-  `displayid` mediumint(8) unsigned NOT NULL default '0',
-  `Quality` tinyint(3) unsigned NOT NULL default '0',
-  `Flags` int(10) unsigned NOT NULL default '0',
-  `Flags2` int(10) unsigned NOT NULL default '0',
-  `BuyCount` tinyint(3) unsigned NOT NULL default '1',
-  `BuyPrice` int(10) unsigned NOT NULL default '0',
-  `SellPrice` int(10) unsigned NOT NULL default '0',
-  `InventoryType` tinyint(3) unsigned NOT NULL default '0',
-  `AllowableClass` mediumint(9) NOT NULL default '-1',
-  `AllowableRace` mediumint(9) NOT NULL default '-1',
-  `ItemLevel` smallint(5) unsigned NOT NULL default '0',
-  `RequiredLevel` tinyint(3) unsigned NOT NULL default '0',
-  `RequiredSkill` smallint(5) unsigned NOT NULL default '0',
-  `RequiredSkillRank` smallint(5) unsigned NOT NULL default '0',
-  `requiredspell` mediumint(8) unsigned NOT NULL default '0',
-  `requiredhonorrank` mediumint(8) unsigned NOT NULL default '0',
-  `RequiredCityRank` mediumint(8) unsigned NOT NULL default '0',
-  `RequiredReputationFaction` smallint(5) unsigned NOT NULL default '0',
-  `RequiredReputationRank` smallint(5) unsigned NOT NULL default '0',
-  `maxcount` smallint(5) NOT NULL default '-1',
-  `stackable` smallint(5) NOT NULL default '1',
-  `ContainerSlots` tinyint(3) unsigned NOT NULL default '0',
-  `StatsCount` tinyint(3) unsigned NOT NULL default '0',
-  `stat_type1` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value1` smallint(6) NOT NULL default '0',
-  `stat_type2` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value2` smallint(6) NOT NULL default '0',
-  `stat_type3` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value3` smallint(6) NOT NULL default '0',
-  `stat_type4` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value4` smallint(6) NOT NULL default '0',
-  `stat_type5` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value5` smallint(6) NOT NULL default '0',
-  `stat_type6` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value6` smallint(6) NOT NULL default '0',
-  `stat_type7` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value7` smallint(6) NOT NULL default '0',
-  `stat_type8` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value8` smallint(6) NOT NULL default '0',
-  `stat_type9` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value9` smallint(6) NOT NULL default '0',
-  `stat_type10` tinyint(3) unsigned NOT NULL default '0',
-  `stat_value10` smallint(6) NOT NULL default '0',
-  `ScalingStatDistribution` smallint(6) NOT NULL default '0',
-  `ScalingStatValue` int(6) unsigned NOT NULL default '0',
-  `dmg_min1` float NOT NULL default '0',
-  `dmg_max1` float NOT NULL default '0',
-  `dmg_type1` tinyint(3) unsigned NOT NULL default '0',
-  `dmg_min2` float NOT NULL default '0',
-  `dmg_max2` float NOT NULL default '0',
-  `dmg_type2` tinyint(3) unsigned NOT NULL default '0',
-  `armor` smallint(5) unsigned NOT NULL default '0',
-  `holy_res` tinyint(3) unsigned NOT NULL default '0',
-  `fire_res` tinyint(3) unsigned NOT NULL default '0',
-  `nature_res` tinyint(3) unsigned NOT NULL default '0',
-  `frost_res` tinyint(3) unsigned NOT NULL default '0',
-  `shadow_res` tinyint(3) unsigned NOT NULL default '0',
-  `arcane_res` tinyint(3) unsigned NOT NULL default '0',
-  `delay` smallint(5) unsigned NOT NULL default '1000',
-  `ammo_type` tinyint(3) unsigned NOT NULL default '0',
-  `RangedModRange` float NOT NULL default '0',
-  `spellid_1` mediumint(8) unsigned NOT NULL default '0',
-  `spelltrigger_1` tinyint(3) unsigned NOT NULL default '0',
-  `spellcharges_1` smallint(5) NOT NULL default '0',
-  `spellppmRate_1` float NOT NULL default '0',
-  `spellcooldown_1` int(11) NOT NULL default '-1',
-  `spellcategory_1` smallint(5) unsigned NOT NULL default '0',
-  `spellcategorycooldown_1` int(11) NOT NULL default '-1',
-  `spellid_2` mediumint(8) unsigned NOT NULL default '0',
-  `spelltrigger_2` tinyint(3) unsigned NOT NULL default '0',
-  `spellcharges_2` smallint(5) NOT NULL default '0',
-  `spellppmRate_2` float NOT NULL default '0',
-  `spellcooldown_2` int(11) NOT NULL default '-1',
-  `spellcategory_2` smallint(5) unsigned NOT NULL default '0',
-  `spellcategorycooldown_2` int(11) NOT NULL default '-1',
-  `spellid_3` mediumint(8) unsigned NOT NULL default '0',
-  `spelltrigger_3` tinyint(3) unsigned NOT NULL default '0',
-  `spellcharges_3` smallint(5) NOT NULL default '0',
-  `spellppmRate_3` float NOT NULL default '0',
-  `spellcooldown_3` int(11) NOT NULL default '-1',
-  `spellcategory_3` smallint(5) unsigned NOT NULL default '0',
-  `spellcategorycooldown_3` int(11) NOT NULL default '-1',
-  `spellid_4` mediumint(8) unsigned NOT NULL default '0',
-  `spelltrigger_4` tinyint(3) unsigned NOT NULL default '0',
-  `spellcharges_4` smallint(5) NOT NULL default '0',
-  `spellppmRate_4` float NOT NULL default '0',
-  `spellcooldown_4` int(11) NOT NULL default '-1',
-  `spellcategory_4` smallint(5) unsigned NOT NULL default '0',
-  `spellcategorycooldown_4` int(11) NOT NULL default '-1',
-  `spellid_5` mediumint(8) unsigned NOT NULL default '0',
-  `spelltrigger_5` tinyint(3) unsigned NOT NULL default '0',
-  `spellcharges_5` smallint(5) NOT NULL default '0',
-  `spellppmRate_5` float NOT NULL default '0',
-  `spellcooldown_5` int(11) NOT NULL default '-1',
-  `spellcategory_5` smallint(5) unsigned NOT NULL default '0',
-  `spellcategorycooldown_5` int(11) NOT NULL default '-1',
-  `bonding` tinyint(3) unsigned NOT NULL default '0',
-  `description` varchar(255) NOT NULL default '',
-  `PageText` mediumint(8) unsigned NOT NULL default '0',
-  `LanguageID` tinyint(3) unsigned NOT NULL default '0',
-  `PageMaterial` tinyint(3) unsigned NOT NULL default '0',
-  `startquest` mediumint(8) unsigned NOT NULL default '0',
-  `lockid` mediumint(8) unsigned NOT NULL default '0',
-  `Material` tinyint(4) NOT NULL default '0',
-  `sheath` tinyint(3) unsigned NOT NULL default '0',
-  `RandomProperty` mediumint(8) unsigned NOT NULL default '0',
-  `RandomSuffix` mediumint(8) unsigned NOT NULL default '0',
-  `block` mediumint(8) unsigned NOT NULL default '0',
-  `itemset` mediumint(8) unsigned NOT NULL default '0',
-  `MaxDurability` smallint(5) unsigned NOT NULL default '0',
-  `area` mediumint(8) unsigned NOT NULL default '0',
-  `Map` smallint(6) NOT NULL default '0',
-  `BagFamily` mediumint(9) NOT NULL default '0',
-  `TotemCategory` mediumint(9) NOT NULL default '0',
-  `socketColor_1` tinyint(4) NOT NULL default '0',
-  `socketContent_1` mediumint(9) NOT NULL default '0',
-  `socketColor_2` tinyint(4) NOT NULL default '0',
-  `socketContent_2` mediumint(9) NOT NULL default '0',
-  `socketColor_3` tinyint(4) NOT NULL default '0',
-  `socketContent_3` mediumint(9) NOT NULL default '0',
-  `socketBonus` mediumint(9) NOT NULL default '0',
-  `GemProperties` mediumint(9) NOT NULL default '0',
-  `RequiredDisenchantSkill` smallint(6) NOT NULL default '-1',
-  `ArmorDamageModifier` float NOT NULL default '0',
-  `Duration` int(11) UNSIGNED DEFAULT '0' NOT NULL COMMENT 'Duration in seconds.',
-  `ItemLimitCategory` smallint(6) NOT NULL default '0',
-  `HolidayId` int(11) UNSIGNED DEFAULT '0' NOT NULL,
-  `ScriptName` varchar(64) NOT NULL default '',
-  `DisenchantID` mediumint(8) unsigned NOT NULL default '0',
-  `FoodType` tinyint(3) unsigned NOT NULL default '0',
-  `minMoneyLoot` int(10) unsigned NOT NULL default '0',
-  `maxMoneyLoot` int(10) unsigned NOT NULL default '0',
-  `ExtraFlags` tinyint(1) UNSIGNED NOT NULL default '0',
-  PRIMARY KEY  (`entry`),
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `subclass` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `unk0` int(11) NOT NULL DEFAULT '-1',
+  `name` varchar(255) NOT NULL DEFAULT '',
+  `displayid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `Quality` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `Flags` int(10) unsigned NOT NULL DEFAULT '0',
+  `Flags2` int(10) unsigned NOT NULL DEFAULT '0',
+  `BuyCount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `BuyPrice` int(10) unsigned NOT NULL DEFAULT '0',
+  `SellPrice` int(10) unsigned NOT NULL DEFAULT '0',
+  `InventoryType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `AllowableClass` mediumint(9) NOT NULL DEFAULT '-1',
+  `AllowableRace` mediumint(9) NOT NULL DEFAULT '-1',
+  `ItemLevel` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredLevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `RequiredSkill` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredSkillRank` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `requiredspell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `requiredhonorrank` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RequiredCityRank` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RequiredReputationFaction` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredReputationRank` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `maxcount` smallint(5) NOT NULL DEFAULT '-1',
+  `stackable` smallint(5) NOT NULL DEFAULT '1',
+  `ContainerSlots` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `StatsCount` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_type1` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value1` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type2` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value2` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type3` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value3` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type4` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value4` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type5` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value5` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type6` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value6` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type7` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value7` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type8` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value8` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type9` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value9` smallint(6) NOT NULL DEFAULT '0',
+  `stat_type10` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `stat_value10` smallint(6) NOT NULL DEFAULT '0',
+  `ScalingStatDistribution` smallint(6) NOT NULL DEFAULT '0',
+  `ScalingStatValue` int(6) unsigned NOT NULL DEFAULT '0',
+  `dmg_min1` float NOT NULL DEFAULT '0',
+  `dmg_max1` float NOT NULL DEFAULT '0',
+  `dmg_type1` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `dmg_min2` float NOT NULL DEFAULT '0',
+  `dmg_max2` float NOT NULL DEFAULT '0',
+  `dmg_type2` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `armor` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `holy_res` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `fire_res` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `nature_res` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `frost_res` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `shadow_res` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `arcane_res` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `delay` smallint(5) unsigned NOT NULL DEFAULT '1000',
+  `ammo_type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `RangedModRange` float NOT NULL DEFAULT '0',
+  `spellid_1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spelltrigger_1` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `spellcharges_1` smallint(5) NOT NULL DEFAULT '0',
+  `spellppmRate_1` float NOT NULL DEFAULT '0',
+  `spellcooldown_1` int(11) NOT NULL DEFAULT '-1',
+  `spellcategory_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `spellcategorycooldown_1` int(11) NOT NULL DEFAULT '-1',
+  `spellid_2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spelltrigger_2` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `spellcharges_2` smallint(5) NOT NULL DEFAULT '0',
+  `spellppmRate_2` float NOT NULL DEFAULT '0',
+  `spellcooldown_2` int(11) NOT NULL DEFAULT '-1',
+  `spellcategory_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `spellcategorycooldown_2` int(11) NOT NULL DEFAULT '-1',
+  `spellid_3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spelltrigger_3` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `spellcharges_3` smallint(5) NOT NULL DEFAULT '0',
+  `spellppmRate_3` float NOT NULL DEFAULT '0',
+  `spellcooldown_3` int(11) NOT NULL DEFAULT '-1',
+  `spellcategory_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `spellcategorycooldown_3` int(11) NOT NULL DEFAULT '-1',
+  `spellid_4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spelltrigger_4` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `spellcharges_4` smallint(5) NOT NULL DEFAULT '0',
+  `spellppmRate_4` float NOT NULL DEFAULT '0',
+  `spellcooldown_4` int(11) NOT NULL DEFAULT '-1',
+  `spellcategory_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `spellcategorycooldown_4` int(11) NOT NULL DEFAULT '-1',
+  `spellid_5` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spelltrigger_5` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `spellcharges_5` smallint(5) NOT NULL DEFAULT '0',
+  `spellppmRate_5` float NOT NULL DEFAULT '0',
+  `spellcooldown_5` int(11) NOT NULL DEFAULT '-1',
+  `spellcategory_5` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `spellcategorycooldown_5` int(11) NOT NULL DEFAULT '-1',
+  `bonding` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `description` varchar(255) NOT NULL DEFAULT '',
+  `PageText` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `LanguageID` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `PageMaterial` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `startquest` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `lockid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `Material` tinyint(4) NOT NULL DEFAULT '0',
+  `sheath` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `RandomProperty` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RandomSuffix` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `block` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `itemset` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `MaxDurability` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `area` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `Map` smallint(6) NOT NULL DEFAULT '0',
+  `BagFamily` mediumint(9) NOT NULL DEFAULT '0',
+  `TotemCategory` mediumint(9) NOT NULL DEFAULT '0',
+  `socketColor_1` tinyint(4) NOT NULL DEFAULT '0',
+  `socketContent_1` mediumint(9) NOT NULL DEFAULT '0',
+  `socketColor_2` tinyint(4) NOT NULL DEFAULT '0',
+  `socketContent_2` mediumint(9) NOT NULL DEFAULT '0',
+  `socketColor_3` tinyint(4) NOT NULL DEFAULT '0',
+  `socketContent_3` mediumint(9) NOT NULL DEFAULT '0',
+  `socketBonus` mediumint(9) NOT NULL DEFAULT '0',
+  `GemProperties` mediumint(9) NOT NULL DEFAULT '0',
+  `RequiredDisenchantSkill` smallint(6) NOT NULL DEFAULT '-1',
+  `ArmorDamageModifier` float NOT NULL DEFAULT '0',
+  `Duration` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Duration in seconds.',
+  `ItemLimitCategory` smallint(6) NOT NULL DEFAULT '0',
+  `HolidayId` int(11) unsigned NOT NULL DEFAULT '0',
+  `ScriptName` varchar(64) NOT NULL DEFAULT '',
+  `DisenchantID` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `FoodType` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `minMoneyLoot` int(10) unsigned NOT NULL DEFAULT '0',
+  `maxMoneyLoot` int(10) unsigned NOT NULL DEFAULT '0',
+  `ExtraFlags` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`),
   KEY `items_index` (`class`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Item System';
 
@@ -2564,25 +3424,25 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_achievement_reward`;
 CREATE TABLE `locales_achievement_reward` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `gender` tinyint(3) default '2',
-  `subject_loc1` varchar(100) NOT NULL default '',
-  `subject_loc2` varchar(100) NOT NULL default '',
-  `subject_loc3` varchar(100) NOT NULL default '',
-  `subject_loc4` varchar(100) NOT NULL default '',
-  `subject_loc5` varchar(100) NOT NULL default '',
-  `subject_loc6` varchar(100) NOT NULL default '',
-  `subject_loc7` varchar(100) NOT NULL default '',
-  `subject_loc8` varchar(100) NOT NULL default '',
-  `text_loc1` text default NULL,
-  `text_loc2` text default NULL,
-  `text_loc3` text default NULL,
-  `text_loc4` text default NULL,
-  `text_loc5` text default NULL,
-  `text_loc6` text default NULL,
-  `text_loc7` text default NULL,
-  `text_loc8` text default NULL,
-  PRIMARY KEY  (`entry`,`gender`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `gender` tinyint(3) NOT NULL DEFAULT '2',
+  `subject_loc1` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc2` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc3` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc4` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc5` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc6` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc7` varchar(100) NOT NULL DEFAULT '',
+  `subject_loc8` varchar(100) NOT NULL DEFAULT '',
+  `text_loc1` text,
+  `text_loc2` text,
+  `text_loc3` text,
+  `text_loc4` text,
+  `text_loc5` text,
+  `text_loc6` text,
+  `text_loc7` text,
+  `text_loc8` text,
+  PRIMARY KEY (`entry`,`gender`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2600,24 +3460,24 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_creature`;
 CREATE TABLE `locales_creature` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `name_loc1` varchar(100) NOT NULL default '',
-  `name_loc2` varchar(100) NOT NULL default '',
-  `name_loc3` varchar(100) NOT NULL default '',
-  `name_loc4` varchar(100) NOT NULL default '',
-  `name_loc5` varchar(100) NOT NULL default '',
-  `name_loc6` varchar(100) NOT NULL default '',
-  `name_loc7` varchar(100) NOT NULL default '',
-  `name_loc8` varchar(100) NOT NULL default '',
-  `subname_loc1` varchar(100) default NULL,
-  `subname_loc2` varchar(100) default NULL,
-  `subname_loc3` varchar(100) default NULL,
-  `subname_loc4` varchar(100) default NULL,
-  `subname_loc5` varchar(100) default NULL,
-  `subname_loc6` varchar(100) default NULL,
-  `subname_loc7` varchar(100) default NULL,
-  `subname_loc8` varchar(100) default NULL,
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `name_loc1` varchar(100) NOT NULL DEFAULT '',
+  `name_loc2` varchar(100) NOT NULL DEFAULT '',
+  `name_loc3` varchar(100) NOT NULL DEFAULT '',
+  `name_loc4` varchar(100) NOT NULL DEFAULT '',
+  `name_loc5` varchar(100) NOT NULL DEFAULT '',
+  `name_loc6` varchar(100) NOT NULL DEFAULT '',
+  `name_loc7` varchar(100) NOT NULL DEFAULT '',
+  `name_loc8` varchar(100) NOT NULL DEFAULT '',
+  `subname_loc1` varchar(100) DEFAULT NULL,
+  `subname_loc2` varchar(100) DEFAULT NULL,
+  `subname_loc3` varchar(100) DEFAULT NULL,
+  `subname_loc4` varchar(100) DEFAULT NULL,
+  `subname_loc5` varchar(100) DEFAULT NULL,
+  `subname_loc6` varchar(100) DEFAULT NULL,
+  `subname_loc7` varchar(100) DEFAULT NULL,
+  `subname_loc8` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2635,24 +3495,24 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_gameobject`;
 CREATE TABLE `locales_gameobject` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `name_loc1` varchar(100) NOT NULL default '',
-  `name_loc2` varchar(100) NOT NULL default '',
-  `name_loc3` varchar(100) NOT NULL default '',
-  `name_loc4` varchar(100) NOT NULL default '',
-  `name_loc5` varchar(100) NOT NULL default '',
-  `name_loc6` varchar(100) NOT NULL default '',
-  `name_loc7` varchar(100) NOT NULL default '',
-  `name_loc8` varchar(100) NOT NULL default '',
-  `castbarcaption_loc1` varchar(100) NOT NULL default '',
-  `castbarcaption_loc2` varchar(100) NOT NULL default '',
-  `castbarcaption_loc3` varchar(100) NOT NULL default '',
-  `castbarcaption_loc4` varchar(100) NOT NULL default '',
-  `castbarcaption_loc5` varchar(100) NOT NULL default '',
-  `castbarcaption_loc6` varchar(100) NOT NULL default '',
-  `castbarcaption_loc7` varchar(100) NOT NULL default '',
-  `castbarcaption_loc8` varchar(100) NOT NULL default '',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `name_loc1` varchar(100) NOT NULL DEFAULT '',
+  `name_loc2` varchar(100) NOT NULL DEFAULT '',
+  `name_loc3` varchar(100) NOT NULL DEFAULT '',
+  `name_loc4` varchar(100) NOT NULL DEFAULT '',
+  `name_loc5` varchar(100) NOT NULL DEFAULT '',
+  `name_loc6` varchar(100) NOT NULL DEFAULT '',
+  `name_loc7` varchar(100) NOT NULL DEFAULT '',
+  `name_loc8` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc1` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc2` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc3` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc4` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc5` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc6` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc7` varchar(100) NOT NULL DEFAULT '',
+  `castbarcaption_loc8` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2670,8 +3530,8 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_gossip_menu_option`;
 CREATE TABLE `locales_gossip_menu_option` (
-  `menu_id` smallint(6) unsigned NOT NULL default '0',
-  `id` smallint(6) unsigned NOT NULL default '0',
+  `menu_id` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `id` smallint(6) unsigned NOT NULL DEFAULT '0',
   `option_text_loc1` text,
   `option_text_loc2` text,
   `option_text_loc3` text,
@@ -2688,7 +3548,7 @@ CREATE TABLE `locales_gossip_menu_option` (
   `box_text_loc6` text,
   `box_text_loc7` text,
   `box_text_loc8` text,
-  PRIMARY KEY  (`menu_id`, `id`)
+  PRIMARY KEY (`menu_id`,`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2706,24 +3566,24 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_item`;
 CREATE TABLE `locales_item` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `name_loc1` varchar(100) NOT NULL default '',
-  `name_loc2` varchar(100) NOT NULL default '',
-  `name_loc3` varchar(100) NOT NULL default '',
-  `name_loc4` varchar(100) NOT NULL default '',
-  `name_loc5` varchar(100) NOT NULL default '',
-  `name_loc6` varchar(100) NOT NULL default '',
-  `name_loc7` varchar(100) NOT NULL default '',
-  `name_loc8` varchar(100) NOT NULL default '',
-  `description_loc1` varchar(255) default NULL,
-  `description_loc2` varchar(255) default NULL,
-  `description_loc3` varchar(255) default NULL,
-  `description_loc4` varchar(255) default NULL,
-  `description_loc5` varchar(255) default NULL,
-  `description_loc6` varchar(255) default NULL,
-  `description_loc7` varchar(255) default NULL,
-  `description_loc8` varchar(255) default NULL,
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `name_loc1` varchar(100) NOT NULL DEFAULT '',
+  `name_loc2` varchar(100) NOT NULL DEFAULT '',
+  `name_loc3` varchar(100) NOT NULL DEFAULT '',
+  `name_loc4` varchar(100) NOT NULL DEFAULT '',
+  `name_loc5` varchar(100) NOT NULL DEFAULT '',
+  `name_loc6` varchar(100) NOT NULL DEFAULT '',
+  `name_loc7` varchar(100) NOT NULL DEFAULT '',
+  `name_loc8` varchar(100) NOT NULL DEFAULT '',
+  `description_loc1` varchar(255) DEFAULT NULL,
+  `description_loc2` varchar(255) DEFAULT NULL,
+  `description_loc3` varchar(255) DEFAULT NULL,
+  `description_loc4` varchar(255) DEFAULT NULL,
+  `description_loc5` varchar(255) DEFAULT NULL,
+  `description_loc6` varchar(255) DEFAULT NULL,
+  `description_loc7` varchar(255) DEFAULT NULL,
+  `description_loc8` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2741,7 +3601,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_npc_text`;
 CREATE TABLE `locales_npc_text` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `Text0_0_loc1` longtext,
   `Text0_0_loc2` longtext,
   `Text0_0_loc3` longtext,
@@ -2870,7 +3730,7 @@ CREATE TABLE `locales_npc_text` (
   `Text7_1_loc6` longtext,
   `Text7_1_loc7` longtext,
   `Text7_1_loc8` longtext,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2888,7 +3748,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_page_text`;
 CREATE TABLE `locales_page_text` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `Text_loc1` longtext,
   `Text_loc2` longtext,
   `Text_loc3` longtext,
@@ -2897,7 +3757,7 @@ CREATE TABLE `locales_page_text` (
   `Text_loc6` longtext,
   `Text_loc7` longtext,
   `Text_loc8` longtext,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2915,7 +3775,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_points_of_interest`;
 CREATE TABLE `locales_points_of_interest` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_name_loc1` text,
   `icon_name_loc2` text,
   `icon_name_loc3` text,
@@ -2924,7 +3784,7 @@ CREATE TABLE `locales_points_of_interest` (
   `icon_name_loc6` text,
   `icon_name_loc7` text,
   `icon_name_loc8` text,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -2942,7 +3802,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `locales_quest`;
 CREATE TABLE `locales_quest` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `Title_loc1` text,
   `Title_loc2` text,
   `Title_loc3` text,
@@ -3031,7 +3891,7 @@ CREATE TABLE `locales_quest` (
   `ObjectiveText4_loc6` text,
   `ObjectiveText4_loc7` text,
   `ObjectiveText4_loc8` text,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -3049,11 +3909,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `mail_level_reward`;
 CREATE TABLE `mail_level_reward` (
-  `level` mediumint(8) unsigned NOT NULL default '0',
-  `raceMask` mediumint(8) unsigned NOT NULL default '0',
-  `mailTemplateId` mediumint(8) unsigned NOT NULL default '0',
-  `senderEntry`    mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`level`,`raceMask`)
+  `level` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `raceMask` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `mailTemplateId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `senderEntry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`level`,`raceMask`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Mail System';
 
 --
@@ -3071,14 +3931,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `mail_loot_template`;
 CREATE TABLE `mail_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -3096,7 +3956,7 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `mangos_string`;
 CREATE TABLE `mangos_string` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `content_default` text NOT NULL,
   `content_loc1` text,
   `content_loc2` text,
@@ -3106,7 +3966,7 @@ CREATE TABLE `mangos_string` (
   `content_loc6` text,
   `content_loc7` text,
   `content_loc8` text,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -3177,8 +4037,8 @@ INSERT INTO `mangos_string` VALUES
 (59,'Using creature EventAI: %s',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (61,'Username: ',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (62,'Password: ',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(63,"Accepts whispers", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-(64,"Doesn't accept whispers", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(63,'Accepts whispers',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(64,'Doesn\'t accept whispers',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (65,'Using script library: <Unknown Script Library>',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (66,'Using script library: <No Script Library Loaded>',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (100,'Global notify: ',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
@@ -3390,7 +4250,7 @@ INSERT INTO `mangos_string` VALUES
 (333,'GM mode is OFF',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (334,'GM Chat Badge is ON',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (335,'GM Chat Badge is OFF',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(336,'You repair all %s''s items.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(336,'You repair all %s\'s items.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (337,'All your items repaired by %s.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (338,'You set waterwalk mode %s for %s.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (339,'Your waterwalk mode %s by %s.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
@@ -3431,9 +4291,9 @@ INSERT INTO `mangos_string` VALUES
 (374,'Tickets count: %i\n',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (375,'Player %s not have tickets.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (376,'%u - |cffffffff|Hpool:%u|h[%s]|h|r AutoSpawn: %u MaxLimit: %u Creatures: %u GameObjecs: %u Pools %u',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(377,"No pools found for map '%s' (Id:%u)",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(378,"You can't use this command at non-instanceable map '%s' (Id:%u). Use .lookup pool command instead.",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(379,"You can't use this command without args at non-instanceable map '%s' (Id:%u).",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(377,'No pools found for map \'%s\' (Id:%u)',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(378,'You can\'t use this command at non-instanceable map \'%s\' (Id:%u). Use .lookup pool command instead.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(379,'You can\'t use this command without args at non-instanceable map \'%s\' (Id:%u).',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (380,'%d%s - |cffffffff|Hcreature:%d|h[%s X:%f Y:%f Z:%f MapId:%d]|h|r Chance:%f %s',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (381,'%d%s - [%s] X:%f Y:%f Z:%f MapId:%d Chance:%f %s',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (382,'%d%s - |cffffffff|Hcreature:%d|h[%s X:%f Y:%f Z:%f MapId:%d]|h|r %s',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
@@ -3756,7 +4616,7 @@ INSERT INTO `mangos_string` VALUES
 (759,'%s was destroyed by the %s!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (760,'The %s is under attack! If left unchecked, the %s will destroy it!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (761,'The %s was taken by the %s!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(762,'The %s was taken by the %s!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL), -- WTF? why 3 same strings?
+(762,'The %s was taken by the %s!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (763,'The %s was taken by the %s!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (764,'The %s is under attack! If left unchecked, the %s will capture it!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (765,'The %s has taken the %s! Its supplies will now be used for reinforcements!',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
@@ -3861,8 +4721,8 @@ INSERT INTO `mangos_string` VALUES
 (1127,'Talents of %s\'s pet reset.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1128,'%d - |cffffffff|Htaxinode:%u|h[%s %s]|h|r (Map:%u X:%f Y:%f Z:%f)',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1129,'%d - %s %s (Map:%u X:%f Y:%f Z:%f)',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(1130,'event started %u "%s"',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
-(1131,'event stopped %u "%s"',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(1130,'event started %u \"%s\"',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
+(1131,'event stopped %u \"%s\"',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1132,'   Follow player %s (lowguid %u)',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1133,'   Follow creature %s (lowguid %u)',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1134,'   Follow <NULL>',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
@@ -3980,7 +4840,6 @@ INSERT INTO `mangos_string` VALUES
 (1634,'|cffffff00Halaa is defenseless!|r',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1635,'|cffffff00The Horde has collected 200 silithyst!|r',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL),
 (1636,'|cffffff00The Alliance has collected 200 silithyst!|r',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
-
 /*!40000 ALTER TABLE `mangos_string` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -3990,14 +4849,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `milling_loot_template`;
 CREATE TABLE `milling_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -4015,9 +4874,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_gossip`;
 CREATE TABLE `npc_gossip` (
-  `npc_guid` int(10) unsigned NOT NULL default '0',
-  `textid` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`npc_guid`)
+  `npc_guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `textid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`npc_guid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -4035,14 +4894,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_spellclick_spells`;
 CREATE TABLE `npc_spellclick_spells` (
-    `npc_entry`   int unsigned NOT NULL COMMENT 'reference to creature_template',
-    `spell_id`    int unsigned NOT NULL COMMENT 'spell which should be casted ',
-    `quest_start`        mediumint(8) unsigned NOT NULL COMMENT 'reference to quest_template',
-    `quest_start_active` tinyint(1) unsigned NOT NULL default '0',
-    `quest_end`          mediumint(8) unsigned NOT NULL default '0',
-    `cast_flags`         tinyint unsigned NOT NULL COMMENT 'first bit defines caster: 1=player, 0=creature; second bit defines target, same mapping as caster bit',
-    `condition_id`       mediumint(8) unsigned NOT NULL default '0'
-) ENGINE = MYISAM DEFAULT CHARSET=utf8;
+  `npc_entry` int(10) unsigned NOT NULL COMMENT 'reference to creature_template',
+  `spell_id` int(10) unsigned NOT NULL COMMENT 'spell which should be casted ',
+  `quest_start` mediumint(8) unsigned NOT NULL COMMENT 'reference to quest_template',
+  `quest_start_active` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `quest_end` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `cast_flags` tinyint(3) unsigned NOT NULL COMMENT 'first bit defines caster: 1=player, 0=creature; second bit defines target, same mapping as caster bit',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0'
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `npc_spellclick_spells`
@@ -4059,88 +4918,88 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_text`;
 CREATE TABLE `npc_text` (
-  `ID` mediumint(8) unsigned NOT NULL default '0',
+  `ID` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `text0_0` longtext,
   `text0_1` longtext,
-  `lang0` tinyint(3) unsigned NOT NULL default '0',
-  `prob0` float NOT NULL default '0',
-  `em0_0` smallint(5) unsigned NOT NULL default '0',
-  `em0_1` smallint(5) unsigned NOT NULL default '0',
-  `em0_2` smallint(5) unsigned NOT NULL default '0',
-  `em0_3` smallint(5) unsigned NOT NULL default '0',
-  `em0_4` smallint(5) unsigned NOT NULL default '0',
-  `em0_5` smallint(5) unsigned NOT NULL default '0',
+  `lang0` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob0` float NOT NULL DEFAULT '0',
+  `em0_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em0_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em0_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em0_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em0_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em0_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text1_0` longtext,
   `text1_1` longtext,
-  `lang1` tinyint(3) unsigned NOT NULL default '0',
-  `prob1` float NOT NULL default '0',
-  `em1_0` smallint(5) unsigned NOT NULL default '0',
-  `em1_1` smallint(5) unsigned NOT NULL default '0',
-  `em1_2` smallint(5) unsigned NOT NULL default '0',
-  `em1_3` smallint(5) unsigned NOT NULL default '0',
-  `em1_4` smallint(5) unsigned NOT NULL default '0',
-  `em1_5` smallint(5) unsigned NOT NULL default '0',
+  `lang1` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob1` float NOT NULL DEFAULT '0',
+  `em1_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em1_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em1_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em1_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em1_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em1_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text2_0` longtext,
   `text2_1` longtext,
-  `lang2` tinyint(3) unsigned NOT NULL default '0',
-  `prob2` float NOT NULL default '0',
-  `em2_0` smallint(5) unsigned NOT NULL default '0',
-  `em2_1` smallint(5) unsigned NOT NULL default '0',
-  `em2_2` smallint(5) unsigned NOT NULL default '0',
-  `em2_3` smallint(5) unsigned NOT NULL default '0',
-  `em2_4` smallint(5) unsigned NOT NULL default '0',
-  `em2_5` smallint(5) unsigned NOT NULL default '0',
+  `lang2` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob2` float NOT NULL DEFAULT '0',
+  `em2_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em2_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em2_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em2_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em2_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em2_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text3_0` longtext,
   `text3_1` longtext,
-  `lang3` tinyint(3) unsigned NOT NULL default '0',
-  `prob3` float NOT NULL default '0',
-  `em3_0` smallint(5) unsigned NOT NULL default '0',
-  `em3_1` smallint(5) unsigned NOT NULL default '0',
-  `em3_2` smallint(5) unsigned NOT NULL default '0',
-  `em3_3` smallint(5) unsigned NOT NULL default '0',
-  `em3_4` smallint(5) unsigned NOT NULL default '0',
-  `em3_5` smallint(5) unsigned NOT NULL default '0',
+  `lang3` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob3` float NOT NULL DEFAULT '0',
+  `em3_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em3_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em3_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em3_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em3_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em3_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text4_0` longtext,
   `text4_1` longtext,
-  `lang4` tinyint(3) unsigned NOT NULL default '0',
-  `prob4` float NOT NULL default '0',
-  `em4_0` smallint(5) unsigned NOT NULL default '0',
-  `em4_1` smallint(5) unsigned NOT NULL default '0',
-  `em4_2` smallint(5) unsigned NOT NULL default '0',
-  `em4_3` smallint(5) unsigned NOT NULL default '0',
-  `em4_4` smallint(5) unsigned NOT NULL default '0',
-  `em4_5` smallint(5) unsigned NOT NULL default '0',
+  `lang4` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob4` float NOT NULL DEFAULT '0',
+  `em4_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em4_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em4_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em4_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em4_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em4_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text5_0` longtext,
   `text5_1` longtext,
-  `lang5` tinyint(3) unsigned NOT NULL default '0',
-  `prob5` float NOT NULL default '0',
-  `em5_0` smallint(5) unsigned NOT NULL default '0',
-  `em5_1` smallint(5) unsigned NOT NULL default '0',
-  `em5_2` smallint(5) unsigned NOT NULL default '0',
-  `em5_3` smallint(5) unsigned NOT NULL default '0',
-  `em5_4` smallint(5) unsigned NOT NULL default '0',
-  `em5_5` smallint(5) unsigned NOT NULL default '0',
+  `lang5` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob5` float NOT NULL DEFAULT '0',
+  `em5_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em5_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em5_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em5_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em5_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em5_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text6_0` longtext,
   `text6_1` longtext,
-  `lang6` tinyint(3) unsigned NOT NULL default '0',
-  `prob6` float NOT NULL default '0',
-  `em6_0` smallint(5) unsigned NOT NULL default '0',
-  `em6_1` smallint(5) unsigned NOT NULL default '0',
-  `em6_2` smallint(5) unsigned NOT NULL default '0',
-  `em6_3` smallint(5) unsigned NOT NULL default '0',
-  `em6_4` smallint(5) unsigned NOT NULL default '0',
-  `em6_5` smallint(5) unsigned NOT NULL default '0',
+  `lang6` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob6` float NOT NULL DEFAULT '0',
+  `em6_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em6_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em6_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em6_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em6_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em6_5` smallint(5) unsigned NOT NULL DEFAULT '0',
   `text7_0` longtext,
   `text7_1` longtext,
-  `lang7` tinyint(3) unsigned NOT NULL default '0',
-  `prob7` float NOT NULL default '0',
-  `em7_0` smallint(5) unsigned NOT NULL default '0',
-  `em7_1` smallint(5) unsigned NOT NULL default '0',
-  `em7_2` smallint(5) unsigned NOT NULL default '0',
-  `em7_3` smallint(5) unsigned NOT NULL default '0',
-  `em7_4` smallint(5) unsigned NOT NULL default '0',
-  `em7_5` smallint(5) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`ID`)
+  `lang7` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prob7` float NOT NULL DEFAULT '0',
+  `em7_0` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em7_1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em7_2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em7_3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em7_4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `em7_5` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`ID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -4158,12 +5017,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_trainer`;
 CREATE TABLE `npc_trainer` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `spell` mediumint(8) unsigned NOT NULL default '0',
-  `spellcost` int(10) unsigned NOT NULL default '0',
-  `reqskill` smallint(5) unsigned NOT NULL default '0',
-  `reqskillvalue` smallint(5) unsigned NOT NULL default '0',
-  `reqlevel` tinyint(3) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spellcost` int(10) unsigned NOT NULL DEFAULT '0',
+  `reqskill` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `reqskillvalue` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `reqlevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `entry_spell` (`entry`,`spell`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
@@ -4182,12 +5041,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_trainer_template`;
 CREATE TABLE `npc_trainer_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `spell` mediumint(8) unsigned NOT NULL default '0',
-  `spellcost` int(10) unsigned NOT NULL default '0',
-  `reqskill` smallint(5) unsigned NOT NULL default '0',
-  `reqskillvalue` smallint(5) unsigned NOT NULL default '0',
-  `reqlevel` tinyint(3) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `spellcost` int(10) unsigned NOT NULL DEFAULT '0',
+  `reqskill` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `reqskillvalue` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `reqlevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `entry_spell` (`entry`,`spell`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
@@ -4206,13 +5065,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_vendor`;
 CREATE TABLE `npc_vendor` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `maxcount` tinyint(3) unsigned NOT NULL default '0',
-  `incrtime` int(10) unsigned NOT NULL default '0',
-  `ExtendedCost` mediumint(8) unsigned NOT NULL default '0',
-  `condition_id` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`,`item`,`ExtendedCost`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `incrtime` int(10) unsigned NOT NULL DEFAULT '0',
+  `ExtendedCost` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`,`ExtendedCost`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Npc System';
 
 --
@@ -4230,13 +5089,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `npc_vendor_template`;
 CREATE TABLE `npc_vendor_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `maxcount` tinyint(3) unsigned NOT NULL default '0',
-  `incrtime` int(10) unsigned NOT NULL default '0',
-  `ExtendedCost` mediumint(8) unsigned NOT NULL default '0',
-  `condition_id` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`,`item`,`ExtendedCost`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `incrtime` int(10) unsigned NOT NULL DEFAULT '0',
+  `ExtendedCost` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`,`ExtendedCost`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Npc System';
 
 --
@@ -4254,10 +5113,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `page_text`;
 CREATE TABLE `page_text` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `text` longtext NOT NULL,
-  `next_page` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
+  `next_page` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Item System';
 
 --
@@ -4279,13 +5138,13 @@ CREATE TABLE `pet_levelstats` (
   `level` tinyint(3) unsigned NOT NULL,
   `hp` smallint(5) unsigned NOT NULL,
   `mana` smallint(5) unsigned NOT NULL,
-  `armor` int(10) unsigned NOT NULL default '0',
+  `armor` int(10) unsigned NOT NULL DEFAULT '0',
   `str` smallint(5) unsigned NOT NULL,
   `agi` smallint(5) unsigned NOT NULL,
   `sta` smallint(5) unsigned NOT NULL,
   `inte` smallint(5) unsigned NOT NULL,
   `spi` smallint(5) unsigned NOT NULL,
-  PRIMARY KEY  (`creature_entry`,`level`)
+  PRIMARY KEY (`creature_entry`,`level`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 PACK_KEYS=0 COMMENT='Stores pet levels stats.';
 
 --
@@ -4303,11 +5162,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pet_name_generation`;
 CREATE TABLE `pet_name_generation` (
-  `id` mediumint(8) unsigned NOT NULL auto_increment,
+  `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
   `word` tinytext NOT NULL,
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `half` tinyint(4) NOT NULL default '0',
-  PRIMARY KEY  (`id`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `half` tinyint(4) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -4577,7 +5436,6 @@ INSERT INTO `pet_name_generation` (`word`,`entry`,`half`) VALUES
 ('roon',17252,1),
 ('thun',17252,1),
 ('tom',17252,1);
-
 /*!40000 ALTER TABLE `pet_name_generation` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -4587,14 +5445,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pickpocketing_loot_template`;
 CREATE TABLE `pickpocketing_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -4616,7 +5474,7 @@ CREATE TABLE `player_classlevelstats` (
   `level` tinyint(3) unsigned NOT NULL,
   `basehp` smallint(5) unsigned NOT NULL,
   `basemana` smallint(5) unsigned NOT NULL,
-  PRIMARY KEY  (`class`,`level`)
+  PRIMARY KEY (`class`,`level`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 PACK_KEYS=0 COMMENT='Stores levels stats.';
 
 --
@@ -5443,7 +6301,7 @@ CREATE TABLE `player_levelstats` (
   `sta` tinyint(3) unsigned NOT NULL,
   `inte` tinyint(3) unsigned NOT NULL,
   `spi` tinyint(3) unsigned NOT NULL,
-  PRIMARY KEY  (`race`,`class`,`level`)
+  PRIMARY KEY (`race`,`class`,`level`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 PACK_KEYS=0 COMMENT='Stores levels stats.';
 
 --
@@ -10416,14 +11274,15 @@ INSERT INTO `player_levelstats` VALUES
 /*!40000 ALTER TABLE `player_levelstats` ENABLE KEYS */;
 UNLOCK TABLES;
 
--- ----------------------------
--- Table structure for player_xp_for_level
--- ----------------------------
+--
+-- Table structure for table `player_xp_for_level`
+--
+
 DROP TABLE IF EXISTS `player_xp_for_level`;
 CREATE TABLE `player_xp_for_level` (
   `lvl` int(3) unsigned NOT NULL,
   `xp_for_next_level` int(10) unsigned NOT NULL,
-  PRIMARY KEY  (`lvl`)
+  PRIMARY KEY (`lvl`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -10433,85 +11292,85 @@ CREATE TABLE `player_xp_for_level` (
 LOCK TABLES `player_xp_for_level` WRITE;
 /*!40000 ALTER TABLE `player_xp_for_level` DISABLE KEYS */;
 INSERT INTO `player_xp_for_level` VALUES
-('1', '400'),
-('2', '900'),
-('3', '1400'),
-('4', '2100'),
-('5', '2800'),
-('6', '3600'),
-('7', '4500'),
-('8', '5400'),
-('9', '6500'),
-('10', '7600'),
-('11', '8700'),
-('12', '9800'),
-('13', '11000'),
-('14', '12300'),
-('15', '13600'),
-('16', '15000'),
-('17', '16400'),
-('18', '17800'),
-('19', '19300'),
-('20', '20800'),
-('21', '22400'),
-('22', '24000'),
-('23', '25500'),
-('24', '27200'),
-('25', '28900'),
-('26', '30500'),
-('27', '32200'),
-('28', '33900'),
-('29', '36300'),
-('30', '38800'),
-('31', '41600'),
-('32', '44600'),
-('33', '48000'),
-('34', '51400'),
-('35', '55000'),
-('36', '58700'),
-('37', '62400'),
-('38', '66200'),
-('39', '70200'),
-('40', '74300'),
-('41', '78500'),
-('42', '82800'),
-('43', '87100'),
-('44', '91600'),
-('45', '96300'),
-('46', '101000'),
-('47', '105800'),
-('48', '110700'),
-('49', '115700'),
-('50', '120900'),
-('51', '126100'),
-('52', '131500'),
-('53', '137000'),
-('54', '142500'),
-('55', '148200'),
-('56', '154000'),
-('57', '159900'),
-('58', '165800'),
-('59', '172000'),
-('60', '290000'),
-('61', '317000'),
-('62', '349000'),
-('63', '386000'),
-('64', '428000'),
-('65', '475000'),
-('66', '527000'),
-('67', '585000'),
-('68', '648000'),
-('69', '717000'),
-('70', '1523800'),
-('71', '1539600'),
-('72', '1555700'),
-('73', '1571800'),
-('74', '1587900'),
-('75', '1604200'),
-('76', '1620700'),
-('77', '1637400'),
-('78', '1653900'),
-('79', '1670800');
+(1,400),
+(2,900),
+(3,1400),
+(4,2100),
+(5,2800),
+(6,3600),
+(7,4500),
+(8,5400),
+(9,6500),
+(10,7600),
+(11,8700),
+(12,9800),
+(13,11000),
+(14,12300),
+(15,13600),
+(16,15000),
+(17,16400),
+(18,17800),
+(19,19300),
+(20,20800),
+(21,22400),
+(22,24000),
+(23,25500),
+(24,27200),
+(25,28900),
+(26,30500),
+(27,32200),
+(28,33900),
+(29,36300),
+(30,38800),
+(31,41600),
+(32,44600),
+(33,48000),
+(34,51400),
+(35,55000),
+(36,58700),
+(37,62400),
+(38,66200),
+(39,70200),
+(40,74300),
+(41,78500),
+(42,82800),
+(43,87100),
+(44,91600),
+(45,96300),
+(46,101000),
+(47,105800),
+(48,110700),
+(49,115700),
+(50,120900),
+(51,126100),
+(52,131500),
+(53,137000),
+(54,142500),
+(55,148200),
+(56,154000),
+(57,159900),
+(58,165800),
+(59,172000),
+(60,290000),
+(61,317000),
+(62,349000),
+(63,386000),
+(64,428000),
+(65,475000),
+(66,527000),
+(67,585000),
+(68,648000),
+(69,717000),
+(70,1523800),
+(71,1539600),
+(72,1555700),
+(73,1571800),
+(74,1587900),
+(75,1604200),
+(76,1620700),
+(77,1637400),
+(78,1653900),
+(79,1670800);
 /*!40000 ALTER TABLE `player_xp_for_level` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -10521,15 +11380,15 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `playercreateinfo`;
 CREATE TABLE `playercreateinfo` (
-  `race` tinyint(3) unsigned NOT NULL default '0',
-  `class` tinyint(3) unsigned NOT NULL default '0',
-  `map` smallint(5) unsigned NOT NULL default '0',
-  `zone` mediumint(8) unsigned NOT NULL default '0',
-  `position_x` float NOT NULL default '0',
-  `position_y` float NOT NULL default '0',
-  `position_z` float NOT NULL default '0',
-  `orientation` float NOT NULL default '0',
-  PRIMARY KEY  (`race`,`class`)
+  `race` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `map` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `zone` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `position_x` float NOT NULL DEFAULT '0',
+  `position_y` float NOT NULL DEFAULT '0',
+  `position_z` float NOT NULL DEFAULT '0',
+  `orientation` float NOT NULL DEFAULT '0',
+  PRIMARY KEY (`race`,`class`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -10577,14 +11436,14 @@ INSERT INTO `playercreateinfo` VALUES
 (6,11,1,215,-2917,-257,53,0),
 (7,1,0,1,-6240,331,383,0),
 (7,4,0,1,-6240,331,383,0),
-(7,6,609,4298,2355.05,-5661.7, 426.026,3.659973),
+(7,6,609,4298,2355.05,-5661.7,426.026,3.659973),
 (7,8,0,1,-6240,331,383,0),
 (7,9,0,1,-6240,331,383,0),
 (8,1,1,14,-618,-4251,39,0),
 (8,3,1,14,-618,-4251,39,0),
 (8,4,1,14,-618,-4251,39,0),
 (8,5,1,14,-618,-4251,39,0),
-(8,6,609,4298,2355.05,-5661.7, 426.026,3.659973),
+(8,6,609,4298,2355.05,-5661.7,426.026,3.659973),
 (8,7,1,14,-618,-4251,39,0),
 (8,8,1,14,-618,-4251,39,0),
 (10,2,530,3431,10349.6,-6357.29,33.4026,5.316046),
@@ -10610,13 +11469,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `playercreateinfo_action`;
 CREATE TABLE `playercreateinfo_action` (
-  `race` tinyint(3) unsigned NOT NULL default '0',
-  `class` tinyint(3) unsigned NOT NULL default '0',
-  `button` smallint(5) unsigned NOT NULL default '0',
-  `action` int(11) unsigned NOT NULL default '0',
-  `type` smallint(5) unsigned NOT NULL default '0',
-  KEY `playercreateinfo_race_class_index` (`race`,`class`),
-  PRIMARY KEY (`race`,`class`,`button`)
+  `race` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `button` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `action` int(11) unsigned NOT NULL DEFAULT '0',
+  `type` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`race`,`class`,`button`),
+  KEY `playercreateinfo_race_class_index` (`race`,`class`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -10662,8 +11521,8 @@ INSERT INTO `playercreateinfo_action` VALUES
 (1,9,9,59752,0),
 (1,9,11,4604,128),
 (2,1,0,6603,0),
-(2,1,1,78, 0),
-(2,1,2,20572, 0),
+(2,1,1,78,0),
+(2,1,2,20572,0),
 (2,1,72,6603,0),
 (2,1,73,78,0),
 (2,1,74,20572,0),
@@ -10990,10 +11849,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `playercreateinfo_item`;
 CREATE TABLE `playercreateinfo_item` (
-  `race` tinyint(3) unsigned NOT NULL default '0',
-  `class` tinyint(3) unsigned NOT NULL default '0',
-  `itemid` mediumint(8) unsigned NOT NULL default '0',
-  `amount` tinyint(3) unsigned NOT NULL default '1',
+  `race` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `itemid` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `amount` tinyint(3) unsigned NOT NULL DEFAULT '1',
   KEY `playercreateinfo_race_class_index` (`race`,`class`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
@@ -11012,11 +11871,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `playercreateinfo_spell`;
 CREATE TABLE `playercreateinfo_spell` (
-  `race` tinyint(3) unsigned NOT NULL default '0',
-  `class` tinyint(3) unsigned NOT NULL default '0',
-  `Spell` mediumint(8) unsigned NOT NULL default '0',
-  `Note` varchar(255) default NULL,
-  PRIMARY KEY  (`race`,`class`,`Spell`)
+  `race` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `class` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `Spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `Note` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`race`,`class`,`Spell`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -11071,7 +11930,7 @@ INSERT INTO `playercreateinfo_spell` VALUES
 (1,1,58985,'Perception'),
 (1,1,59752,'Every Man for Himself'),
 (1,1,61437,'Opening'),
-(1,1,68398, 'Opening'),
+(1,1,68398,'Opening'),
 (1,2,81,'Dodge'),
 (1,2,107,'Block'),
 (1,2,198,'One-Handed Maces'),
@@ -11266,7 +12125,7 @@ INSERT INTO `playercreateinfo_spell` VALUES
 (1,6,59921,'Frost Fever'),
 (1,6,61437,'Opening'),
 (1,6,61455,'Runic Focus'),
-(1,6,68398, 'Opening'),
+(1,6,68398,'Opening'),
 (1,8,81,'Dodge'),
 (1,8,133,'Fireball'),
 (1,8,168,'Frost Armor'),
@@ -13306,7 +14165,7 @@ INSERT INTO `playercreateinfo_spell` VALUES
 (10,2,27762,'Libram'),
 (10,2,28730,'Arcane Torrent'),
 (10,2,28877,'Arcane Affinity'),
-(10,2,68398, 'Opening'),
+(10,2,68398,'Opening'),
 (10,3,75,'Auto Shot'),
 (10,3,81,'Dodge'),
 (10,3,197,'Two-Handed Axes'),
@@ -13420,7 +14279,7 @@ INSERT INTO `playercreateinfo_spell` VALUES
 (10,5,22810,'Opening - No Text'),
 (10,5,28730,'Arcane Torrent'),
 (10,5,28877,'Arcane Affinity'),
-(10,5,68398, 'Opening'),
+(10,5,68398,'Opening'),
 (10,6,81,'Dodge'),
 (10,6,196,'One-Handed Axes'),
 (10,6,197,'Two-Handed Axes'),
@@ -13888,14 +14747,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `points_of_interest`;
 CREATE TABLE `points_of_interest` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `x` float NOT NULL default '0',
-  `y` float NOT NULL default '0',
-  `icon` mediumint(8) unsigned NOT NULL default '0',
-  `flags` mediumint(8) unsigned NOT NULL default '0',
-  `data` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `x` float NOT NULL DEFAULT '0',
+  `y` float NOT NULL DEFAULT '0',
+  `icon` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `flags` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `data` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_name` text NOT NULL,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -13913,12 +14772,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pool_creature`;
 CREATE TABLE `pool_creature` (
-  `guid` int(10) unsigned NOT NULL default '0',
-  `pool_entry` mediumint(8) unsigned NOT NULL default '0',
-  `chance` float unsigned NOT NULL default '0',
+  `guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `pool_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `chance` float unsigned NOT NULL DEFAULT '0',
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (`guid`),
-  INDEX `pool_idx` (pool_entry)
+  PRIMARY KEY (`guid`),
+  KEY `pool_idx` (`pool_entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -13936,12 +14795,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pool_creature_template`;
 CREATE TABLE `pool_creature_template` (
-  `id` int(10) unsigned NOT NULL default '0',
-  `pool_entry` mediumint(8) unsigned NOT NULL default '0',
-  `chance` float unsigned NOT NULL default '0',
+  `id` int(10) unsigned NOT NULL DEFAULT '0',
+  `pool_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `chance` float unsigned NOT NULL DEFAULT '0',
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (`id`),
-  INDEX `pool_idx` (pool_entry)
+  PRIMARY KEY (`id`),
+  KEY `pool_idx` (`pool_entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -13959,12 +14818,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pool_gameobject`;
 CREATE TABLE `pool_gameobject` (
-  `guid` int(10) unsigned NOT NULL default '0',
-  `pool_entry` mediumint(8) unsigned NOT NULL default '0',
-  `chance` float unsigned NOT NULL default '0',
+  `guid` int(10) unsigned NOT NULL DEFAULT '0',
+  `pool_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `chance` float unsigned NOT NULL DEFAULT '0',
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (`guid`),
-  INDEX `pool_idx` (pool_entry)
+  PRIMARY KEY (`guid`),
+  KEY `pool_idx` (`pool_entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -13982,12 +14841,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pool_gameobject_template`;
 CREATE TABLE `pool_gameobject_template` (
-  `id` int(10) unsigned NOT NULL default '0',
-  `pool_entry` mediumint(8) unsigned NOT NULL default '0',
-  `chance` float unsigned NOT NULL default '0',
+  `id` int(10) unsigned NOT NULL DEFAULT '0',
+  `pool_entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `chance` float unsigned NOT NULL DEFAULT '0',
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (`id`),
-  INDEX `pool_idx` (pool_entry)
+  PRIMARY KEY (`id`),
+  KEY `pool_idx` (`pool_entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -14005,12 +14864,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pool_pool`;
 CREATE TABLE `pool_pool` (
-  `pool_id` mediumint(8) unsigned NOT NULL default '0',
-  `mother_pool` mediumint(8) unsigned NOT NULL default '0',
-  `chance` float NOT NULL default '0',
+  `pool_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `mother_pool` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `chance` float NOT NULL DEFAULT '0',
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (pool_id),
-  INDEX pool_idx (mother_pool)
+  PRIMARY KEY (`pool_id`),
+  KEY `pool_idx` (`mother_pool`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -14028,10 +14887,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pool_template`;
 CREATE TABLE `pool_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Pool entry',
-  `max_limit` int(10) unsigned NOT NULL default '0' COMMENT 'Max number of objects (0) is no limit',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Pool entry',
+  `max_limit` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Max number of objects (0) is no limit',
   `description` varchar(255) NOT NULL,
-  PRIMARY KEY  (`entry`)
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -14049,14 +14908,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `prospecting_loot_template`;
 CREATE TABLE `prospecting_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -14067,7 +14926,6 @@ LOCK TABLES `prospecting_loot_template` WRITE;
 /*!40000 ALTER TABLE `prospecting_loot_template` DISABLE KEYS */;
 /*!40000 ALTER TABLE `prospecting_loot_template` ENABLE KEYS */;
 UNLOCK TABLES;
-
 
 --
 -- Table structure for table `quest_poi`
@@ -14117,44 +14975,43 @@ LOCK TABLES `quest_poi_points` WRITE;
 /*!40000 ALTER TABLE `quest_poi_points` ENABLE KEYS */;
 UNLOCK TABLES;
 
-
 --
 -- Table structure for table `quest_template`
 --
 
 DROP TABLE IF EXISTS `quest_template`;
 CREATE TABLE `quest_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `Method` tinyint(3) unsigned NOT NULL default '2',
-  `ZoneOrSort` smallint(6) NOT NULL default '0',
-  `MinLevel` tinyint(3) unsigned NOT NULL default '0',
-  `QuestLevel` smallint(6) NOT NULL default '0',
-  `Type` smallint(5) unsigned NOT NULL default '0',
-  `RequiredClasses` smallint(5) unsigned NOT NULL default '0',
-  `RequiredRaces` smallint(5) unsigned NOT NULL default '0',
-  `RequiredSkill` smallint(5) unsigned NOT NULL default '0',
-  `RequiredSkillValue` smallint(5) unsigned NOT NULL default '0',
-  `RepObjectiveFaction` smallint(5) unsigned NOT NULL default '0',
-  `RepObjectiveValue` mediumint(9) NOT NULL default '0',
-  `RequiredMinRepFaction` smallint(5) unsigned NOT NULL default '0',
-  `RequiredMinRepValue` mediumint(9) NOT NULL default '0',
-  `RequiredMaxRepFaction` smallint(5) unsigned NOT NULL default '0',
-  `RequiredMaxRepValue` mediumint(9) NOT NULL default '0',
-  `SuggestedPlayers` tinyint(3) unsigned NOT NULL default '0',
-  `LimitTime` int(10) unsigned NOT NULL default '0',
-  `QuestFlags` mediumint(8) unsigned NOT NULL default '0',
-  `SpecialFlags` tinyint(3) unsigned NOT NULL default '0',
-  `CharTitleId` tinyint(3) unsigned NOT NULL default '0',
-  `PlayersSlain` tinyint(3) unsigned NOT NULL default '0',
-  `BonusTalents` tinyint(3) unsigned NOT NULL default '0',
-  `PrevQuestId` mediumint(9) NOT NULL default '0',
-  `NextQuestId` mediumint(9) NOT NULL default '0',
-  `ExclusiveGroup` mediumint(9) NOT NULL default '0',
-  `NextQuestInChain` mediumint(8) unsigned NOT NULL default '0',
-  `RewXPId` tinyint(3) unsigned NOT NULL default '0',
-  `SrcItemId` mediumint(8) unsigned NOT NULL default '0',
-  `SrcItemCount` tinyint(3) unsigned NOT NULL default '0',
-  `SrcSpell` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `Method` tinyint(3) unsigned NOT NULL DEFAULT '2',
+  `ZoneOrSort` smallint(6) NOT NULL DEFAULT '0',
+  `MinLevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `QuestLevel` smallint(6) NOT NULL DEFAULT '0',
+  `Type` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredClasses` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredRaces` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredSkill` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredSkillValue` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RepObjectiveFaction` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RepObjectiveValue` mediumint(9) NOT NULL DEFAULT '0',
+  `RequiredMinRepFaction` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredMinRepValue` mediumint(9) NOT NULL DEFAULT '0',
+  `RequiredMaxRepFaction` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RequiredMaxRepValue` mediumint(9) NOT NULL DEFAULT '0',
+  `SuggestedPlayers` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `LimitTime` int(10) unsigned NOT NULL DEFAULT '0',
+  `QuestFlags` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `SpecialFlags` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `CharTitleId` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `PlayersSlain` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `BonusTalents` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `PrevQuestId` mediumint(9) NOT NULL DEFAULT '0',
+  `NextQuestId` mediumint(9) NOT NULL DEFAULT '0',
+  `ExclusiveGroup` mediumint(9) NOT NULL DEFAULT '0',
+  `NextQuestInChain` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewXPId` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `SrcItemId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `SrcItemCount` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `SrcSpell` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `Title` text,
   `Details` text,
   `Objectives` text,
@@ -14166,106 +15023,106 @@ CREATE TABLE `quest_template` (
   `ObjectiveText2` text,
   `ObjectiveText3` text,
   `ObjectiveText4` text,
-  `ReqItemId1` mediumint(8) unsigned NOT NULL default '0',
-  `ReqItemId2` mediumint(8) unsigned NOT NULL default '0',
-  `ReqItemId3` mediumint(8) unsigned NOT NULL default '0',
-  `ReqItemId4` mediumint(8) unsigned NOT NULL default '0',
-  `ReqItemId5` mediumint(8) unsigned NOT NULL default '0',
-  `ReqItemId6` mediumint(8) unsigned NOT NULL default '0',
-  `ReqItemCount1` smallint(5) unsigned NOT NULL default '0',
-  `ReqItemCount2` smallint(5) unsigned NOT NULL default '0',
-  `ReqItemCount3` smallint(5) unsigned NOT NULL default '0',
-  `ReqItemCount4` smallint(5) unsigned NOT NULL default '0',
-  `ReqItemCount5` smallint(5) unsigned NOT NULL default '0',
-  `ReqItemCount6` smallint(5) unsigned NOT NULL default '0',
-  `ReqSourceId1` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSourceId2` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSourceId3` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSourceId4` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSourceCount1` smallint(5) unsigned NOT NULL default '0',
-  `ReqSourceCount2` smallint(5) unsigned NOT NULL default '0',
-  `ReqSourceCount3` smallint(5) unsigned NOT NULL default '0',
-  `ReqSourceCount4` smallint(5) unsigned NOT NULL default '0',
-  `ReqCreatureOrGOId1` mediumint(9) NOT NULL default '0',
-  `ReqCreatureOrGOId2` mediumint(9) NOT NULL default '0',
-  `ReqCreatureOrGOId3` mediumint(9) NOT NULL default '0',
-  `ReqCreatureOrGOId4` mediumint(9) NOT NULL default '0',
-  `ReqCreatureOrGOCount1` smallint(5) unsigned NOT NULL default '0',
-  `ReqCreatureOrGOCount2` smallint(5) unsigned NOT NULL default '0',
-  `ReqCreatureOrGOCount3` smallint(5) unsigned NOT NULL default '0',
-  `ReqCreatureOrGOCount4` smallint(5) unsigned NOT NULL default '0',
-  `ReqSpellCast1` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSpellCast2` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSpellCast3` mediumint(8) unsigned NOT NULL default '0',
-  `ReqSpellCast4` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemId1` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemId2` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemId3` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemId4` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemId5` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemId6` mediumint(8) unsigned NOT NULL default '0',
-  `RewChoiceItemCount1` smallint(5) unsigned NOT NULL default '0',
-  `RewChoiceItemCount2` smallint(5) unsigned NOT NULL default '0',
-  `RewChoiceItemCount3` smallint(5) unsigned NOT NULL default '0',
-  `RewChoiceItemCount4` smallint(5) unsigned NOT NULL default '0',
-  `RewChoiceItemCount5` smallint(5) unsigned NOT NULL default '0',
-  `RewChoiceItemCount6` smallint(5) unsigned NOT NULL default '0',
-  `RewItemId1` mediumint(8) unsigned NOT NULL default '0',
-  `RewItemId2` mediumint(8) unsigned NOT NULL default '0',
-  `RewItemId3` mediumint(8) unsigned NOT NULL default '0',
-  `RewItemId4` mediumint(8) unsigned NOT NULL default '0',
-  `RewItemCount1` smallint(5) unsigned NOT NULL default '0',
-  `RewItemCount2` smallint(5) unsigned NOT NULL default '0',
-  `RewItemCount3` smallint(5) unsigned NOT NULL default '0',
-  `RewItemCount4` smallint(5) unsigned NOT NULL default '0',
-  `RewRepFaction1` smallint(5) unsigned NOT NULL default '0' COMMENT 'faction id from Faction.dbc in this case',
-  `RewRepFaction2` smallint(5) unsigned NOT NULL default '0' COMMENT 'faction id from Faction.dbc in this case',
-  `RewRepFaction3` smallint(5) unsigned NOT NULL default '0' COMMENT 'faction id from Faction.dbc in this case',
-  `RewRepFaction4` smallint(5) unsigned NOT NULL default '0' COMMENT 'faction id from Faction.dbc in this case',
-  `RewRepFaction5` smallint(5) unsigned NOT NULL default '0' COMMENT 'faction id from Faction.dbc in this case',
-  `RewRepValueId1` tinyint(3) NOT NULL default '0',
-  `RewRepValueId2` tinyint(3) NOT NULL default '0',
-  `RewRepValueId3` tinyint(3) NOT NULL default '0',
-  `RewRepValueId4` tinyint(3) NOT NULL default '0',
-  `RewRepValueId5` tinyint(3) NOT NULL default '0',
-  `RewRepValue1` mediumint(9) NOT NULL default '0',
-  `RewRepValue2` mediumint(9) NOT NULL default '0',
-  `RewRepValue3` mediumint(9) NOT NULL default '0',
-  `RewRepValue4` mediumint(9) NOT NULL default '0',
-  `RewRepValue5` mediumint(9) NOT NULL default '0',
-  `RewHonorAddition` int unsigned NOT NULL default '0',
-  `RewHonorMultiplier` float NOT NULL default '0',
-  `RewOrReqMoney` int(11) NOT NULL default '0',
-  `RewMoneyMaxLevel` int(10) unsigned NOT NULL default '0',
-  `RewSpell` mediumint(8) unsigned NOT NULL default '0',
-  `RewSpellCast` mediumint(8) unsigned NOT NULL default '0',
-  `RewMailTemplateId` mediumint(8) unsigned NOT NULL default '0',
-  `RewMailDelaySecs` int(11) unsigned NOT NULL default '0',
-  `PointMapId` smallint(5) unsigned NOT NULL default '0',
-  `PointX` float NOT NULL default '0',
-  `PointY` float NOT NULL default '0',
-  `PointOpt` mediumint(8) unsigned NOT NULL default '0',
-  `DetailsEmote1` smallint(5) unsigned NOT NULL default '0',
-  `DetailsEmote2` smallint(5) unsigned NOT NULL default '0',
-  `DetailsEmote3` smallint(5) unsigned NOT NULL default '0',
-  `DetailsEmote4` smallint(5) unsigned NOT NULL default '0',
-  `DetailsEmoteDelay1` int(11) unsigned NOT NULL default '0',
-  `DetailsEmoteDelay2` int(11) unsigned NOT NULL default '0',
-  `DetailsEmoteDelay3` int(11) unsigned NOT NULL default '0',
-  `DetailsEmoteDelay4` int(11) unsigned NOT NULL default '0',
-  `IncompleteEmote` smallint(5) unsigned NOT NULL default '0',
-  `CompleteEmote` smallint(5) unsigned NOT NULL default '0',
-  `OfferRewardEmote1` smallint(5) unsigned NOT NULL default '0',
-  `OfferRewardEmote2` smallint(5) unsigned NOT NULL default '0',
-  `OfferRewardEmote3` smallint(5) unsigned NOT NULL default '0',
-  `OfferRewardEmote4` smallint(5) unsigned NOT NULL default '0',
-  `OfferRewardEmoteDelay1` int(11) unsigned NOT NULL default '0',
-  `OfferRewardEmoteDelay2` int(11) unsigned NOT NULL default '0',
-  `OfferRewardEmoteDelay3` int(11) unsigned NOT NULL default '0',
-  `OfferRewardEmoteDelay4` int(11) unsigned NOT NULL default '0',
-  `StartScript` mediumint(8) unsigned NOT NULL default '0',
-  `CompleteScript` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
+  `ReqItemId1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqItemId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqItemId3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqItemId4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqItemId5` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqItemId6` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqItemCount1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqItemCount2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqItemCount3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqItemCount4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqItemCount5` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqItemCount6` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceId1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceId3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceId4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceCount1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceCount2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceCount3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqSourceCount4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOId1` mediumint(9) NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOId2` mediumint(9) NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOId3` mediumint(9) NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOId4` mediumint(9) NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOCount1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOCount2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOCount3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqCreatureOrGOCount4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ReqSpellCast1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSpellCast2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSpellCast3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ReqSpellCast4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemId1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemId3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemId4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemId5` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemId6` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemCount1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemCount2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemCount3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemCount4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemCount5` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewChoiceItemCount6` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewItemId1` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewItemId2` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewItemId3` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewItemId4` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewItemCount1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewItemCount2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewItemCount3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewItemCount4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `RewRepFaction1` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'faction id from Faction.dbc in this case',
+  `RewRepFaction2` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'faction id from Faction.dbc in this case',
+  `RewRepFaction3` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'faction id from Faction.dbc in this case',
+  `RewRepFaction4` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'faction id from Faction.dbc in this case',
+  `RewRepFaction5` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'faction id from Faction.dbc in this case',
+  `RewRepValueId1` tinyint(3) NOT NULL DEFAULT '0',
+  `RewRepValueId2` tinyint(3) NOT NULL DEFAULT '0',
+  `RewRepValueId3` tinyint(3) NOT NULL DEFAULT '0',
+  `RewRepValueId4` tinyint(3) NOT NULL DEFAULT '0',
+  `RewRepValueId5` tinyint(3) NOT NULL DEFAULT '0',
+  `RewRepValue1` mediumint(9) NOT NULL DEFAULT '0',
+  `RewRepValue2` mediumint(9) NOT NULL DEFAULT '0',
+  `RewRepValue3` mediumint(9) NOT NULL DEFAULT '0',
+  `RewRepValue4` mediumint(9) NOT NULL DEFAULT '0',
+  `RewRepValue5` mediumint(9) NOT NULL DEFAULT '0',
+  `RewHonorAddition` int(10) unsigned NOT NULL DEFAULT '0',
+  `RewHonorMultiplier` float NOT NULL DEFAULT '0',
+  `RewOrReqMoney` int(11) NOT NULL DEFAULT '0',
+  `RewMoneyMaxLevel` int(10) unsigned NOT NULL DEFAULT '0',
+  `RewSpell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewSpellCast` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewMailTemplateId` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `RewMailDelaySecs` int(11) unsigned NOT NULL DEFAULT '0',
+  `PointMapId` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `PointX` float NOT NULL DEFAULT '0',
+  `PointY` float NOT NULL DEFAULT '0',
+  `PointOpt` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmote1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmote2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmote3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmote4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmoteDelay1` int(11) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmoteDelay2` int(11) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmoteDelay3` int(11) unsigned NOT NULL DEFAULT '0',
+  `DetailsEmoteDelay4` int(11) unsigned NOT NULL DEFAULT '0',
+  `IncompleteEmote` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `CompleteEmote` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmote1` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmote2` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmote3` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmote4` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmoteDelay1` int(11) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmoteDelay2` int(11) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmoteDelay3` int(11) unsigned NOT NULL DEFAULT '0',
+  `OfferRewardEmoteDelay4` int(11) unsigned NOT NULL DEFAULT '0',
+  `StartScript` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `CompleteScript` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Quest System';
 
 --
@@ -14283,14 +15140,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `reference_loot_template`;
 CREATE TABLE `reference_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -14308,11 +15165,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `reputation_reward_rate`;
 CREATE TABLE `reputation_reward_rate` (
-  `faction` mediumint(8) unsigned NOT NULL default '0',
-  `quest_rate` float NOT NULL default '1',
-  `creature_rate` float NOT NULL default '1',
-  `spell_rate` float NOT NULL default '1',
-  PRIMARY KEY  (`faction`)
+  `faction` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest_rate` float NOT NULL DEFAULT '1',
+  `creature_rate` float NOT NULL DEFAULT '1',
+  `spell_rate` float NOT NULL DEFAULT '1',
+  PRIMARY KEY (`faction`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -14330,20 +15187,20 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `reputation_spillover_template`;
 CREATE TABLE `reputation_spillover_template` (
-  `faction` smallint(6) unsigned NOT NULL default '0' COMMENT 'faction entry',
-  `faction1` smallint(6) unsigned NOT NULL default '0' COMMENT 'faction to give spillover for',
-  `rate_1` float NOT NULL default '0' COMMENT 'the given rep points * rate',
-  `rank_1` tinyint(3) unsigned NOT NULL default '0' COMMENT 'max rank, above this will not give any spillover',
-  `faction2` smallint(6) unsigned NOT NULL default '0',
-  `rate_2` float NOT NULL default '0',
-  `rank_2` tinyint(3) unsigned NOT NULL default '0',
-  `faction3` smallint(6) unsigned NOT NULL default '0',
-  `rate_3` float NOT NULL default '0',
-  `rank_3` tinyint(3) unsigned NOT NULL default '0',
-  `faction4` smallint(6) unsigned NOT NULL default '0',
-  `rate_4` float NOT NULL default '0',
-  `rank_4` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`faction`)
+  `faction` smallint(6) unsigned NOT NULL DEFAULT '0' COMMENT 'faction entry',
+  `faction1` smallint(6) unsigned NOT NULL DEFAULT '0' COMMENT 'faction to give spillover for',
+  `rate_1` float NOT NULL DEFAULT '0' COMMENT 'the given rep points * rate',
+  `rank_1` tinyint(3) unsigned NOT NULL DEFAULT '0' COMMENT 'max rank, above this will not give any spillover',
+  `faction2` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `rate_2` float NOT NULL DEFAULT '0',
+  `rank_2` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `faction3` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `rate_3` float NOT NULL DEFAULT '0',
+  `rank_3` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `faction4` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `rate_4` float NOT NULL DEFAULT '0',
+  `rank_4` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`faction`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Reputation spillover reputation gain';
 
 --
@@ -14361,8 +15218,8 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `reserved_name`;
 CREATE TABLE `reserved_name` (
-  `name` varchar(12) NOT NULL default '',
-  PRIMARY KEY  (`name`)
+  `name` varchar(12) NOT NULL DEFAULT '',
+  PRIMARY KEY (`name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player Reserved Names';
 
 --
@@ -14380,10 +15237,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `scripted_areatrigger`;
 CREATE TABLE `scripted_areatrigger` (
-  `entry` MEDIUMINT( 8 ) NOT NULL ,
-  `ScriptName` CHAR( 64 ) NOT NULL ,
-  PRIMARY KEY ( `entry` )
-) ENGINE = MYISAM DEFAULT CHARSET=utf8;
+  `entry` mediumint(8) NOT NULL,
+  `ScriptName` char(64) NOT NULL,
+  PRIMARY KEY (`entry`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
 -- Dumping data for table `scripted_areatrigger`
@@ -14402,7 +15259,7 @@ DROP TABLE IF EXISTS `scripted_event_id`;
 CREATE TABLE `scripted_event_id` (
   `id` mediumint(8) NOT NULL,
   `ScriptName` char(64) NOT NULL,
-  PRIMARY KEY  (`id`)
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Script library scripted events';
 
 --
@@ -14420,10 +15277,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `skill_discovery_template`;
 CREATE TABLE `skill_discovery_template` (
-  `spellId` mediumint(8) unsigned NOT NULL default '0' COMMENT 'SpellId of the discoverable spell',
-  `reqSpell` mediumint(8) unsigned NOT NULL default '0' COMMENT 'spell requirement',
-  `reqSkillValue` smallint(5) unsigned NOT NULL default '0' COMMENT 'skill points requirement',
-  `chance` float NOT NULL default '0' COMMENT 'chance to discover',
+  `spellId` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'SpellId of the discoverable spell',
+  `reqSpell` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'spell requirement',
+  `reqSkillValue` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'skill points requirement',
+  `chance` float NOT NULL DEFAULT '0' COMMENT 'chance to discover',
   PRIMARY KEY (`spellId`,`reqSpell`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Skill Discovery System';
 
@@ -14442,11 +15299,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `skill_extra_item_template`;
 CREATE TABLE `skill_extra_item_template` (
-  `spellId` mediumint(8) unsigned NOT NULL default '0' COMMENT 'SpellId of the item creation spell',
-  `requiredSpecialization` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Specialization spell id',
-  `additionalCreateChance` float NOT NULL default '0' COMMENT 'chance to create add',
-  `additionalMaxNum` tinyint(3) unsigned NOT NULL default '0' COMMENT 'max num of adds',
-  PRIMARY KEY  (`spellId`)
+  `spellId` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'SpellId of the item creation spell',
+  `requiredSpecialization` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Specialization spell id',
+  `additionalCreateChance` float NOT NULL DEFAULT '0' COMMENT 'chance to create add',
+  `additionalMaxNum` tinyint(3) unsigned NOT NULL DEFAULT '0' COMMENT 'max num of adds',
+  PRIMARY KEY (`spellId`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Skill Specialization System';
 
 --
@@ -14464,9 +15321,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `skill_fishing_base_level`;
 CREATE TABLE `skill_fishing_base_level` (
-  `entry` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Area identifier',
-  `skill` smallint(6) NOT NULL default '0' COMMENT 'Base skill level requirement',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Area identifier',
+  `skill` smallint(6) NOT NULL DEFAULT '0' COMMENT 'Base skill level requirement',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Fishing system';
 
 --
@@ -14484,14 +15341,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `skinning_loot_template`;
 CREATE TABLE `skinning_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -14509,17 +15366,17 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `spell_area`;
 CREATE TABLE `spell_area` (
-  `spell`              mediumint(8) unsigned NOT NULL default '0',
-  `area`               mediumint(8) unsigned NOT NULL default '0',
-  `quest_start`        mediumint(8) unsigned NOT NULL default '0',
-  `quest_start_active` tinyint(1) unsigned NOT NULL default '0',
-  `quest_end`          mediumint(8) unsigned NOT NULL default '0',
-  `condition_id`       mediumint(8) unsigned NOT NULL default '0',
-  `aura_spell`         mediumint(8) NOT NULL default '0',
-  `racemask`           mediumint(8) unsigned NOT NULL default '0',
-  `gender`             tinyint(1) unsigned NOT NULL default '2',
-  `autocast`           tinyint(1) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`spell`,`area`,`quest_start`,`quest_start_active`,`aura_spell`,`racemask`,`gender`)
+  `spell` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `area` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest_start` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `quest_start_active` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `quest_end` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `aura_spell` mediumint(8) NOT NULL DEFAULT '0',
+  `racemask` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `gender` tinyint(1) unsigned NOT NULL DEFAULT '2',
+  `autocast` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`spell`,`area`,`quest_start`,`quest_start_active`,`aura_spell`,`racemask`,`gender`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -14532,18 +15389,18 @@ LOCK TABLES `spell_area` WRITE;
 UNLOCK TABLES;
 
 --
--- Table structure for `spell_bonus_data`
+-- Table structure for table `spell_bonus_data`
 --
 
 DROP TABLE IF EXISTS `spell_bonus_data`;
 CREATE TABLE `spell_bonus_data` (
   `entry` mediumint(8) unsigned NOT NULL,
-  `direct_bonus` float NOT NULL default '0',
-  `dot_bonus` float NOT NULL default '0',
-  `ap_bonus` float NOT NULL default '0',
-  `ap_dot_bonus` float NOT NULL default '0',
-  `comments` varchar(255) default NULL,
-  PRIMARY KEY  (`entry`)
+  `direct_bonus` float NOT NULL DEFAULT '0',
+  `dot_bonus` float NOT NULL DEFAULT '0',
+  `ap_bonus` float NOT NULL DEFAULT '0',
+  `ap_dot_bonus` float NOT NULL DEFAULT '0',
+  `comments` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -14711,7 +15568,6 @@ INSERT INTO `spell_bonus_data` VALUES
 (21179, 0,      0,       0,     0,     'Item - Six Demon Bag - Chain Lightning'),
 (15662, 0,      0,       0,     0,     'Item - Six Demon Bag - Fireball'),
 (11538, 0,      0,       0,     0,     'Item - Six Demon Bag - Frostbolt');
-
 /*!40000 ALTER TABLE `spell_bonus_data` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -14721,12 +15577,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `spell_chain`;
 CREATE TABLE `spell_chain` (
-  `spell_id` mediumint(9) NOT NULL default '0',
-  `prev_spell` mediumint(9) NOT NULL default '0',
-  `first_spell` mediumint(9) NOT NULL default '0',
-  `rank` tinyint(4) NOT NULL default '0',
-  `req_spell` mediumint(9) NOT NULL default '0',
-  PRIMARY KEY  (`spell_id`)
+  `spell_id` mediumint(9) NOT NULL DEFAULT '0',
+  `prev_spell` mediumint(9) NOT NULL DEFAULT '0',
+  `first_spell` mediumint(9) NOT NULL DEFAULT '0',
+  `rank` tinyint(4) NOT NULL DEFAULT '0',
+  `req_spell` mediumint(9) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`spell_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Spell Additinal Data';
 
 --
@@ -16722,9 +17578,9 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `spell_elixir`;
 CREATE TABLE `spell_elixir` (
-  `entry` int(11) unsigned NOT NULL default '0' COMMENT 'SpellId of potion',
-  `mask` tinyint(1) unsigned NOT NULL default '0' COMMENT 'Mask 0x1 battle 0x2 guardian 0x3 flask 0x7 unstable flasks 0xB shattrath flasks',
-  PRIMARY KEY  (`entry`)
+  `entry` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'SpellId of potion',
+  `mask` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Mask 0x1 battle 0x2 guardian 0x3 flask 0x7 unstable flasks 0xB shattrath flasks',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Spell System';
 
 --
@@ -16867,8 +17723,6 @@ INSERT INTO `spell_elixir` VALUES
 (67017,0x3),
 (67018,0x3),
 (67019,0x3);
-
-
 /*!40000 ALTER TABLE `spell_elixir` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -16878,10 +17732,10 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `spell_learn_spell`;
 CREATE TABLE `spell_learn_spell` (
-  `entry` smallint(5) unsigned NOT NULL default '0',
-  `SpellID` smallint(5) unsigned NOT NULL default '0',
-  `Active` tinyint(3) unsigned NOT NULL default '1',
-  PRIMARY KEY  (`entry`,`SpellID`)
+  `entry` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `SpellID` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `Active` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  PRIMARY KEY (`entry`,`SpellID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Item System';
 
 --
@@ -16918,14 +17772,14 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `spell_loot_template`;
 CREATE TABLE `spell_loot_template` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
-  `item` mediumint(8) unsigned NOT NULL default '0',
-  `ChanceOrQuestChance` float NOT NULL default '100',
-  `groupid` tinyint(3) unsigned NOT NULL default '0',
-  `mincountOrRef` mediumint(9) NOT NULL default '1',
-  `maxcount` tinyint(3) unsigned NOT NULL default '1',
-  `condition_id` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0',
-  PRIMARY KEY  (`entry`,`item`)
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `item` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `ChanceOrQuestChance` float NOT NULL DEFAULT '100',
+  `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mincountOrRef` mediumint(9) NOT NULL DEFAULT '1',
+  `maxcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `condition_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`,`item`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Loot System';
 
 --
@@ -16944,10 +17798,10 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `spell_pet_auras`;
 CREATE TABLE `spell_pet_auras` (
   `spell` mediumint(8) unsigned NOT NULL COMMENT 'dummy spell id',
-  `effectId` tinyint(3) unsigned NOT NULL default '0',
-  `pet` mediumint(8) unsigned NOT NULL default '0' COMMENT 'pet id; 0 = all',
+  `effectId` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `pet` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'pet id; 0 = all',
   `aura` mediumint(8) unsigned NOT NULL COMMENT 'pet aura id',
-  PRIMARY KEY  (`spell`,`effectId`,`pet`)
+  PRIMARY KEY (`spell`,`effectId`,`pet`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -16957,52 +17811,51 @@ CREATE TABLE `spell_pet_auras` (
 LOCK TABLES `spell_pet_auras` WRITE;
 /*!40000 ALTER TABLE `spell_pet_auras` DISABLE KEYS */;
 INSERT INTO `spell_pet_auras` VALUES
-(19028, 0, 0, 25228),
-(19578, 0, 0, 19579),
-(20895, 0, 0, 24529),
-(28757, 0, 0, 28758),
-(35029, 0, 0, 35060),
-(35030, 0, 0, 35061),
-(35691, 0, 0, 35696),
-(35692, 0, 0, 35696),
-(35693, 0, 0, 35696),
-(56314, 0, 0, 57447),
-(56314, 1, 0, 57485),
-(56315, 0, 0, 57452),
-(56315, 1, 0, 57484),
-(56316, 0, 0, 57453),
-(56316, 1, 0, 57483),
-(56317, 0, 0, 57457),
-(56317, 1, 0, 57482),
-(56318, 0, 0, 57458),
-(56318, 1, 0, 57475),
-(23785, 0, 416, 23759),
-(23822, 0, 416, 23826),
-(23823, 0, 416, 23827),
-(23824, 0, 416, 23828),
-(23825, 0, 416, 23829),
-(23785, 0, 417, 23762),
-(23822, 0, 417, 23837),
-(23823, 0, 417, 23838),
-(23824, 0, 417, 23839),
-(23825, 0, 417, 23840),
-(23785, 0, 1860, 23760),
-(23822, 0, 1860, 23841),
-(23823, 0, 1860, 23842),
-(23824, 0, 1860, 23843),
-(23825, 0, 1860, 23844),
-(23785, 0, 1863, 23761),
-(23822, 0, 1863, 23833),
-(23823, 0, 1863, 23834),
-(23824, 0, 1863, 23835),
-(23825, 0, 1863, 23836),
-(23785, 0, 17252, 35702),
-(23822, 0, 17252, 35703),
-(23823, 0, 17252, 35704),
-(23824, 0, 17252, 35705),
-(23825, 0, 17252, 35706),
-(58228, 0, 19668, 57989);
-
+(19028,0,0,25228),
+(19578,0,0,19579),
+(20895,0,0,24529),
+(28757,0,0,28758),
+(35029,0,0,35060),
+(35030,0,0,35061),
+(35691,0,0,35696),
+(35692,0,0,35696),
+(35693,0,0,35696),
+(56314,0,0,57447),
+(56314,1,0,57485),
+(56315,0,0,57452),
+(56315,1,0,57484),
+(56316,0,0,57453),
+(56316,1,0,57483),
+(56317,0,0,57457),
+(56317,1,0,57482),
+(56318,0,0,57458),
+(56318,1,0,57475),
+(23785,0,416,23759),
+(23822,0,416,23826),
+(23823,0,416,23827),
+(23824,0,416,23828),
+(23825,0,416,23829),
+(23785,0,417,23762),
+(23822,0,417,23837),
+(23823,0,417,23838),
+(23824,0,417,23839),
+(23825,0,417,23840),
+(23785,0,1860,23760),
+(23822,0,1860,23841),
+(23823,0,1860,23842),
+(23824,0,1860,23843),
+(23825,0,1860,23844),
+(23785,0,1863,23761),
+(23822,0,1863,23833),
+(23823,0,1863,23834),
+(23824,0,1863,23835),
+(23825,0,1863,23836),
+(23785,0,17252,35702),
+(23822,0,17252,35703),
+(23823,0,17252,35704),
+(23824,0,17252,35705),
+(23825,0,17252,35706),
+(58228,0,19668,57989);
 /*!40000 ALTER TABLE `spell_pet_auras` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -17706,19 +18559,18 @@ INSERT INTO `spell_proc_event` VALUES
 (75481, 0x00,  0, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0.000000, 0.000000, 45),
 (75490, 0x7F,  0, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0.000000, 0.000000,  0),
 (75495, 0x7F,  0, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0.000000, 0.000000,  0);
-
 /*!40000 ALTER TABLE `spell_proc_event` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --
--- Table structure for spell_proc_item_enchant
+-- Table structure for table `spell_proc_item_enchant`
 --
 
 DROP TABLE IF EXISTS `spell_proc_item_enchant`;
 CREATE TABLE `spell_proc_item_enchant` (
-  `entry` mediumint unsigned NOT NULL,
-  `ppmRate` float NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
+  `entry` mediumint(8) unsigned NOT NULL,
+  `ppmRate` float NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -17727,7 +18579,7 @@ CREATE TABLE `spell_proc_item_enchant` (
 
 LOCK TABLES `spell_proc_item_enchant` WRITE;
 /*!40000 ALTER TABLE `spell_proc_item_enchant` DISABLE KEYS */;
-INSERT INTO `spell_proc_item_enchant` (`entry`, `ppmRate`) VALUES
+INSERT INTO `spell_proc_item_enchant` VALUES
 (8034, 9),        -- Frostbrand Weapon
 (8680, 8.5714),   -- Instant Poison
 (13218, 21.4286), -- Wound Poison
@@ -17746,9 +18598,9 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `spell_script_target`;
 CREATE TABLE `spell_script_target` (
   `entry` mediumint(8) unsigned NOT NULL,
-  `type` tinyint(3) unsigned NOT NULL default '0',
-  `targetEntry` mediumint(8) unsigned NOT NULL default '0',
-  `inverseEffectMask` mediumint(8) unsigned NOT NULL default '0',
+  `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `targetEntry` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `inverseEffectMask` mediumint(8) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `entry_type_target` (`entry`,`type`,`targetEntry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='Spell System';
 
@@ -17761,20 +18613,19 @@ LOCK TABLES `spell_script_target` WRITE;
 /*!40000 ALTER TABLE `spell_script_target` ENABLE KEYS */;
 UNLOCK TABLES;
 
-
 --
 -- Table structure for table `spell_target_position`
 --
 
 DROP TABLE IF EXISTS `spell_target_position`;
 CREATE TABLE `spell_target_position` (
-  `id` mediumint(8) unsigned NOT NULL default '0' COMMENT 'Identifier',
-  `target_map` smallint(5) unsigned NOT NULL default '0',
-  `target_position_x` float NOT NULL default '0',
-  `target_position_y` float NOT NULL default '0',
-  `target_position_z` float NOT NULL default '0',
-  `target_orientation` float NOT NULL default '0',
-  PRIMARY KEY  (`id`)
+  `id` mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'Identifier',
+  `target_map` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `target_position_x` float NOT NULL DEFAULT '0',
+  `target_position_y` float NOT NULL DEFAULT '0',
+  `target_position_z` float NOT NULL DEFAULT '0',
+  `target_orientation` float NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Spell System';
 
 --
@@ -17814,6 +18665,7 @@ CREATE TABLE `spell_template` (
 --
 -- Dumping data for table `spell_template`
 --
+
 LOCK TABLES `spell_template` WRITE;
 /*!40000 ALTER TABLE `spell_template` DISABLE KEYS */;
 INSERT INTO `spell_template` VALUES
@@ -17863,9 +18715,9 @@ DROP TABLE IF EXISTS `spell_threat`;
 CREATE TABLE `spell_threat` (
   `entry` mediumint(8) unsigned NOT NULL,
   `Threat` smallint(6) NOT NULL,
-  `multiplier` float NOT NULL default '1' COMMENT 'threat multiplier for damage/healing',
-  `ap_bonus` float NOT NULL default '0' COMMENT 'additional threat bonus from attack power',
-  PRIMARY KEY  (`entry`)
+  `multiplier` float NOT NULL DEFAULT '1' COMMENT 'threat multiplier for damage/healing',
+  `ap_bonus` float NOT NULL DEFAULT '0' COMMENT 'additional threat bonus from attack power',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
 
 --
@@ -17989,650 +18841,15 @@ INSERT INTO `spell_threat` VALUES
 UNLOCK TABLES;
 
 --
--- Table structure for table `instance_encounters`
---
-
-DROP TABLE IF EXISTS `instance_encounters`;
-CREATE TABLE `instance_encounters` (
-  `entry` int(10) unsigned NOT NULL COMMENT 'Unique entry from DungeonEncounter.dbc',
-  `creditType` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `creditEntry` int(10) unsigned NOT NULL DEFAULT '0',
-  `lastEncounterDungeon` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'If not 0, LfgDungeon.dbc entry for the instance it is last encounter in',
-  PRIMARY KEY (`entry`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
-
---
--- Dumping data for table `instance_encounters`
---
-
-LOCK TABLES `instance_encounters` WRITE;
-/*!40000 ALTER TABLE `instance_encounters` DISABLE KEYS */;
-INSERT INTO `instance_encounters` VALUES
-(161,0,644,0),
-(162,0,643,0),
-(163,0,1763,0),
-(164,0,646,0),
-(165,0,645,0),
-(166,0,647,0),
-(167,0,639,6),
-(201,0,18371,0),
-(202,0,18373,149),
-(203,0,18341,0),
-(204,0,18343,0),
-(205,0,18344,148),
-(206,0,18472,0),
-(207,0,18473,150),
-(208,0,18731,0),
-(209,0,18667,0),
-(210,0,18732,0),
-(211,0,18708,151),
-(212,0,29309,0),
-(213,0,29308,0),
-(214,0,29310,0),
-(215,0,29311,218),
-(216,0,28684,0),
-(217,0,28921,0),
-(218,0,29120,204),
-(219,0,4887,0),
-(220,0,4831,0),
-(221,0,6243,0),
-(222,0,12902,0),
-(224,0,4830,0),
-(225,0,4832,0),
-(226,0,4829,10),
-(227,0,9018,30),
-(228,0,9025,0),
-(229,0,9319,0),
-(230,0,10096,0),
-(231,0,9024,0),
-(232,0,9017,0),
-(233,0,9041,0),
-(234,0,9056,0),
-(235,0,9016,0),
-(236,0,9033,0),
-(237,0,8983,0),
-(238,0,9537,0),
-(239,0,9502,0),
-(240,0,9543,0),
-(241,0,9499,0),
-(242,0,9156,0),
-(243,0,9035,0),
-(244,0,9938,0),
-(245,0,9019,276),
-(246,0,18371,0),
-(247,0,18373,178),
-(248,0,18341,0),
-(249,0,18343,0),
-(250,0,22930,0),
-(251,0,18344,179),
-(252,0,18472,0),
-(253,0,23035,0),
-(254,0,18473,180),
-(255,0,18731,0),
-(256,0,18667,0),
-(257,0,18732,0),
-(258,0,18708,181),
-(259,0,29309,0),
-(260,0,29308,0),
-(261,0,29310,0),
-(262,0,30258,0),
-(263,0,29311,219),
-(264,0,28684,0),
-(265,0,28921,0),
-(266,0,29120,241),
-(267,0,9196,0),
-(268,0,9236,0),
-(269,0,9237,0),
-(270,0,10596,0),
-(271,0,10584,0),
-(272,0,9736,0),
-(273,0,10268,0),
-(274,0,10220,0),
-(275,0,9568,32),
-(276,0,9816,0),
-(277,0,10264,0),
-(278,0,10429,0),
-(279,0,10430,0),
-(280,0,10363,44),
-(281,0,18096,170),
-(282,0,18096,183),
-(283,0,17862,0),
-(284,0,17862,0),
-(285,0,17848,0),
-(286,0,17848,0),
-(287,0,17879,0),
-(288,0,17879,0),
-(289,0,17880,0),
-(290,0,17880,0),
-(291,0,17881,171),
-(292,0,17881,182),
-(293,0,26529,0),
-(294,0,26530,0),
-(295,0,26532,0),
-(296,1,58630,209),
-(297,0,26529,0),
-(298,0,26530,0),
-(299,0,26532,0),
-(300,1,58630,210),
-(301,0,17941,0),
-(302,0,17991,0),
-(303,0,17942,140),
-(304,0,17941,0),
-(305,0,17991,0),
-(306,0,17942,184),
-(314,0,17797,0),
-(315,0,17797,0),
-(316,0,17796,0),
-(317,0,17796,0),
-(318,0,17798,147),
-(319,0,17798,185),
-(320,0,17770,0),
-(321,0,17770,0),
-(322,0,18105,0),
-(323,0,18105,0),
-(329,0,17826,0),
-(330,0,17826,0),
-(331,0,17882,146),
-(332,0,17882,186),
-(334,1,68572,0),
-(336,1,68572,0),
-(338,1,68574,0),
-(339,1,68574,0),
-(340,1,68663,245),
-(341,1,68663,249),
-(343,0,11490,0),
-(344,0,13280,0),
-(345,0,14327,0),
-(346,0,11492,34),
-(347,0,11488,0),
-(348,0,11487,0),
-(349,0,11496,0),
-(350,0,11489,0),
-(361,0,11486,36),
-(362,0,14326,0),
-(363,0,14322,0),
-(364,0,14321,0),
-(365,0,14323,0),
-(366,0,14325,0),
-(367,0,14324,0),
-(368,0,11501,38),
-(369,0,26630,0),
-(370,0,26630,0),
-(371,0,26631,0),
-(372,0,26631,0),
-(373,0,27483,0),
-(374,0,27483,0),
-(375,1,61863,214),
-(376,1,61863,215),
-(378,0,7079,0),
-(379,0,7361,0),
-(380,0,6235,0),
-(381,0,6229,0),
-(382,0,7800,14),
-(383,0,29304,0),
-(384,0,29304,0),
-(385,0,29573,0),
-(386,0,29573,0),
-(387,0,29305,0),
-(388,0,29305,0),
-(389,0,29932,0),
-(390,0,29306,216),
-(391,0,29306,217),
-(392,0,17306,0),
-(393,0,17306,0),
-(394,0,17308,0),
-(395,0,17308,0),
-(396,0,17537,136),
-(397,0,17537,188),
-(401,0,17381,0),
-(402,0,17381,0),
-(403,0,17380,0),
-(404,0,17380,0),
-(405,0,17377,137),
-(406,0,17377,187),
-(407,0,16807,0),
-(408,0,16807,0),
-(409,0,20923,0),
-(410,0,16809,0),
-(411,0,16809,0),
-(412,0,16808,138),
-(413,0,16808,189),
-(414,0,24723,0),
-(415,0,24723,0),
-(416,0,24744,0),
-(417,0,24744,0),
-(418,0,24560,0),
-(419,0,24560,0),
-(420,0,24664,198),
-(421,0,24664,201),
-(422,0,13282,0),
-(423,0,12258,26),
-(424,0,12236,272),
-(425,0,12225,0),
-(426,0,12203,0),
-(427,0,13601,0),
-(428,0,13596,0),
-(429,0,12201,273),
-(430,0,11517,0),
-(431,0,11520,4),
-(432,0,11518,0),
-(433,0,11519,0),
-(434,0,7355,0),
-(435,0,7357,0),
-(436,0,8567,0),
-(437,0,7358,20),
-(438,0,6168,0),
-(439,0,4424,0),
-(440,0,4428,0),
-(441,0,4420,0),
-(443,0,4421,16),
-(444,0,3983,0),
-(445,0,4543,18),
-(446,0,3974,0),
-(447,0,6487,165),
-(448,0,3975,163),
-(449,0,4542,0),
-(450,0,3977,164),
-(451,0,10506,0),
-(452,0,10503,0),
-(453,0,11622,0),
-(454,0,10433,0),
-(455,0,10432,0),
-(456,0,10508,0),
-(457,0,10505,0),
-(458,0,11261,0),
-(459,0,10901,0),
-(460,0,10507,0),
-(461,0,10504,0),
-(462,0,10502,0),
-(463,0,1853,2),
-(464,0,3914,0),
-(465,0,3886,0),
-(466,0,3887,0),
-(467,0,4278,0),
-(468,0,4279,0),
-(469,0,4274,0),
-(470,0,3927,0),
-(471,0,4275,8),
-(472,0,10516,0),
-(473,0,10558,0),
-(474,0,10808,0),
-(475,0,10997,0),
-(476,0,11032,0),
-(477,0,10811,0),
-(478,0,10813,40),
-(479,0,10436,0),
-(480,0,10437,0),
-(481,0,10438,0),
-(482,0,10435,0),
-(483,0,10439,0),
-(484,0,10440,274),
-(485,0,8580,0),
-(486,0,5721,0),
-(487,0,5720,0),
-(488,0,5710,0),
-(490,0,5719,0),
-(491,0,5722,0),
-(492,0,8443,0),
-(493,0,5709,28),
-(494,0,20870,0),
-(495,0,20870,0),
-(496,0,20885,0),
-(497,0,20885,0),
-(498,0,20886,0),
-(499,0,20886,0),
-(500,0,20912,174),
-(501,0,20912,190),
-(502,0,17976,0),
-(504,0,17976,0),
-(505,0,17975,0),
-(506,0,17975,0),
-(507,0,17978,0),
-(508,0,17978,0),
-(509,0,17980,0),
-(510,0,17980,0),
-(511,0,17977,173),
-(512,0,17977,191),
-(513,0,19219,0),
-(514,0,19219,0),
-(515,0,19221,0),
-(516,0,19221,0),
-(517,0,19220,172),
-(518,0,19220,192),
-(519,0,26796,0),
-(520,0,26731,0),
-(521,0,26731,0),
-(522,0,26763,0),
-(523,0,26763,0),
-(524,0,26794,0),
-(525,0,26794,0),
-(526,0,26723,225),
-(527,0,26723,226),
-(528,0,27654,0),
-(529,0,27654,0),
-(530,0,27447,0),
-(531,0,27447,0),
-(532,0,27655,0),
-(533,0,27655,0),
-(534,0,27656,206),
-(535,0,27656,211),
-(536,0,1696,0),
-(537,0,1666,0),
-(538,0,1717,0),
-(539,0,1716,0),
-(540,0,1663,12),
-(541,0,29315,0),
-(542,0,29315,0),
-(543,0,29316,0),
-(544,0,29316,0),
-(545,0,31134,220),
-(546,0,31134,221),
-(547,0,6910,0),
-(548,0,6906,0),
-(549,0,7228,0),
-(551,0,7206,0),
-(552,0,7291,0),
-(553,0,4854,0),
-(554,0,2748,22),
-(555,0,28586,0),
-(556,0,28586,0),
-(557,0,28587,0),
-(558,0,28587,0),
-(559,0,28546,0),
-(560,0,28546,0),
-(561,0,28923,207),
-(562,0,28923,212),
-(563,0,27977,0),
-(564,0,27977,0),
-(565,0,27975,0),
-(566,0,27975,0),
-(567,1,59046,0),
-(568,1,59046,0),
-(569,0,27978,208),
-(570,0,27978,213),
-(571,0,23953,0),
-(572,0,23953,0),
-(573,0,24201,0),
-(574,0,24201,0),
-(575,0,23954,202),
-(576,0,23954,242),
-(577,0,26668,0),
-(578,0,26668,0),
-(579,0,26687,0),
-(580,0,26687,0),
-(581,0,26693,0),
-(582,0,26693,0),
-(583,0,26861,203),
-(584,0,26861,205),
-(585,0,3671,0),
-(586,0,3669,0),
-(587,0,3653,0),
-(588,0,3670,0),
-(589,0,3674,0),
-(590,0,3673,0),
-(591,0,5775,0),
-(592,0,3654,1),
-(593,0,7795,0),
-(594,0,7273,0),
-(595,0,8127,0),
-(596,0,7272,0),
-(597,0,7271,0),
-(598,0,7796,0),
-(599,0,7275,0),
-(600,0,7267,24),
-(601,0,22887,0),
-(602,0,22898,0),
-(603,0,22841,0),
-(604,0,22871,0),
-(605,0,22948,0),
-(606,0,23420,0),
-(607,0,22947,0),
-(608,0,23426,0),
-(609,0,22917,196),
-(610,0,12435,0),
-(611,0,13020,0),
-(612,0,12017,0),
-(613,0,11983,0),
-(614,0,14601,0),
-(615,0,11981,0),
-(616,0,14020,0),
-(617,0,11583,50),
-(618,0,17767,0),
-(619,0,17808,0),
-(620,0,17888,0),
-(621,0,17842,0),
-(622,0,17968,195),
-(623,0,21216,0),
-(624,0,21217,0),
-(625,0,21215,0),
-(626,0,21214,0),
-(627,0,21213,0),
-(628,0,21212,194),
-(629,0,34797,0),
-(630,0,34797,0),
-(631,0,34797,0),
-(632,0,34797,0),
-(633,0,34780,0),
-(634,0,34780,0),
-(635,0,34780,0),
-(636,0,34780,0),
-(637,1,68184,0),
-(638,1,68184,0),
-(639,1,68184,0),
-(640,1,68184,0),
-(641,0,34496,0),
-(642,0,34496,0),
-(643,0,34496,0),
-(644,0,34496,0),
-(645,0,34564,246),
-(646,0,34564,248),
-(647,0,34564,247),
-(648,0,34564,250),
-(649,0,18831,0),
-(650,0,19044,177),
-(651,0,17257,176),
-(652,0,15550,0),
-(653,0,15687,0),
-(654,0,16457,0),
-(655,0,16812,0),
-(656,0,15691,0),
-(657,0,15688,0),
-(658,0,16524,0),
-(659,0,15689,0),
-(660,0,22520,0),
-(661,0,15690,175),
-(662,0,17225,0),
-(663,0,12118,0),
-(664,0,11982,0),
-(665,0,12259,0),
-(666,0,12057,0),
-(667,0,12264,0),
-(668,0,12056,0),
-(669,0,12098,0),
-(670,0,11988,0),
-(671,0,12018,0),
-(672,0,11502,48),
-(673,0,15956,0),
-(674,0,15956,0),
-(677,0,15953,0),
-(678,0,15953,0),
-(679,0,15952,0),
-(680,0,15952,0),
-(681,0,15954,0),
-(682,0,15954,0),
-(683,0,15936,0),
-(684,0,15936,0),
-(685,0,16011,0),
-(686,0,16011,0),
-(687,0,16061,0),
-(689,0,16061,0),
-(690,0,16060,0),
-(691,0,16060,0),
-(692,1,59450,0),
-(693,1,59450,0),
-(694,0,16028,0),
-(695,0,16028,0),
-(696,0,15931,0),
-(697,0,15931,0),
-(698,0,15932,0),
-(699,0,15932,0),
-(700,0,15928,0),
-(701,0,15928,0),
-(702,0,15989,0),
-(703,0,15989,0),
-(704,0,15990,159),
-(706,0,15990,227),
-(707,0,10184,46),
-(708,0,10184,257),
-(709,0,15263,0),
-(710,0,15544,0),
-(711,0,15516,0),
-(712,0,15510,0),
-(713,0,15299,0),
-(714,0,15509,0),
-(715,0,15275,0),
-(716,0,15517,0),
-(717,0,15727,161),
-(718,0,15348,0),
-(719,0,15341,0),
-(720,0,15340,0),
-(721,0,15370,0),
-(722,0,15369,0),
-(723,0,15339,160),
-(724,0,24892,0),
-(725,0,24882,0),
-(726,0,25038,0),
-(727,0,25165,0),
-(728,0,25840,0),
-(729,0,25315,199),
-(730,0,19514,0),
-(731,0,19516,0),
-(732,0,18805,0),
-(733,0,19622,193),
-(734,0,28859,223),
-(735,0,28859,237),
-(736,0,30452,0),
-(737,0,30452,0),
-(738,0,30451,0),
-(739,0,30451,0),
-(740,0,30449,0),
-(741,0,30449,0),
-(742,0,28860,224),
-(743,0,28860,238),
-(744,0,33113,0),
-(745,0,33118,0),
-(746,0,33186,0),
-(747,0,33293,0),
-(748,1,65195,0),
-(749,0,32930,0),
-(750,0,33515,0),
-(751,1,64899,0),
-(752,1,64985,0),
-(753,1,65074,0),
-(754,0,33432,0),
-(755,0,33271,0),
-(756,0,33288,0),
-(757,0,32871,243),
-(758,0,33113,0),
-(759,0,33118,0),
-(760,0,33186,0),
-(761,0,33293,0),
-(762,1,65195,0),
-(763,0,32930,0),
-(764,0,33515,0),
-(765,1,64899,0),
-(766,1,64985,0),
-(767,1,65074,0),
-(768,0,33432,0),
-(769,0,33271,0),
-(770,0,33288,0),
-(771,0,32871,244),
-(772,0,31125,0),
-(773,0,31125,0),
-(774,0,33993,0),
-(775,0,33993,0),
-(776,0,35013,0),
-(777,0,35013,0),
-(778,0,23574,0),
-(779,0,23576,0),
-(780,0,23578,0),
-(781,0,23577,0),
-(782,0,24239,0),
-(783,0,23863,197),
-(784,0,14507,0),
-(785,0,14517,0),
-(786,0,14510,0),
-(787,0,11382,0),
-(788,0,15083,0),
-(789,0,14509,0),
-(790,0,15114,0),
-(791,0,14515,0),
-(792,0,11380,0),
-(793,0,14834,42),
-(829,0,36497,0),
-(830,0,36497,0),
-(831,0,36502,251),
-(832,0,36502,252),
-(833,0,36494,0),
-(834,0,36494,0),
-(835,0,36476,0),
-(836,0,36476,0),
-(837,0,36658,253),
-(838,0,36658,254),
-(839,0,38113,0),
-(840,0,38113,0),
-(841,0,38112,0),
-(842,0,38112,0),
-(843,1,72830,255),
-(844,1,72830,256),
-(845,0,36612,0),
-(846,0,36855,0),
-(847,1,72959,0),
-(848,0,37813,0),
-(849,0,36626,0),
-(850,0,36627,0),
-(851,0,36678,0),
-(852,0,37970,0),
-(853,0,37955,0),
-(854,1,72706,0),
-(855,0,36853,0),
-(856,0,36597,279),
-(857,0,36612,0),
-(858,0,36855,0),
-(859,1,72959,0),
-(860,0,37813,0),
-(861,0,36626,0),
-(862,0,36627,0),
-(863,0,36678,0),
-(864,0,37970,0),
-(865,0,37955,0),
-(866,1,72706,0),
-(867,0,36853,0),
-(868,0,36597,280),
-(883,0,4422,0),
-(885,0,38433,239),
-(886,0,38433,240),
-(887,0,39863,293),
-(888,0,39863,294),
-(889,0,39751,0),
-(890,0,39751,0),
-(891,0,39747,0),
-(892,0,39747,0),
-(893,0,39746,0),
-(894,0,39746,0);
-/*!40000 ALTER TABLE `instance_encounters` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `transports`
 --
 
 DROP TABLE IF EXISTS `transports`;
 CREATE TABLE `transports` (
-  `entry` mediumint(8) unsigned NOT NULL default '0',
+  `entry` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `name` text,
-  `period` mediumint(8) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`entry`)
+  `period` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Transports';
 
 --
@@ -18647,18 +18864,20 @@ UNLOCK TABLES;
 --
 -- Table structure for table `vehicle_accessory`
 --
-DROP TABLE IF EXISTS vehicle_accessory;
+
+DROP TABLE IF EXISTS `vehicle_accessory`;
 CREATE TABLE `vehicle_accessory` (
-  `vehicle_entry` int(10) UNSIGNED NOT NULL COMMENT 'entry of the npc who has some accessory as vehicle',
-  `seat` mediumint(8) UNSIGNED NOT NULL COMMENT 'onto which seat shall the passenger be boarded',
-  `accessory_entry` int(10) UNSIGNED NOT NULL COMMENT 'entry of the passenger that is to be boarded',
+  `vehicle_entry` int(10) unsigned NOT NULL COMMENT 'entry of the npc who has some accessory as vehicle',
+  `seat` mediumint(8) unsigned NOT NULL COMMENT 'onto which seat shall the passenger be boarded',
+  `accessory_entry` int(10) unsigned NOT NULL COMMENT 'entry of the passenger that is to be boarded',
   `comment` varchar(255) NOT NULL,
-  PRIMARY KEY  (`vehicle_entry`, `seat`)
+  PRIMARY KEY (`vehicle_entry`,`seat`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Vehicle Accessory (passengers that are auto-boarded onto a vehicle)';
 
 --
 -- Dumping data for table `vehicle_accessory`
 --
+
 LOCK TABLES `vehicle_accessory` WRITE;
 /*!40000 ALTER TABLE `vehicle_accessory` DISABLE KEYS */;
 /*!40000 ALTER TABLE `vehicle_accessory` ENABLE KEYS */;
@@ -18671,8 +18890,8 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `world_template`;
 CREATE TABLE `world_template` (
   `map` smallint(5) unsigned NOT NULL,
-  `ScriptName` varchar(128) NOT NULL default '',
-  PRIMARY KEY  (`map`)
+  `ScriptName` varchar(128) NOT NULL DEFAULT '',
+  PRIMARY KEY (`map`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --
@@ -18683,8 +18902,8 @@ LOCK TABLES `world_template` WRITE;
 /*!40000 ALTER TABLE `world_template` DISABLE KEYS */;
 /*!40000 ALTER TABLE `world_template` ENABLE KEYS */;
 UNLOCK TABLES;
-
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
@@ -18693,4 +18912,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2008-03-30 15:34:54
+-- Dump completed on 2013-05-13 10:19:04

--- a/sql/realmd.sql
+++ b/sql/realmd.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.11
+-- MySQL dump 10.13
 --
 -- Host: localhost    Database: realmd
 -- ------------------------------------------------------
--- Server version    5.0.45-Debian_1ubuntu3.1-log
+-- Server version	5.5.15
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -21,7 +21,7 @@
 
 DROP TABLE IF EXISTS `realmd_db_version`;
 CREATE TABLE `realmd_db_version` (
-  `required_10008_01_realmd_realmd_db_version` bit(1) default NULL
+  `required_10008_01_realmd_realmd_db_version` bit(1) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Last applied sql update to DB';
 
 --
@@ -41,27 +41,27 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `account`;
 CREATE TABLE `account` (
-  `id` int(11) unsigned NOT NULL auto_increment COMMENT 'Identifier',
-  `username`      varchar(32) NOT NULL default '',
-  `sha_pass_hash` varchar(40) NOT NULL default '',
-  `gmlevel` tinyint(3) unsigned NOT NULL default '0',
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Identifier',
+  `username` varchar(32) NOT NULL DEFAULT '',
+  `sha_pass_hash` varchar(40) NOT NULL DEFAULT '',
+  `gmlevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `sessionkey` longtext,
   `v` longtext,
   `s` longtext,
   `email` text,
-  `joindate` timestamp NOT NULL default CURRENT_TIMESTAMP,
-  `last_ip` varchar(30) NOT NULL default '0.0.0.0',
-  `failed_logins` int(11) unsigned NOT NULL default '0',
-  `locked` tinyint(3) unsigned NOT NULL default '0',
-  `last_login` timestamp NOT NULL default '0000-00-00 00:00:00',
-  `active_realm_id` int(11) unsigned NOT NULL default '0',
-  `expansion` tinyint(3) unsigned NOT NULL default '0',
-  `mutetime` bigint(40) unsigned NOT NULL default '0',
-  `locale` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`id`),
+  `joindate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_ip` varchar(30) NOT NULL DEFAULT '0.0.0.0',
+  `failed_logins` int(11) unsigned NOT NULL DEFAULT '0',
+  `locked` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `last_login` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `active_realm_id` int(11) unsigned NOT NULL DEFAULT '0',
+  `expansion` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `mutetime` bigint(40) unsigned NOT NULL DEFAULT '0',
+  `locale` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
   UNIQUE KEY `idx_username` (`username`),
   KEY `idx_gmlevel` (`gmlevel`)
-) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci ROW_FORMAT=DYNAMIC COMMENT='Account System';
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Account System';
 
 --
 -- Dumping data for table `account`
@@ -83,13 +83,13 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `account_banned`;
 CREATE TABLE `account_banned` (
-  `id` int(11) NOT NULL default '0' COMMENT 'Account id',
-  `bandate` bigint(40) NOT NULL default '0',
-  `unbandate` bigint(40) NOT NULL default '0',
+  `id` int(11) NOT NULL DEFAULT '0' COMMENT 'Account id',
+  `bandate` bigint(40) NOT NULL DEFAULT '0',
+  `unbandate` bigint(40) NOT NULL DEFAULT '0',
   `bannedby` varchar(50) NOT NULL,
   `banreason` varchar(255) NOT NULL,
-  `active` tinyint(4) NOT NULL default '1',
-  PRIMARY KEY  (`id`,`bandate`)
+  `active` tinyint(4) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`id`,`bandate`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Ban List';
 
 --
@@ -107,12 +107,12 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `ip_banned`;
 CREATE TABLE `ip_banned` (
-  `ip` varchar(32) NOT NULL default '0.0.0.0',
+  `ip` varchar(32) NOT NULL DEFAULT '0.0.0.0',
   `bandate` bigint(40) NOT NULL,
   `unbandate` bigint(40) NOT NULL,
-  `bannedby` varchar(50) NOT NULL default '[Console]',
-  `banreason` varchar(255) NOT NULL default 'no reason',
-  PRIMARY KEY  (`ip`,`bandate`)
+  `bannedby` varchar(50) NOT NULL DEFAULT '[Console]',
+  `banreason` varchar(255) NOT NULL DEFAULT 'no reason',
+  PRIMARY KEY (`ip`,`bandate`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Banned IPs';
 
 --
@@ -130,11 +130,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `realmcharacters`;
 CREATE TABLE `realmcharacters` (
-  `realmid` int(11) unsigned NOT NULL default '0',
+  `realmid` int(11) unsigned NOT NULL DEFAULT '0',
   `acctid` bigint(20) unsigned NOT NULL,
-  `numchars` tinyint(3) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`realmid`,`acctid`),
-  KEY (acctid)
+  `numchars` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`realmid`,`acctid`),
+  KEY `acctid` (`acctid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Realm Character Tracker';
 
 --
@@ -152,17 +152,17 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `realmlist`;
 CREATE TABLE `realmlist` (
-  `id` int(11) unsigned NOT NULL auto_increment,
-  `name` varchar(32) NOT NULL default '',
-  `address` varchar(32) NOT NULL default '127.0.0.1',
-  `port` int(11) NOT NULL default '8085',
-  `icon` tinyint(3) unsigned NOT NULL default '0',
-  `realmflags` tinyint(3) unsigned NOT NULL default '2' COMMENT 'Supported masks: 0x1 (invalid, not show in realm list), 0x2 (offline, set by mangosd), 0x4 (show version and build), 0x20 (new players), 0x40 (recommended)',
-  `timezone` tinyint(3) unsigned NOT NULL default '0',
-  `allowedSecurityLevel` tinyint(3) unsigned NOT NULL default '0',
-  `population` float unsigned NOT NULL default '0',
-  `realmbuilds` varchar(64) NOT NULL default '',
-  PRIMARY KEY  (`id`),
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) NOT NULL DEFAULT '',
+  `address` varchar(32) NOT NULL DEFAULT '127.0.0.1',
+  `port` int(11) NOT NULL DEFAULT '8085',
+  `icon` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `realmflags` tinyint(3) unsigned NOT NULL DEFAULT '2' COMMENT 'Supported masks: 0x1 (invalid, not show in realm list), 0x2 (offline, set by mangosd), 0x4 (show version and build), 0x20 (new players), 0x40 (recommended)',
+  `timezone` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `allowedSecurityLevel` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `population` float unsigned NOT NULL DEFAULT '0',
+  `realmbuilds` varchar(64) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
   UNIQUE KEY `idx_name` (`name`)
 ) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Realm System';
 
@@ -184,11 +184,11 @@ UNLOCK TABLES;
 DROP TABLE IF EXISTS `uptime`;
 CREATE TABLE `uptime` (
   `realmid` int(11) unsigned NOT NULL,
-  `starttime` bigint(20) unsigned NOT NULL default '0',
-  `startstring` varchar(64) NOT NULL default '',
-  `uptime` bigint(20) unsigned NOT NULL default '0',
-  `maxplayers` smallint(5) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`realmid`,`starttime`)
+  `starttime` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `startstring` varchar(64) NOT NULL DEFAULT '',
+  `uptime` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `maxplayers` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`realmid`,`starttime`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Uptime system';
 
 --
@@ -209,4 +209,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2008-01-10 11:37:06
+-- Dump completed on 2013-05-13 12:01:37


### PR DESCRIPTION
The main reason for this was because classic has updated the sql formatting and manually syncing would be a pain so redumping from master->tbc->classic->cata is easier.

Only the formatting was changed. The values were not changed at all.

mysqldump was used however the following additional manual modifications had to be done:
- split insert values into multiple rows
- remove autoincrement values from insert values
- preserve our custom insert formatting including comments
- remove some `/*!40101 SET character_set_client = utf8 */` and related stuff around table inserts
