### PR TITLE
Send text

### DIFF
--- a/src/game/AchievementMgr.cpp
+++ b/src/game/AchievementMgr.cpp
@@ -67,6 +67,7 @@ namespace MaNGOS
                 data << uint8(0);
                 data << uint32(i_achievementId);
             }
+            void AfterCached(WorldPacket*& aData) {}
 
         private:
             Player const& i_player;

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -61,6 +61,7 @@ namespace MaNGOS
                 else
                     do_helper(data, text);
             }
+            void AfterCached(WorldPacket*& aData) {}
         private:
             void do_helper(WorldPacket& data, char const* text)
             {
@@ -106,6 +107,7 @@ namespace MaNGOS
                 else
                     do_helper(data, text);
             }
+            void AfterCached(WorldPacket*& aData) {}
         private:
             void do_helper(WorldPacket& data, char const* text)
             {
@@ -153,6 +155,7 @@ namespace MaNGOS
                 data << str;
                 data << uint8(i_source ? i_source->GetChatTag() : uint8(CHAT_TAG_NONE));
             }
+            void AfterCached(WorldPacket*& aData) {}
         private:
 
             ChatMsg i_msgtype;
@@ -187,6 +190,7 @@ namespace MaNGOS
                 data << str;
                 data << uint8(0);                           // ChatTag - for bgs allways 0?
             }
+            void AfterCached(WorldPacket*& aData) {}
         private:
 
             uint32 i_language;

--- a/src/game/ChatHandler.cpp
+++ b/src/game/ChatHandler.cpp
@@ -539,6 +539,7 @@ namespace MaNGOS
                 else
                     data << uint8(0x00);
             }
+            void AfterCached(WorldPacket*& aData) {}
 
         private:
             Player const& i_player;

--- a/src/game/GridNotifiers.h
+++ b/src/game/GridNotifiers.h
@@ -1233,18 +1233,21 @@ namespace MaNGOS
     class LocalizedPacketDo
     {
         public:
-            explicit LocalizedPacketDo(Builder& builder) : i_builder(builder) {}
+            explicit LocalizedPacketDo(Builder& builder) : i_builder(builder), i_aData(NULL) {}
 
             ~LocalizedPacketDo()
             {
                 for (size_t i = 0; i < i_data_cache.size(); ++i)
                     delete i_data_cache[i];
+                if (i_aData)
+                    delete i_aData;
             }
             void operator()(Player* p);
 
         private:
             Builder& i_builder;
             std::vector<WorldPacket*> i_data_cache;         // 0 = default, i => i-1 locale index
+            WorldPacket* i_aData;
     };
 
     // Prepare using Builder localized packets with caching and send to player

--- a/src/game/GridNotifiersImpl.h
+++ b/src/game/GridNotifiersImpl.h
@@ -573,6 +573,7 @@ void MaNGOS::LocalizedPacketDo<Builder>::operator()(Player* p)
         data = new WorldPacket(SMSG_MESSAGECHAT, 200);
 
         i_builder(*data, loc_idx);
+        i_builder.AfterCached(i_aData);
 
         i_data_cache[cache_idx] = data;
     }
@@ -580,6 +581,8 @@ void MaNGOS::LocalizedPacketDo<Builder>::operator()(Player* p)
         data = i_data_cache[cache_idx];
 
     p->SendDirectMessage(data);
+    if (i_aData)
+        p->SendDirectMessage(i_aData);
 }
 
 template<class Builder>

--- a/src/game/Map.cpp
+++ b/src/game/Map.cpp
@@ -1872,6 +1872,7 @@ class StaticMonsterChatBuilder
 
             WorldObject::BuildMonsterChat(&data, i_senderGuid, i_msgtype, text, i_language, nameForLocale, i_target ? i_target->GetObjectGuid() : ObjectGuid(), i_target ? i_target->GetNameForLocaleIdx(loc_idx) : "");
         }
+        void AfterCached(WorldPacket*& aData) {}
 
     private:
         ObjectGuid i_senderGuid;

--- a/src/game/Object.cpp
+++ b/src/game/Object.cpp
@@ -1413,6 +1413,14 @@ namespace MaNGOS
 
                 WorldObject::BuildMonsterChat(&data, i_object.GetObjectGuid(), i_msgtype, text, i_language, i_object.GetNameForLocaleIdx(loc_idx), i_target ? i_target->GetObjectGuid() : ObjectGuid(), i_target ? i_target->GetNameForLocaleIdx(loc_idx) : "");
             }
