### PR TITLE
pet level modifiers for SPELL_EFFECT_SUMMON_PET

### DIFF
--- a/src/game/SpellEffects.cpp
+++ b/src/game/SpellEffects.cpp
@@ -6648,7 +6648,10 @@ void Spell::EffectSummonPet(SpellEffectIndex eff_idx)
 
     NewSummon->SetRespawnCoord(pos);
 
-    uint32 petlevel = m_caster->getLevel();
+    uint32 petlevel = (m_caster->getLevel() + m_spellInfo->EffectMultipleValue[eff_idx] > 0)
+                      ? m_caster->getLevel() + m_spellInfo->EffectMultipleValue[eff_idx]
+                      : 1;
+
     NewSummon->setPetType(SUMMON_PET);
 
     uint32 faction = m_caster->getFaction();


### PR DESCRIPTION
The multiplier field of SPELL_EFFECT_SUMMON_PET spell effects is added to
the master's level to yield the pet's level.