### PR TITLE
Fixed possible mount abuse after leaving BattleGround

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -968,6 +968,10 @@ void BattleGround::RemovePlayerAtLeave(ObjectGuid guid, bool Transport, bool Sen
             plr->SpawnCorpseBones();
         }
     }
+    
+    if (plr)
+        if (plr->HasAuraType(SPELL_AURA_MOUNTED))
+            plr->RemoveSpellsCausingAura(SPELL_AURA_MOUNTED);
 
     RemovePlayer(plr, guid);                                // BG subclass specific code
 


### PR DESCRIPTION
How to reproduce the bug:
- Talk with a flight master and take a fly to somewhere
- Join a BattleGround while flying
- Mount when you are still in the BG, and then left BG while mounted

Result:

While flight is ended, the mount icon is still enabled and the speed is set as you are mounted (your mount speed). But you are not actually mounted, so you are able to cast spells and fight against NPCs.
So you can play with the mounted speed, even if you are not really mounted.