+            void AfterCached(WorldPacket*& aData)
+            {
+                if (!aData && i_textData->SoundId)
+                {
+                    aData = new WorldPacket(SMSG_PLAY_SOUND, 4);
+                    *aData << uint32(i_textData->SoundId);
+                }
+            }
 
         private:
             WorldObject const& i_object;

--- a/src/game/Object.cpp
+++ b/src/game/Object.cpp
@@ -1401,11 +1401,15 @@ namespace MaNGOS
     class MonsterChatBuilder
     {
         public:
-            MonsterChatBuilder(WorldObject const& obj, ChatMsg msgtype, int32 textId, uint32 language, Unit const* target)
-                : i_object(obj), i_msgtype(msgtype), i_textId(textId), i_language(language), i_target(target) {}
+            MonsterChatBuilder(WorldObject const& obj, ChatMsg msgtype, MangosStringLocale const* textData, uint32 language, Unit const* target)
+                : i_object(obj), i_msgtype(msgtype), i_textData(textData), i_language(language), i_target(target) {}
             void operator()(WorldPacket& data, int32 loc_idx)
             {
-                char const* text = sObjectMgr.GetMangosString(i_textId, loc_idx);
+                char const* text = NULL;
+                if ((int32)i_textData->Content.size() > loc_idx + 1 && !i_textData->Content[loc_idx + 1].empty())
+                    text = i_textData->Content[loc_idx + 1].c_str();
+                else
+                    text = i_textData->Content[0].c_str();
 
                 WorldObject::BuildMonsterChat(&data, i_object.GetObjectGuid(), i_msgtype, text, i_language, i_object.GetNameForLocaleIdx(loc_idx), i_target ? i_target->GetObjectGuid() : ObjectGuid(), i_target ? i_target->GetNameForLocaleIdx(loc_idx) : "");
             }
@@ -1413,53 +1417,73 @@ namespace MaNGOS
         private:
             WorldObject const& i_object;
             ChatMsg i_msgtype;
-            int32 i_textId;
+            MangosStringLocale const* i_textData;
             uint32 i_language;
             Unit const* i_target;
     };
 }                                                           // namespace MaNGOS
 
-void WorldObject::MonsterSay(int32 textId, uint32 language, Unit const* target) const
+/// Helper function to create localized around a source
+void _DoLocalizedTextAround(WorldObject const* source, MangosStringLocale const* textData, ChatMsg msgtype, uint32 language, Unit const* target, float range)
 {
-    float range = sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_SAY);
-    MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_SAY, textId, language, target);
+    MaNGOS::MonsterChatBuilder say_build(*source, msgtype, textData, language, target);
     MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
-    MaNGOS::CameraDistWorker<MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> > say_worker(this, range, say_do);
-    Cell::VisitWorldObjects(this, say_worker, range);
+    MaNGOS::CameraDistWorker<MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> > say_worker(source, range, say_do);
+    Cell::VisitWorldObjects(source, say_worker, range);
 }
 
-void WorldObject::MonsterYell(int32 textId, uint32 language, Unit const* target) const
+/// Function that sends a text associated to a MangosString
+void WorldObject::MonsterText(MangosStringLocale const* textData, Unit const* target) const
 {
-    float range = sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL);
-    MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_YELL, textId, language, target);
-    MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
-    MaNGOS::CameraDistWorker<MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> > say_worker(this, range, say_do);
-    Cell::VisitWorldObjects(this, say_worker, range);
+    MANGOS_ASSERT(textData);
+
+    switch (textData->Type)
+    {
+        case CHAT_TYPE_SAY:
+            _DoLocalizedTextAround(this, textData, CHAT_MSG_MONSTER_SAY, textData->Language, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_SAY));
+            break;
+        case CHAT_TYPE_YELL:
+            _DoLocalizedTextAround(this, textData, CHAT_MSG_MONSTER_YELL, textData->Language, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL));
+            break;
+        case CHAT_TYPE_TEXT_EMOTE:
+            _DoLocalizedTextAround(this, textData, CHAT_MSG_MONSTER_EMOTE, LANG_UNIVERSAL, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_TEXTEMOTE));
+            break;
+        case CHAT_TYPE_BOSS_EMOTE:
+            _DoLocalizedTextAround(this, textData, CHAT_MSG_RAID_BOSS_EMOTE, LANG_UNIVERSAL, target, sWorld.getConfig(CONFIG_FLOAT_LISTEN_RANGE_YELL));
+            break;
+        case CHAT_TYPE_WHISPER:
+        {
+            if (!target || target->GetTypeId() != TYPEID_PLAYER)
+                return;
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_WHISPER, textData, LANG_UNIVERSAL, target);
+            MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
+            say_do((Player*)target);
+            break;
+        }
+        case CHAT_TYPE_BOSS_WHISPER:
+        {
+            if (!target || target->GetTypeId() != TYPEID_PLAYER)
+                return;
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_RAID_BOSS_WHISPER, textData, LANG_UNIVERSAL, target);
+            MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
+            say_do((Player*)target);
+            break;
+        }
+        case CHAT_TYPE_ZONE_YELL:
+        {
+            MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_YELL, textData, textData->Language, target);
+            MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
+            uint32 zoneid = GetZoneId();
+            Map::PlayerList const& pList = GetMap()->GetPlayers();
+            for (Map::PlayerList::const_iterator itr = pList.begin(); itr != pList.end(); ++itr)
+                if (itr->getSource()->GetZoneId() == zoneid)
+                    say_do(itr->getSource());
+            break;
+        }
+    }
 }
 
