### PR TITLE
Fix vmap geometry.

### DIFF
--- a/contrib/vmap_extractor/vmapextract/model.cpp
+++ b/contrib/vmap_extractor/vmapextract/model.cpp
@@ -102,6 +102,15 @@ bool Model::ConvertToVMAPModel(const char* outfilename)
     fwrite(&nIndexes, sizeof(uint32), 1, output);
     if (nIndexes > 0)
     {
+        for (uint32 i = 0; i < nIndexes; ++i)
+        {
+            if ((i % 3) - 1 == 0)
+            {
+                uint16 tmp = indices[i];
+                indices[i] = indices[i+1];
+                indices[i+1] = tmp;
+            }
+        }
         fwrite(indices, sizeof(unsigned short), nIndexes, output);
     }
     fwrite("VERT", 4, 1, output);
@@ -112,7 +121,9 @@ bool Model::ConvertToVMAPModel(const char* outfilename)
     {
         for (uint32 vpos = 0; vpos < nVertices; ++vpos)
         {
-            std::swap(vertices[vpos].y, vertices[vpos].z);
+            float tmp = vertices[vpos].y;
+            vertices[vpos].y = -vertices[vpos].z;
+            vertices[vpos].z = tmp;
         }
         fwrite(vertices, sizeof(float) * 3, nVertices, output);
     }


### PR DESCRIPTION
This patch fixes 2 issues with the vmap extractor. 1) Incorrectly converts vertex coordinates. 2) Forgets to convert coordinates on triangle indices.

The effects of [1] causes models to be flipped. This isn't very noticeable on most trees as flipping a cylinder results in the same cylinder, but it's very noticeable on any non-symmetrical geometry (which, even includes trees, it's just harder to notice). [2] Didn't seem to be a problem when the coordinates were incorrectly converted, but when applying the correct conversion caused some triangles to be flipped (i.e. facing inwards).

You will need to re-extract vmaps and re-generate mmaps for these changes to take effect.
