### PR TITLE
Implement hearbeat resist mechanic

### DIFF
--- a/src/game/SharedDefines.h
+++ b/src/game/SharedDefines.h
@@ -279,7 +279,7 @@ enum SpellAttributes
     SPELL_ATTR_CASTABLE_WHILE_SITTING          = 0x08000000,// 27 castable while sitting
     SPELL_ATTR_CANT_USED_IN_COMBAT             = 0x10000000,// 28 Cannot be used in combat
     SPELL_ATTR_UNAFFECTED_BY_INVULNERABILITY   = 0x20000000,// 29 unaffected by invulnerability (hmm possible not...)
-    SPELL_ATTR_UNK30                           = 0x40000000,// 30 breakable by damage?
+    SPELL_ATTR_HEARTBEAT_RESIST_CHECK          = 0x40000000,// 30 random chance the effect will end (subjected to the hearbeat resist)
     SPELL_ATTR_CANT_CANCEL                     = 0x80000000,// 31 positive aura can't be canceled
 };
 

--- a/src/game/SpellAuras.cpp
+++ b/src/game/SpellAuras.cpp
@@ -9021,7 +9021,7 @@ SpellAuraHolder::SpellAuraHolder(SpellEntry const* spellproto, Unit* target, Wor
     m_auraSlot(MAX_AURAS), m_auraFlags(AFLAG_NONE), m_auraLevel(1),
     m_procCharges(0), m_stackAmount(1),
     m_timeCla(1000), m_removeMode(AURA_REMOVE_BY_DEFAULT), m_AuraDRGroup(DIMINISHING_NONE),
-    m_permanent(false), m_isRemovedOnShapeLost(true), m_deleted(false), m_in_use(0)
+    m_permanent(false), m_isRemovedOnShapeLost(true), m_deleted(false), m_in_use(0), m_heartBeatTimer(0)
 {
     MANGOS_ASSERT(target);
     MANGOS_ASSERT(spellproto && spellproto == sSpellStore.LookupEntry(spellproto->Id) && "`info` must be pointer to sSpellStore element");
@@ -10274,6 +10274,9 @@ void SpellAuraHolder::Update(uint32 diff)
         if (Aura* aura = m_auras[i])
             aura->UpdateAura(diff);
 
+    if (m_duration && (m_spellProto->Attributes & SPELL_ATTR_HEARTBEAT_RESIST_CHECK))
+        HeartbeatResistance(diff);
+
     // Channeled aura required check distance from caster
     if (IsChanneledSpell(m_spellProto) && GetCasterGuid() != m_target->GetObjectGuid())
     {
@@ -10415,4 +10418,101 @@ void SpellAuraHolder::UnregisterAndCleanupTrackedAuras()
     }
 
     m_trackedAuraType = TRACK_AURA_TYPE_NOT_TRACKED;
+}
+
+void SpellAuraHolder::HeartbeatResistance(uint32 diff)
+{
+    m_heartBeatTimer += diff;
+
+    if (m_heartBeatTimer < 950)
+        return;
+
+    if(SpellEntry const* spellProto = sSpellStore.LookupEntry(m_spellProtoId))
+    {
+        Unit* target = GetTarget();
+        Unit* caster = GetCaster();
+
+        if (!target || !caster)
+            return;
+
+        if (target->GetTypeId() == TYPEID_UNIT && caster->GetTypeId() == TYPEID_PLAYER)
+        {
+            m_heartBeatTimer = 0;
+
+            size_t auraTimePassed = time(NULL) - GetAuraApplyTime();
+
+            if (auraTimePassed == (uint32)floor((GetAuraMaxDuration() * 0.25 / IN_MILLISECONDS) + 0.5f) ||
+                auraTimePassed == (uint32)floor((GetAuraMaxDuration() * 0.50 / IN_MILLISECONDS) + 0.5f) ||
+                auraTimePassed == (uint32)floor((GetAuraMaxDuration() * 0.75 / IN_MILLISECONDS) + 0.5f))
+            {
+                sLog.outDebug("[Heartbeat Resist] Breaking creature aura. Duration %u, Max %u", (uint32)auraTimePassed, (GetAuraMaxDuration() / IN_MILLISECONDS));
+
+                SpellSchoolMask spellMask = GetSpellSchoolMask(spellProto);
+                uint32 pResistance = 0;
+
+                if (spellMask != SPELL_SCHOOL_MASK_NORMAL)
+                    pResistance = target->GetResistance(GetFirstSchoolInMask(spellMask));
+
+                uint32 breakChance = urand(0, 100);
+                uint32 breakPct = (5 + ((pResistance / powf(target->getLevel(), 1.441f) * 0.10) * 100));
+
+                if (breakChance < breakPct)
+                {
+                    target->RemoveAurasDueToSpellByCancel(spellProto->Id);
+                    sLog.outDebug("[Heartbeat Resist] Breaking creature aura %u. Seconds passed %u with chance %u and roll %u.", spellProto->Id, (uint32)auraTimePassed, breakPct, breakChance);
+                    return;
+                }
+            }
+        }
+        else if (target->GetTypeId() == TYPEID_PLAYER && caster->GetTypeId() == TYPEID_PLAYER)
+        {
+            m_heartBeatTimer = 0;
+
+            sLog.outDebug("[Heartbeat Resist] Trying to break aura #%u on player #%u", spellProto->Id, target->GetGUIDLow());
+
+            size_t heartbeatDelay = 5;
+            size_t auraTimePassed = time(NULL) - GetAuraApplyTime();
+            int32 auraDuration = GetAuraMaxDuration() / IN_MILLISECONDS;
+
+            sLog.outDebug("[Heartbeat Resist] Aura duration %d and aura time passed currently %u", auraDuration, (uint32)auraTimePassed);
+
+            if (auraTimePassed < heartbeatDelay)
+                return;
+
+            SpellSchoolMask spellMask = GetSpellSchoolMask(spellProto);
+            uint32 pResistance = 0;
+
+            if (spellMask != SPELL_SCHOOL_MASK_NORMAL)
+                pResistance = target->GetResistance(GetFirstSchoolInMask(spellMask));
+
+            uint32 breakChance = urand(0, 100);
+
+            // Chance resist mechanic (select max value from every mechanic spell effect)
+            int32 pMechanicPct = 0;
+
+            // Get effects mechanic and chance
+            // [TODO] Identify if this is correct use.
+            for (int eff = 0; eff < MAX_EFFECT_INDEX; ++eff)
+            {
+                int32 effect_mech = GetEffectMechanic(spellProto, SpellEffectIndex(eff));
+                if (effect_mech)
+                {
+                    int32 temp = target->GetTotalAuraModifierByMiscValue(SPELL_AURA_MOD_MECHANIC_RESISTANCE, effect_mech);
+                    if (pMechanicPct < temp)
+                        pMechanicPct = temp;
+                }
+            }
+
+            float pResistancePct = (auraDuration - 5) * (pResistance / powf(target->getLevel(), 1.441f));
+            uint32 breakPct = (uint32)floor((100 * powf(auraTimePassed - heartbeatDelay, 2) / powf(auraDuration - heartbeatDelay, 2)) + (float)pResistancePct + (float)pMechanicPct + 0.5f) / 2;
+
+            if (breakChance < breakPct)
+            {
+                target->RemoveAurasDueToSpellByCancel(GetId());
+                sLog.outDebug("[Heartbeat Resist] Breaking aura %u. Seconds passed %u with chance %u and roll %u.", spellProto->Id, (uint32)auraTimePassed, breakPct, breakChance);
+                sLog.outDebug("[Heartbeat Resist] Resistance: %u Mechanic: %u Native: %u", (uint32)pResistancePct, pMechanicPct, (uint32)floor((100 * powf(auraTimePassed - heartbeatDelay, 2) / powf(15.f - heartbeatDelay, 2)) + 0.5f));
+                return;
+            }
+        }
+    }
 }

--- a/src/game/SpellAuras.h
+++ b/src/game/SpellAuras.h
@@ -192,6 +192,8 @@ class MANGOS_DLL_SPEC SpellAuraHolder
 
         ~SpellAuraHolder();
     private:
+        void HeartbeatResistance(uint32 diff);
+
         SpellEntry const* m_spellProto;
 
         Unit* m_target;
@@ -219,6 +221,7 @@ class MANGOS_DLL_SPEC SpellAuraHolder
         bool m_deleted: 1;
 
         uint32 m_in_use;                                    // > 0 while in SpellAuraHolder::ApplyModifiers call/SpellAuraHolder::Update/etc
+        uint32 m_heartBeatTimer;                            // HeartbeatResist
 };
 
 typedef void(Aura::*pAuraHandler)(bool Apply, bool Real);


### PR DESCRIPTION
Spells with flag SPELL_ATTR_HEARTBEAT_RESIST_CHECK will have a chance to
break on each tick.

1) Creature will try to break aura based on time left 25, 50, 75% with a
base chance of 5% and 0,02% extra per resistance point into applied
school @ lvl 70 up to 10%

2) In PVP case resist checks are delayed by 5 seconds after which base %
will be calculated on amount of time remaining. In PVP case resistance school uses same formula as creatures and should apply resistance bonus given by talents/spells.

Note: Resistance bonus given by talents/spells doesn't appear to work properly if at all.
Note 2: Not tested in wotlk yet this was developed originally for classic and tbc and it's tested on it.