-void WorldObject::MonsterYellToZone(int32 textId, uint32 language, Unit const* target) const
-{
-    MaNGOS::MonsterChatBuilder say_build(*this, CHAT_MSG_MONSTER_YELL, textId, language, target);
-    MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
-
-    uint32 zoneid = GetZoneId();
-
-    Map::PlayerList const& pList = GetMap()->GetPlayers();
-    for (Map::PlayerList::const_iterator itr = pList.begin(); itr != pList.end(); ++itr)
-        if (itr->getSource()->GetZoneId() == zoneid)
-            say_do(itr->getSource());
-}
-
-void WorldObject::MonsterTextEmote(int32 textId, Unit const* target, bool IsBossEmote) const
-{
-    float range = sWorld.getConfig(IsBossEmote ? CONFIG_FLOAT_LISTEN_RANGE_YELL : CONFIG_FLOAT_LISTEN_RANGE_TEXTEMOTE);
-
-    MaNGOS::MonsterChatBuilder say_build(*this, IsBossEmote ? CHAT_MSG_RAID_BOSS_EMOTE : CHAT_MSG_MONSTER_EMOTE, textId, LANG_UNIVERSAL, target);
-    MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> say_do(say_build);
-    MaNGOS::CameraDistWorker<MaNGOS::LocalizedPacketDo<MaNGOS::MonsterChatBuilder> > say_worker(this, range, say_do);
-    Cell::VisitWorldObjects(this, say_worker, range);
-}
-
+/*
 void WorldObject::MonsterWhisper(int32 textId, Unit const* target, bool IsBossWhisper) const
 {
     if (!target || target->GetTypeId() != TYPEID_PLAYER)
@@ -1474,6 +1498,7 @@ void WorldObject::MonsterWhisper(int32 textId, Unit const* target, bool IsBossWh
 
     ((Player*)target)->GetSession()->SendPacket(&data);
 }
+*/
 
 void WorldObject::BuildMonsterChat(WorldPacket* data, ObjectGuid senderGuid, uint8 msgtype, char const* text, uint32 language, char const* name, ObjectGuid targetGuid, char const* targetName)
 {

--- a/src/game/Object.h
+++ b/src/game/Object.h
@@ -74,6 +74,7 @@ class UpdateMask;
 class InstanceData;
 class TerrainInfo;
 class TransportInfo;
+struct MangosStringLocale;
 
 typedef UNORDERED_MAP<Player*, UpdateData> UpdateDataMapType;
 
@@ -545,11 +546,7 @@ class MANGOS_DLL_SPEC WorldObject : public Object
         void MonsterYell(const char* text, uint32 language, Unit const* target = NULL) const;
         void MonsterTextEmote(const char* text, Unit const* target, bool IsBossEmote = false) const;
         void MonsterWhisper(const char* text, Unit const* target, bool IsBossWhisper = false) const;
-        void MonsterSay(int32 textId, uint32 language, Unit const* target = NULL) const;
-        void MonsterYell(int32 textId, uint32 language, Unit const* target = NULL) const;
-        void MonsterTextEmote(int32 textId, Unit const* target, bool IsBossEmote = false) const;
-        void MonsterWhisper(int32 textId, Unit const* receiver, bool IsBossWhisper = false) const;
-        void MonsterYellToZone(int32 textId, uint32 language, Unit const* target) const;
+        void MonsterText(MangosStringLocale const* textData, Unit const* target) const;
         static void BuildMonsterChat(WorldPacket* data, ObjectGuid senderGuid, uint8 msgtype, char const* text, uint32 language, char const* name, ObjectGuid targetGuid, char const* targetName);
 
         void PlayDistanceSound(uint32 sound_id, Player const* target = NULL) const;

--- a/src/game/ObjectMgr.cpp
+++ b/src/game/ObjectMgr.cpp
@@ -9764,46 +9764,12 @@ bool DoDisplayText(WorldObject* source, int32 entry, Unit const* target /*=NULL*
         }
     }
 
-    switch (data->Type)
+    if ((data->Type == CHAT_TYPE_WHISPER || data->Type == CHAT_TYPE_BOSS_WHISPER) && (!target || target->GetTypeId() != TYPEID_PLAYER))
     {
-        case CHAT_TYPE_SAY:
-            source->MonsterSay(entry, data->Language, target);
-            break;
-        case CHAT_TYPE_YELL:
-            source->MonsterYell(entry, data->Language, target);
-            break;
-        case CHAT_TYPE_TEXT_EMOTE:
-            source->MonsterTextEmote(entry, target);
-            break;
-        case CHAT_TYPE_BOSS_EMOTE:
-            source->MonsterTextEmote(entry, target, true);
-            break;
-        case CHAT_TYPE_WHISPER:
-        {
-            if (target && target->GetTypeId() == TYPEID_PLAYER)
-                source->MonsterWhisper(entry, target);
-            else
-            {
-                _DoStringError(entry, "DoDisplayText entry %i cannot whisper without target unit (TYPEID_PLAYER).", entry);
-                return false;
-            }
-            break;
-        }
-        case CHAT_TYPE_BOSS_WHISPER:
-        {
-            if (target && target->GetTypeId() == TYPEID_PLAYER)
-                source->MonsterWhisper(entry, target, true);
-            else
-            {
-                _DoStringError(entry, "DoDisplayText entry %i cannot whisper without target unit (TYPEID_PLAYER).", entry);
-                return false;
-            }
-            break;
-        }
-        case CHAT_TYPE_ZONE_YELL:
-            source->MonsterYellToZone(entry, data->Language, target);
-            break;
+        _DoStringError(entry, "DoDisplayText entry %i cannot whisper without target unit (TYPEID_PLAYER).", entry);
+        return false;
     }
 
+    source->MonsterText(data, target);
     return true;
 }

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -2275,8 +2275,13 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
                         Spell::SelectMountByAreaAndSkill(target, GetSpellProto(), 0, 0, 54726, 54727, 0);
                         return;
                     case 58600:                             // Restricted Flight Area
-                        target->MonsterWhisper(LANG_NO_FLY_ZONE, target, true);
+                    {
+                        if (!target || target->GetTypeId() != TYPEID_PLAYER)
+                            return;
+                        const char* text = sObjectMgr.GetMangosString(LANG_NO_FLY_ZONE, ((Player*)target)->GetSession()->GetSessionDbLocaleIndex());
+                        target->MonsterWhisper(text, target, true);
                         return;
+                    }
                     case 61187:                             // Twilight Shift (single target)
                     case 61190:                             // Twilight Shift (many targets)
                         target->RemoveAurasDueToSpell(57620);

--- a/src/game/WaypointMovementGenerator.cpp
+++ b/src/game/WaypointMovementGenerator.cpp
@@ -136,6 +136,7 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature& creature)
 
         if (behavior->textid[0])
         {
+            int32 textId = behavior->textid[0];
             // Not only one text is set
             if (behavior->textid[1])
             {
@@ -147,10 +148,13 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature& creature)
                         break;
                 }
 
-                creature.MonsterSay(behavior->textid[rand() % i], LANG_UNIVERSAL);
+                textId = behavior->textid[urand(0, i - 1)];
             }
+
+            if (MangosStringLocale const* textData = sObjectMgr.GetMangosStringLocale(textId))
+                creature.MonsterText(textData, NULL);
             else
-                creature.MonsterSay(behavior->textid[0], LANG_UNIVERSAL);
+                sLog.outErrorDb("%s reached waypoint %u, attempted to do text %i, but required text-data could not be found", creature.GetGuidStr().c_str(), i_currentNode, textId);
         }
     }
 


### PR DESCRIPTION
First commit is pretty clear:
- Remove MonsterText, MonsterYell, MonsterEmote, MonsterWhisper functions (int32 entry versions) and replace with a generic function MonsterText that operates on MangosLocaleString (which has the information about type, language)
- Pass the MangosLocaleString to the actual builder functions, to prevent a double lookup

The second commit:
The goal is to be able to handle sound (maybe later on emote) within the same "iterators" over the players then the actual strings. This should give some small performance benefits on the long run

(Both untested)
