### PR TITLE
Fix duplicate indexes

### DIFF
--- a/sql/characters.sql
+++ b/sql/characters.sql
@@ -679,8 +679,7 @@ DROP TABLE IF EXISTS `character_queststatus_daily`;
 CREATE TABLE `character_queststatus_daily` (
   `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
   `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY (`guid`,`quest`),
-  KEY `idx_guid` (`guid`)
+  PRIMARY KEY (`guid`,`quest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -700,8 +699,7 @@ DROP TABLE IF EXISTS `character_queststatus_monthly`;
 CREATE TABLE `character_queststatus_monthly` (
   `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
   `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY (`guid`,`quest`),
-  KEY `idx_guid` (`guid`)
+  PRIMARY KEY (`guid`,`quest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -721,8 +719,7 @@ DROP TABLE IF EXISTS `character_queststatus_weekly`;
 CREATE TABLE `character_queststatus_weekly` (
   `guid` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Global Unique Identifier',
   `quest` int(11) unsigned NOT NULL DEFAULT '0' COMMENT 'Quest Identifier',
-  PRIMARY KEY (`guid`,`quest`),
-  KEY `idx_guid` (`guid`)
+  PRIMARY KEY (`guid`,`quest`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
 
 --
@@ -789,8 +786,6 @@ CREATE TABLE `character_social` (
   `flags` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Friend Flags',
   `note` varchar(48) NOT NULL DEFAULT '' COMMENT 'Friend Note',
   PRIMARY KEY (`guid`,`friend`,`flags`),
-  KEY `guid` (`guid`),
-  KEY `friend` (`friend`),
   KEY `guid_flags` (`guid`,`flags`),
   KEY `friend_flags` (`friend`,`flags`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC COMMENT='Player System';
@@ -908,7 +903,6 @@ CREATE TABLE `character_talent` (
   `current_rank` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `spec` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guid`,`talent_id`,`spec`),
-  KEY `guid_key` (`guid`),
   KEY `talent_key` (`talent_id`),
   KEY `spec_key` (`spec`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -1285,7 +1279,6 @@ CREATE TABLE `guild_bank_eventlog` (
   `DestTabId` tinyint(1) unsigned NOT NULL DEFAULT '0' COMMENT 'Destination Tab Id',
   `TimeStamp` bigint(20) unsigned NOT NULL DEFAULT '0' COMMENT 'Event UNIX time',
   PRIMARY KEY (`guildid`,`LogGuid`,`TabId`),
-  KEY `guildid_key` (`guildid`),
   KEY `Idx_PlayerGuid` (`PlayerGuid`),
   KEY `Idx_LogGuid` (`LogGuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -1311,7 +1304,6 @@ CREATE TABLE `guild_bank_item` (
   `item_guid` int(11) unsigned NOT NULL DEFAULT '0',
   `item_entry` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`guildid`,`TabId`,`SlotId`),
-  KEY `guildid_key` (`guildid`),
   KEY `Idx_item_guid` (`item_guid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1335,8 +1327,7 @@ CREATE TABLE `guild_bank_right` (
   `rid` int(11) unsigned NOT NULL DEFAULT '0',
   `gbright` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `SlotPerDay` int(11) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`guildid`,`TabId`,`rid`),
-  KEY `guildid_key` (`guildid`)
+  PRIMARY KEY (`guildid`,`TabId`,`rid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1359,8 +1350,7 @@ CREATE TABLE `guild_bank_tab` (
   `TabName` varchar(100) NOT NULL DEFAULT '',
   `TabIcon` varchar(100) NOT NULL DEFAULT '',
   `TabText` text,
-  PRIMARY KEY (`guildid`,`TabId`),
-  KEY `guildid_key` (`guildid`)
+  PRIMARY KEY (`guildid`,`TabId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
@@ -1426,7 +1416,6 @@ CREATE TABLE `guild_member` (
   `BankResetTimeTab5` int(11) unsigned NOT NULL DEFAULT '0',
   `BankRemSlotsTab5` int(11) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `guid_key` (`guid`),
-  KEY `guildid_key` (`guildid`),
   KEY `guildid_rank_key` (`guildid`,`rank`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED COMMENT='Guild System';
 

--- a/sql/mangos.sql
+++ b/sql/mangos.sql
@@ -11223,8 +11223,7 @@ CREATE TABLE `playercreateinfo_action` (
   `button` smallint(5) unsigned NOT NULL DEFAULT '0',
   `action` int(11) unsigned NOT NULL DEFAULT '0',
   `type` smallint(5) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`race`,`class`,`button`),
-  KEY `playercreateinfo_race_class_index` (`race`,`class`)
+  PRIMARY KEY (`race`,`class`,`button`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --


### PR DESCRIPTION
Some indexes are left-prefix of others indexes.

"If the table has a multiple-column index, any leftmost prefix of the index can be used by the optimizer to find rows. For example, if you have a three-column index on (col1, col2, col3), you have indexed search capabilities on (col1), (col1, col2), and (col1, col2, col3)."

Source : http://dev.mysql.com/doc/refman/5.5/en/multiple-column-indexes.html
