### PR TITLE
Fit with PvPstats

### DIFF
--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -613,8 +613,8 @@ enum Team
 
 enum PvpTeamIndex
 {
-    TEAM_INDEX_ALLIANCE = 0,
-    TEAM_INDEX_HORDE    = 1,
+    TEAM_INDEX_HORDE    = 0,
+    TEAM_INDEX_ALLIANCE = 1,
     TEAM_INDEX_NEUTRAL  = 2,
 };
 


### PR DESCRIPTION
This is needed in order to fit with PvPstats web-application (see https://github.com/ShinDarth/PvPstats/blob/master/variables.php#L11).

The reason I can't change those values in web-application and fit them with cmangos is PvPstats web-app is supporting other server applications which have those values exchanged.
