### PR TITLE
Fix possible freeze if opcode.txt file does not exist on .debug send opcode

### DIFF
--- a/src/game/Level2.cpp
+++ b/src/game/Level2.cpp
@@ -3921,19 +3921,18 @@ bool ChatHandler::HandleWpImportCommand(char* args)
     if (!arg_str)
         return false;
 
+    std::ifstream stream(arg_str);
+    if (!stream.is_open())
+        return false;
+
     std::string line;
-    std::ifstream infile(arg_str);
-    if (infile.is_open())
+    while (getline(stream, line))
     {
-        while (! infile.eof())
-        {
-            getline(infile, line);
-            // cout << line << endl;
-            QueryResult* result = WorldDatabase.Query(line.c_str());
-            delete result;
-        }
-        infile.close();
+        QueryResult* result = WorldDatabase.Query(line.c_str());
+        delete result;
     }
+    stream.close();
+
     PSendSysMessage(LANG_WAYPOINT_IMPORTED);
 
     return true;

--- a/src/game/debugcmds.cpp
+++ b/src/game/debugcmds.cpp
@@ -122,58 +122,60 @@ bool ChatHandler::HandleDebugSendOpcodeCommand(char* /*args*/)
     if (!unit || (unit->GetTypeId() != TYPEID_PLAYER))
         unit = m_session->GetPlayer();
 
-    std::ifstream ifs("opcode.txt");
-    if (ifs.bad())
+    std::ifstream stream("opcode.txt");
+    if (!stream.is_open())
         return false;
 
     uint32 opcode;
-    ifs >> opcode;
+    if (!stream >> opcode)
+    {
+        stream.close();
+        return false;
+    }
 
     WorldPacket data(Opcodes(opcode), 0);
 
-    while (!ifs.eof())
+    std::string type;
+    while (std::getline(stream, type))
     {
-        std::string type;
-        ifs >> type;
-
         if (type == "")
             break;
 
         if (type == "uint8")
         {
-            uint16 val1;
-            ifs >> val1;
-            data << uint8(val1);
+            uint16 value;
+            stream >> value;
+            data << uint8(value);
         }
         else if (type == "uint16")
         {
-            uint16 val2;
-            ifs >> val2;
-            data << val2;
+            uint16 value;
+            stream >> value;
+            data << value;
         }
         else if (type == "uint32")
         {
-            uint32 val3;
-            ifs >> val3;
-            data << val3;
+            uint32 value;
+            stream >> value;
+            data << value;
         }
         else if (type == "uint64")
         {
-            uint64 val4;
-            ifs >> val4;
-            data << val4;
+            uint64 value;
+            stream >> value;
+            data << value;
         }
         else if (type == "float")
         {
-            float val5;
-            ifs >> val5;
-            data << val5;
+            float value;
+            stream >> value;
+            data << value;
         }
         else if (type == "string")
         {
-            std::string val6;
-            ifs >> val6;
-            data << val6;
+            std::string value;
+            stream >> value;
+            data << value;
         }
         else if (type == "pguid")
         {
@@ -185,11 +187,15 @@ bool ChatHandler::HandleDebugSendOpcodeCommand(char* /*args*/)
             break;
         }
     }
-    ifs.close();
+    stream.close();
+
     DEBUG_LOG("Sending opcode %u, %s", data.GetOpcode(), data.GetOpcodeName());
+
     data.hexlike();
     ((Player*)unit)->GetSession()->SendPacket(&data);
+
     PSendSysMessage(LANG_COMMAND_OPCODESENT, data.GetOpcode(), unit->GetName());
+
     return true;
 }
 


### PR DESCRIPTION
I am no ifstream expert but I think handling it like this looks safer according to http://gehrcke.de/2011/06/reading-files-in-c-using-ifstream-dealing-correctly-with-badbit-failbit-eofbit-and-perror/

Originally inspired by https://github.com/TrinityCore/TrinityCore/commit/35ef163703164a8190473ee8eb2ece32a9565045
