### PR TITLE
Possibility to force enable/disable MMaps for specific creatures

### DIFF
--- a/src/game/Creature.h
+++ b/src/game/Creature.h
@@ -43,19 +43,21 @@ struct GameEventCreatureData;
 
 enum CreatureFlagsExtra
 {
-    CREATURE_FLAG_EXTRA_INSTANCE_BIND   = 0x00000001,       // creature kill bind instance with killer and killer's group
-    CREATURE_FLAG_EXTRA_CIVILIAN        = 0x00000002,       // not aggro (ignore faction/reputation hostility)
-    CREATURE_FLAG_EXTRA_NO_PARRY        = 0x00000004,       // creature can't parry
-    CREATURE_FLAG_EXTRA_NO_PARRY_HASTEN = 0x00000008,       // creature can't counter-attack at parry
-    CREATURE_FLAG_EXTRA_NO_BLOCK        = 0x00000010,       // creature can't block
-    CREATURE_FLAG_EXTRA_NO_CRUSH        = 0x00000020,       // creature can't do crush attacks
-    CREATURE_FLAG_EXTRA_NO_XP_AT_KILL   = 0x00000040,       // creature kill not provide XP
-    CREATURE_FLAG_EXTRA_INVISIBLE       = 0x00000080,       // creature is always invisible for player (mostly trigger creatures)
-    CREATURE_FLAG_EXTRA_NOT_TAUNTABLE   = 0x00000100,       // creature is immune to taunt auras and effect attack me
-    CREATURE_FLAG_EXTRA_AGGRO_ZONE      = 0x00000200,       // creature sets itself in combat with zone on aggro
-    CREATURE_FLAG_EXTRA_GUARD           = 0x00000400,       // creature is a guard
-    CREATURE_FLAG_EXTRA_NO_CALL_ASSIST  = 0x00000800,       // creature shouldn't call for assistance on aggro
-    CREATURE_FLAG_EXTRA_ACTIVE          = 0x00001000,       // creature is active object. Grid of this creature will be loaded and creature set as active
+    CREATURE_FLAG_EXTRA_INSTANCE_BIND       = 0x00000001,       // creature kill bind instance with killer and killer's group
+    CREATURE_FLAG_EXTRA_CIVILIAN            = 0x00000002,       // not aggro (ignore faction/reputation hostility)
+    CREATURE_FLAG_EXTRA_NO_PARRY            = 0x00000004,       // creature can't parry
+    CREATURE_FLAG_EXTRA_NO_PARRY_HASTEN     = 0x00000008,       // creature can't counter-attack at parry
+    CREATURE_FLAG_EXTRA_NO_BLOCK            = 0x00000010,       // creature can't block
+    CREATURE_FLAG_EXTRA_NO_CRUSH            = 0x00000020,       // creature can't do crush attacks
+    CREATURE_FLAG_EXTRA_NO_XP_AT_KILL       = 0x00000040,       // creature kill not provide XP
+    CREATURE_FLAG_EXTRA_INVISIBLE           = 0x00000080,       // creature is always invisible for player (mostly trigger creatures)
+    CREATURE_FLAG_EXTRA_NOT_TAUNTABLE       = 0x00000100,       // creature is immune to taunt auras and effect attack me
+    CREATURE_FLAG_EXTRA_AGGRO_ZONE          = 0x00000200,       // creature sets itself in combat with zone on aggro
+    CREATURE_FLAG_EXTRA_GUARD               = 0x00000400,       // creature is a guard
+    CREATURE_FLAG_EXTRA_NO_CALL_ASSIST      = 0x00000800,       // creature shouldn't call for assistance on aggro
+    CREATURE_FLAG_EXTRA_ACTIVE              = 0x00001000,       // creature is active object. Grid of this creature will be loaded and creature set as active
+    CREATURE_FLAG_EXTRA_MMAP_FORCE_ENABLE   = 0x00010000,       // creature is force to use MMaps
+    CREATURE_FLAG_EXTRA_MMAP_FORCE_DISABLE  = 0x00020000        // creature is forced to NOT use MMaps
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform

--- a/src/game/MoveMap.cpp
+++ b/src/game/MoveMap.cpp
@@ -19,6 +19,7 @@
 #include "GridMap.h"
 #include "Log.h"
 #include "World.h"
+#include "Creature.h"
 
 #include "MoveMap.h"
 #include "MoveMapSharedDefines.h"
@@ -59,10 +60,30 @@ namespace MMAP
         delete[] mapList;
     }
 
-    bool MMapFactory::IsPathfindingEnabled(uint32 mapId)
+    bool MMapFactory::IsPathfindingEnabled(uint32 mapId, const Unit* unit = NULL)
     {
-        return sWorld.getConfig(CONFIG_BOOL_MMAP_ENABLED)
-               && g_mmapDisabledIds->find(mapId) == g_mmapDisabledIds->end();
+        if (!sWorld.getConfig(CONFIG_BOOL_MMAP_ENABLED))
+            return false;
+
+        if (unit)
+        {
+            // always use mmaps for players
+            if (unit->GetTypeId() == TYPEID_PLAYER)
+                return true;
+
+            if (IsPathfindingForceDisabled(unit))
+                return false;
+
+            if (IsPathfindingForceEnabled(unit))
+                return true;
+
+            // always use mmaps for pets of players (can still be disabled by extra-flag for pet creature)
+            if (unit->GetTypeId() == TYPEID_UNIT && ((Creature*)unit)->IsPet() && unit->GetOwner() &&
+                unit->GetOwner()->GetTypeId() == TYPEID_PLAYER)
+                return true;
+        }
+
+        return g_mmapDisabledIds->find(mapId) == g_mmapDisabledIds->end();
     }
 
     void MMapFactory::clear()
@@ -72,6 +93,34 @@ namespace MMAP
 
         g_mmapDisabledIds = NULL;
         g_MMapManager = NULL;
+    }
+
+    bool MMapFactory::IsPathfindingForceEnabled(const Unit* unit)
+    {
+        if (const Creature* pCreature = dynamic_cast<const Creature*>(unit))
+        {
+            if (const CreatureInfo* pInfo = pCreature->GetCreatureInfo())
+            {
+                if (pInfo->ExtraFlags & CREATURE_FLAG_EXTRA_MMAP_FORCE_ENABLE)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool MMapFactory::IsPathfindingForceDisabled(const Unit* unit)
+    {
+        if (const Creature* pCreature = dynamic_cast<const Creature*>(unit))
+        {
+            if (const CreatureInfo* pInfo = pCreature->GetCreatureInfo())
+            {
+                if (pInfo->ExtraFlags & CREATURE_FLAG_EXTRA_MMAP_FORCE_DISABLE)
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     // ######################## MMapManager ########################

--- a/src/game/MoveMap.h
+++ b/src/game/MoveMap.h
@@ -25,6 +25,8 @@
 #include "../../dep/recastnavigation/Detour/Include/DetourNavMesh.h"
 #include "../../dep/recastnavigation/Detour/Include/DetourNavMeshQuery.h"
 
+#include "Unit.h"
+
 //  memory management
 inline void* dtCustomAlloc(int size, dtAllocHint /*hint*/)
 {
@@ -100,7 +102,9 @@ namespace MMAP
             static MMapManager* createOrGetMMapManager();
             static void clear();
             static void preventPathfindingOnMaps(const char* ignoreMapIds);
-            static bool IsPathfindingEnabled(uint32 mapId);
+            static bool IsPathfindingEnabled(uint32 mapId, const Unit* unit);
+            static bool IsPathfindingForceEnabled(const Unit* unit);
+            static bool IsPathfindingForceDisabled(const Unit* unit);
     };
 }
 

--- a/src/game/PathFinder.cpp
+++ b/src/game/PathFinder.cpp
@@ -33,7 +33,7 @@ PathFinder::PathFinder(const Unit* owner) :
     DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::PathInfo for %u \n", m_sourceUnit->GetGUIDLow());
 
     uint32 mapId = m_sourceUnit->GetMapId();
-    if (MMAP::MMapFactory::IsPathfindingEnabled(mapId))
+    if (MMAP::MMapFactory::IsPathfindingEnabled(mapId, owner))
     {
         MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
         m_navMesh = mmap->GetNavMesh(mapId);


### PR DESCRIPTION
Not much to say here.

Adding the respecting new extraFlag to a creature's template results in disabling/enabling MMaps for this creature.
This may be useful for some raidbosses or some trashmobs (i.e. Al'ar).

Also we enabled MMaps for Players all the time and by default for pets too (but there it's possible to disable it by creature-template).