### PR TITLE
Use git_id for sql updates only

### DIFF
--- a/contrib/git_id/git_id.cpp
+++ b/contrib/git_id/git_id.cpp
@@ -50,16 +50,16 @@
 
 // config
 
-#define NUM_REMOTES 2
+#define NUM_REMOTES 3
 #define NUM_DATABASES 3
 
 char remotes[NUM_REMOTES][MAX_REMOTE] = {
+    "https://github.com/cmangos/mangos-wotlk.git",
     "git@github.com:cmangos/mangos-wotlk.git",
-    "git://github.com/cmangos/mangos-wotlk.git"             // used for fetch if present
+    "git://github.com/cmangos/mangos-wotlk.git"
 };
 
 char remote_branch[MAX_REMOTE] = "master";
-char rev_nr_file[MAX_PATH] = "src/shared/revision_nr.h";
 char rev_sql_file[MAX_PATH] = "src/shared/revision_sql.h";
 char sql_update_dir[MAX_PATH] = "sql/updates";
 char new_index_file[MAX_PATH] = ".git/git_id_index";
@@ -89,11 +89,8 @@ char db_sql_rev_field[NUM_DATABASES][MAX_PATH] = {
 };
 
 bool allow_replace = false;
-bool local = false;
 bool do_fetch = false;
-bool do_sql = false;
 bool use_new_index = true;
-bool generate_makefile = false;                             // not need for cmake build systems
 // aux
 
 char origins[NUM_REMOTES][MAX_REMOTE];
@@ -117,7 +114,6 @@ FILE *cmd_pipe;
 
 bool find_path()
 {
-    printf("+ finding path\n");
     char *ptr;
     char cur_path[MAX_PATH];
     getcwd(cur_path, MAX_PATH);
@@ -161,7 +157,6 @@ bool find_path()
 
 bool find_origin()
 {
-    printf("+ finding origin\n");
     if( (cmd_pipe = popen( "git remote -v", "r" )) == NULL )
         return false;
 
@@ -185,7 +180,6 @@ bool find_origin()
 
 bool fetch_origin()
 {
-    printf("+ fetching origin\n");
     // use the public clone url if present because the private may require a password
     snprintf(cmd, MAX_CMD, "git fetch %s %s", (origins[1][0] ? origins[1] : origins[0]), remote_branch);
     int ret = system(cmd);
@@ -194,7 +188,6 @@ bool fetch_origin()
 
 bool check_fwd()
 {
-    printf("+ checking fast forward\n");
     snprintf(cmd, MAX_CMD, "git log -n 1 --pretty=\"format:%%H\" %s/%s", (origins[1][0] ? origins[1] : origins[0]), remote_branch);
     if( (cmd_pipe = popen( cmd, "r" )) == NULL )
         return false;
@@ -222,8 +215,8 @@ bool check_fwd()
     {
         // with fetch you still get the latest rev, you just rebase afterwards and push
         // without it you may not get the right rev
-        if(do_fetch) printf("WARNING: non-fastforward, use rebase!\n");
-        else { printf("ERROR: non-fastforward, use rebase!\n"); return false; }
+        if(do_fetch) printf("WARNING: non-fastforward, use rebase\n");
+        else { printf("ERROR: non-fastforward, use rebase\n"); return false; }
     }
     return true;
 }
@@ -239,14 +232,12 @@ int get_rev(const char *from_msg)
 
 bool find_rev()
 {
-    printf("+ finding next revision number\n");
     // find the highest rev number on either of the remotes
     for(int i = 0; i < NUM_REMOTES; i++)
     {
-        if(!local && !origins[i][0]) continue;
+        if(!origins[i][0]) continue;
 
-        if(local) snprintf(cmd, MAX_CMD, "git log HEAD --pretty=\"format:%%s\"");
-        else sprintf(cmd, "git log %s/%s --pretty=\"format:%%s\"", origins[i], remote_branch);
+        sprintf(cmd, "git log %s/%s --pretty=\"format:%%s\"", origins[i], remote_branch);
         if( (cmd_pipe = popen( cmd, "r" )) == NULL )
             continue;
 
@@ -260,19 +251,7 @@ bool find_rev()
         pclose(cmd_pipe);
     }
 
-    if(rev > 0) printf("Found [%d].\n", rev);
-
     return rev > 0;
-}
-
-std::string generateNrHeader(char const* rev_str)
-{
-    std::ostringstream newData;
-    newData << "#ifndef __REVISION_NR_H__" << std::endl;
-    newData << "#define __REVISION_NR_H__"  << std::endl;
-    newData << " #define REVISION_NR \"" << rev_str << "\"" << std::endl;
-    newData << "#endif // __REVISION_NR_H__" << std::endl;
-    return newData.str();
 }
 
 std::string generateSqlHeader()
@@ -299,35 +278,8 @@ void system_switch_index(const char *cmd)
     if(putenv(old_index_cmd) != 0) return;
 }
 
-bool write_rev_nr()
-{
-    printf("+ writing revision_nr.h\n");
-    char rev_str[256];
-    sprintf(rev_str, "%d", rev);
-    std::string header = generateNrHeader(rev_str);
-
-    char prefixed_file[MAX_PATH];
-    snprintf(prefixed_file, MAX_PATH, "%s%s", path_prefix, rev_nr_file);
-
-    if(FILE* OutputFile = fopen(prefixed_file, "wb"))
-    {
-        fprintf(OutputFile,"%s", header.c_str());
-        fclose(OutputFile);
-
-        // add the file to both indices, to be committed later
-        snprintf(cmd, MAX_CMD, "git add %s", prefixed_file);
-        system_switch_index(cmd);
-
-        return true;
-    }
-
-    return false;
-}
-
 bool write_rev_sql()
 {
-    if(new_sql_updates.empty()) return true;
-    printf("+ writing revision_sql.h\n");
     std::string header = generateSqlHeader();
 
     char prefixed_file[MAX_PATH];
@@ -350,7 +302,6 @@ bool write_rev_sql()
 
 bool find_head_msg()
 {
-    printf("+ finding last message on HEAD\n");
     if( (cmd_pipe = popen( "git log -n 1 --pretty=\"format:%s%n%n%b\"", "r" )) == NULL )
         return false;
 
@@ -364,7 +315,7 @@ bool find_head_msg()
     {
         if(!allow_replace)
         {
-            printf("Last commit on HEAD is [%d]. Use -r to replace it with [%d].\n", head_rev, rev);
+            printf("Last sql version on HEAD is [%d]. Use -r to replace it with [%d]\n", head_rev, rev);
             return false;
         }
 
@@ -382,8 +333,6 @@ bool find_head_msg()
 
 bool amend_commit()
 {
-    printf("+ amending last commit\n");
-
     // commit the contents of the (new) index
     if(use_new_index && putenv(new_index_cmd) != 0) return false;
     snprintf(cmd, MAX_CMD, "git commit --amend -F-");
@@ -431,7 +380,6 @@ bool get_sql_update_info(const char *buffer, sql_update_info &info)
 
 bool find_sql_updates()
 {
-    printf("+ finding new sql updates on HEAD\n");
     // add all updates from HEAD
     snprintf(cmd, MAX_CMD, "git show HEAD:%s", sql_update_dir);
     if( (cmd_pipe = popen( cmd, "r" )) == NULL )
@@ -504,8 +452,6 @@ bool find_sql_updates()
         for(std::set<std::string>::iterator itr = new_sql_updates.begin(); itr != new_sql_updates.end(); ++itr)
             printf("%s\n", itr->c_str());
     }
-    else
-        printf("WARNING: no new sql updates found.\n");
 
     return true;
 }
@@ -526,10 +472,6 @@ bool copy_file(const char *src_file, const char *dst_file)
 
 bool convert_sql_updates()
 {
-    if(new_sql_updates.empty()) return true;
-
-    printf("+ converting sql updates\n");
-
     // rename the sql update files and add the required update statement
     for(std::set<std::string>::iterator itr = new_sql_updates.begin(); itr != new_sql_updates.end(); ++itr)
     {
@@ -598,110 +540,8 @@ bool convert_sql_updates()
     return true;
 }
 
-bool generate_sql_makefile()
-{
-    if(new_sql_updates.empty()) return true;
-
-    // find all files in the update dir
-    snprintf(cmd, MAX_CMD, "git show HEAD:%s", sql_update_dir);
-    if( (cmd_pipe = popen( cmd, "r" )) == NULL )
-        return false;
-
-    // skip first two lines
-    if(!fgets(buffer, MAX_BUF, cmd_pipe)) { pclose(cmd_pipe); return false; }
-    if(!fgets(buffer, MAX_BUF, cmd_pipe)) { pclose(cmd_pipe); return false; }
-
-    char newname[MAX_PATH];
-    std::set<std::string> file_list;
-    sql_update_info info;
-
-    while(fgets(buffer, MAX_BUF, cmd_pipe))
-    {
-        buffer[strlen(buffer) - 1] = '\0';
-        if(buffer[strlen(buffer) - 1] != '/' &&
-            strncmp(buffer, "Makefile.am", MAX_BUF) != 0)
-        {
-            if(new_sql_updates.find(buffer) != new_sql_updates.end())
-            {
-                if(!get_sql_update_info(buffer, info)) return false;
-                snprintf(newname, MAX_PATH, "%d_%0*d_%s%s%s.sql", rev, 2, info.nr, info.db, info.has_table ? "_" : "", info.table);
-                file_list.insert(newname);
-            }
-            else
-                file_list.insert(buffer);
-        }
-    }
-
-    pclose(cmd_pipe);
-
-    // write the makefile
-    char file_name[MAX_PATH];
-    snprintf(file_name, MAX_PATH, "%s%s/Makefile.am", path_prefix, sql_update_dir);
-    FILE *fout = fopen(file_name, "w");
-    if(!fout) { pclose(cmd_pipe); return false; }
-
-    fprintf(fout,
-        "# This file is part of the CMaNGOS Project. See AUTHORS file for Copyright information\n"
-        "#\n"
-        "# This program is free software; you can redistribute it and/or modify\n"
-        "# it under the terms of the GNU General Public License as published by\n"
-        "# the Free Software Foundation; either version 2 of the License, or\n"
-        "# (at your option) any later version.\n"
-        "#\n"
-        "# This program is distributed in the hope that it will be useful,\n"
-        "# but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
-        "# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
-        "# GNU General Public License for more details.\n"
-        "#\n"
-        "# You should have received a copy of the GNU General Public License\n"
-        "# along with this program; if not, write to the Free Software\n"
-        "# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n"
-        "\n"
-        "## Process this file with automake to produce Makefile.in\n"
-        "\n"
-        "## Sub-directories to parse\n"
-        "\n"
-        "## Change installation location\n"
-        "#  datadir = mangos/%s\n"
-        "pkgdatadir = $(datadir)/mangos/%s\n"
-        "\n"
-        "## Files to be installed\n"
-        "#  Install basic SQL files to datadir\n"
-        "pkgdata_DATA = \\\n",
-        sql_update_dir, sql_update_dir
-    );
-
-    for(std::set<std::string>::iterator itr = file_list.begin(), next; itr != file_list.end(); ++itr)
-    {
-        next = itr; ++next;
-        fprintf(fout, "\t%s%s\n", itr->c_str(), next == file_list.end() ? "" : " \\");
-    }
-
-    fprintf(fout,
-        "\n## Additional files to include when running 'make dist'\n"
-        "#  SQL update files, to upgrade database schema from older revisions\n"
-        "EXTRA_DIST = \\\n"
-    );
-
-    for(std::set<std::string>::iterator itr = file_list.begin(), next; itr != file_list.end(); ++itr)
-    {
-        next = itr; ++next;
-        fprintf(fout, "\t%s%s\n", itr->c_str(), next == file_list.end() ? "" : " \\");
-    }
-
-    fclose(fout);
-
-    snprintf(cmd, MAX_CMD, "git add %s%s/Makefile.am", path_prefix, sql_update_dir);
-    system_switch_index(cmd);
-
-    return true;
-}
-
 bool change_sql_database()
 {
-    if(new_sql_updates.empty()) return true;
-    printf("+ changing database sql files\n");
-
     // rename the database files, copy their contents back
     // and change the required update line
     for(int i = 0; i < NUM_DATABASES; i++)
@@ -826,8 +666,6 @@ bool prepare_new_index()
 
     pclose(cmd_pipe);
 
-    printf("+ preparing new index\n");
-
     // copy the existing index file to a new one
     char src_file[MAX_PATH], dst_file[MAX_PATH];
 
@@ -854,14 +692,13 @@ bool prepare_new_index()
 bool cleanup_new_index()
 {
     if(!use_new_index) return true;
-    printf("+ cleaning up the new index\n");
     char idx_file[MAX_PATH];
     snprintf(idx_file, MAX_PATH, "%s%s", path_prefix, new_index_file);
     remove(idx_file);
     return true;
 }
 
-#define DO(cmd) if(!cmd) { printf("FAILED\n"); return 1; }
+#define DO(CMD) if(!CMD()) { printf("FAILED at " #CMD "\n"); return 1; }
 
 int main(int argc, char *argv[])
 {
@@ -870,64 +707,44 @@ int main(int argc, char *argv[])
         if(argv[i] == NULL) continue;
         if(strncmp(argv[i], "-r", 2) == 0 || strncmp(argv[i], "--replace", 9) == 0)
             allow_replace = true;
-        else if(strncmp(argv[i], "-l", 2) == 0 || strncmp(argv[i], "--local", 7) == 0)
-            local = true;
         else if(strncmp(argv[i], "-f", 2) == 0 || strncmp(argv[i], "--fetch", 7) == 0)
             do_fetch = true;
-        else if(strncmp(argv[i], "-s", 2) == 0 || strncmp(argv[i], "--sql", 5) == 0)
-            do_sql = true;
         else if(strncmp(argv[i], "--branch=", 9) == 0)
             snprintf(remote_branch, MAX_REMOTE, "%s", argv[i] + 9);
         else if(strncmp(argv[i], "-h", 2) == 0 || strncmp(argv[i], "--help", 6) == 0)
         {
             printf("Usage: git_id [OPTION]\n");
-            printf("Generates a new rev number and updates revision_nr.h and the commit message.\n");
+            printf("Generates a new sql revision number.\n");
             printf("Should be used just before push.\n");
             printf("   -h, --help            show the usage\n");
             printf("   -r, --replace         replace the rev number if it was already applied\n");
             printf("                         to the last commit\n");
-            printf("   -l, --local           search for the highest rev number on HEAD\n");
             printf("   -f, --fetch           fetch from origin before searching for the new rev\n");
-            printf("   -s, --sql             search for new sql updates and do all of the changes\n");
-            printf("                         for the new rev\n");
             printf("       --branch=BRANCH   specify which remote branch to use\n");
             return 0;
         }
     }
 
-    if (local && do_sql)
-    {
-        printf("Options -l/--local and -s/--sql can't be used in same time currently.\n");
-        printf("FAILED\n");
-        return 1;
-    }
+    DO(find_path);
 
-    DO( find_path()                     );
-    if(!local)
-    {
-        DO( find_origin()               );
-        if(do_fetch)
-            DO( fetch_origin()          );
-        DO( check_fwd()                 );
-    }
-    DO( find_rev()                      );
-    DO( find_head_msg()                 );
-    if(do_sql)
-        DO( find_sql_updates()          );
-    DO( prepare_new_index()             );
-    DO( write_rev_nr()                  );
-    if(do_sql)
-    {
-        DO( convert_sql_updates()       );
-        if (generate_makefile)
-            DO( generate_sql_makefile() );
-        DO( change_sql_database()       );
-        DO( write_rev_sql()             );
-    }
-    DO( amend_commit()                  );
-    DO( cleanup_new_index()             );
-    //if(do_sql)
-    //    DO( change_sql_history()        );
+    DO(find_origin);
+    if (do_fetch)
+        DO(fetch_origin);
+    DO(check_fwd);
+
+    DO(find_rev);
+    DO(find_head_msg);
+    DO(find_sql_updates);
+
+    if (new_sql_updates.empty())
+        return 0;
+
+    DO(prepare_new_index);
+    DO(convert_sql_updates);
+    DO(change_sql_database);
+    DO(write_rev_sql);
+    DO(amend_commit);
+    DO(cleanup_new_index);
 
     return 0;
 }

--- a/src/game/Level0.cpp
+++ b/src/game/Level0.cpp
@@ -28,7 +28,6 @@
 #include "ScriptMgr.h"
 #include "SystemConfig.h"
 #include "revision.h"
-#include "revision_nr.h"
 #include "Util.h"
 
 bool ChatHandler::HandleHelpCommand(char* args)
@@ -97,9 +96,9 @@ bool ChatHandler::HandleServerInfoCommand(char* /*args*/)
 
     char const* full;
     if (m_session)
-        full = _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_NR, "|cffffffff|Hurl:" REVISION_ID "|h" REVISION_ID "|h|r");
+        full = _FULLVERSION(REVISION_DATE, REVISION_TIME, "|cffffffff|Hurl:" REVISION_ID "|h" REVISION_ID "|h|r");
     else
-        full = _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_NR, REVISION_ID);
+        full = _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_ID);
     SendSysMessage(full);
 
     if (sScriptMgr.IsScriptLibraryLoaded())

--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -33,8 +33,6 @@
 #include "WaypointMovementGenerator.h"
 #include "Mail.h"
 
-#include "revision_nr.h"
-
 ScriptMapMapName sQuestEndScripts;
 ScriptMapMapName sQuestStartScripts;
 ScriptMapMapName sSpellScripts;
@@ -2386,13 +2384,6 @@ ScriptLoadResult ScriptMgr::LoadScriptLibrary(const char* libName)
     GET_SCRIPT_HOOK_PTR(m_pOnAuraDummy,                "AuraDummy");
 
 #   undef GET_SCRIPT_HOOK_PTR
-
-    if (strcmp(pGetMangosRevStr(), REVISION_NR) != 0)
-    {
-        m_pOnFreeScriptLibrary = NULL;                      // prevent call before init
-        UnloadScriptLibrary();
-        return SCRIPT_LOAD_ERR_OUTDATED;
-    }
 
     m_pOnInitScriptLibrary();
     return SCRIPT_LOAD_OK;

--- a/src/mangosd/Main.cpp
+++ b/src/mangosd/Main.cpp
@@ -29,7 +29,6 @@
 #include "SystemConfig.h"
 #include "AuctionHouseBot/AuctionHouseBot.h"
 #include "revision.h"
-#include "revision_nr.h"
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #include <ace/Version.h>
@@ -103,7 +102,7 @@ extern int main(int argc, char** argv)
                 cfg_file = cmd_opts.opt_arg();
                 break;
             case 'v':
-                printf("%s\n", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_NR, REVISION_ID));
+                printf("%s\n", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_ID));
                 return 0;
             case 's':
             {
@@ -178,7 +177,7 @@ extern int main(int argc, char** argv)
     }
 #endif
 
-    sLog.outString("%s [world-daemon]", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_NR, REVISION_ID));
+    sLog.outString("%s [world-daemon]", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_ID));
     sLog.outString("<Ctrl-C> to stop.");
     sLog.outString("\n\n"
                    "       _____     __  __       _   _  _____  ____   _____ \n"

--- a/src/realmd/Main.cpp
+++ b/src/realmd/Main.cpp
@@ -29,7 +29,6 @@
 #include "AuthSocket.h"
 #include "SystemConfig.h"
 #include "revision.h"
-#include "revision_nr.h"
 #include "revision_sql.h"
 #include "Util.h"
 #include <openssl/opensslv.h>
@@ -107,7 +106,7 @@ extern int main(int argc, char** argv)
                 cfg_file = cmd_opts.opt_arg();
                 break;
             case 'v':
-                printf("%s\n", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_NR, REVISION_ID));
+                printf("%s\n", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_ID));
                 return 0;
 
             case 's':
@@ -185,7 +184,7 @@ extern int main(int argc, char** argv)
 
     sLog.Initialize();
 
-    sLog.outString("%s [realm-daemon]", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_NR, REVISION_ID));
+    sLog.outString("%s [realm-daemon]", _FULLVERSION(REVISION_DATE, REVISION_TIME, REVISION_ID));
     sLog.outString("<Ctrl-C> to stop.\n");
     sLog.outString("Using configuration file %s.", cfg_file);
 

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -100,7 +100,6 @@ set(LIBRARY_SRCS
     Common.cpp
     Common.h
     LockedQueue.h
-    revision_nr.h
     revision_sql.h
     SystemConfig.h
     Threading.cpp

--- a/src/shared/SystemConfig.h.in
+++ b/src/shared/SystemConfig.h.in
@@ -27,9 +27,9 @@
 
 #ifndef _VERSION
 #if PLATFORM == PLATFORM_WINDOWS
-# define _VERSION(REVD,REVT,REVN,REVH) "0.17" " (" REVD " " REVT " Revision " REVN " - " REVH ")"
+# define _VERSION(REVD,REVT,REVH) "0.17" " (" REVD " " REVT " - " REVH ")"
 #else
-# define _VERSION(REVD,REVT,REVN,REVH) "@VERSION@" " (" REVD " " REVT " Revision " REVN " - " REVH ")"
+# define _VERSION(REVD,REVT,REVH) "@VERSION@" " (" REVD " " REVT " - " REVH ")"
 #endif
 #endif
 
@@ -93,7 +93,7 @@
 # define _AUCTIONHOUSEBOT_CONFIG   SYSCONFDIR"ahbot.conf"
 #endif
 
-#define _FULLVERSION(REVD,REVT,REVN,REVH) _PACKAGENAME "/" _VERSION(REVD,REVT,REVN,REVH) " for " _ENDIAN_PLATFORM
+#define _FULLVERSION(REVD,REVT,REVH) _PACKAGENAME "/" _VERSION(REVD,REVT,REVH) " for " _ENDIAN_PLATFORM
 
 #define DEFAULT_PLAYER_LIMIT 100
 #define DEFAULT_WORLDSERVER_PORT 8085                       //8129

--- a/src/shared/WheatyExceptionReport.cpp
+++ b/src/shared/WheatyExceptionReport.cpp
@@ -15,7 +15,6 @@
 #include <dbghelp.h>
 #include "WheatyExceptionReport.h"
 #include "revision.h"
-#include "revision_nr.h"
 #define CrashFolder _T("Crashes")
 //#pragma comment(linker, "/defaultlib:dbghelp.lib")
 
@@ -299,7 +298,7 @@ void WheatyExceptionReport::GenerateExceptionReport(
     GetLocalTime(&systime);
 
     // Start out with a banner
-    _tprintf(_T("Revision: %s %s %s %s\r\n"), REVISION_DATE, REVISION_TIME, REVISION_NR, REVISION_ID);
+    _tprintf(_T("Revision: %s %s %s\r\n"), REVISION_DATE, REVISION_TIME, REVISION_ID);
     _tprintf(_T("Date %u:%u:%u. Time %u:%u \r\n"), systime.wDay, systime.wMonth, systime.wYear, systime.wHour, systime.wMinute);
     PEXCEPTION_RECORD pExceptionRecord = pExceptionInfo->ExceptionRecord;
 

--- a/src/shared/revision_nr.h
+++ b/src/shared/revision_nr.h
@@ -1,4 +1,0 @@
-#ifndef __REVISION_NR_H__
-#define __REVISION_NR_H__
- #define REVISION_NR "12934"
-#endif // __REVISION_NR_H__

--- a/win/VC100/shared.vcxproj
+++ b/win/VC100/shared.vcxproj
@@ -482,7 +482,6 @@
     <ClInclude Include="..\..\src\shared\LockedQueue.h" />
     <ClInclude Include="..\..\src\shared\Log.h" />
     <ClInclude Include="..\..\src\shared\ProgressBar.h" />
-    <ClInclude Include="..\..\src\shared\revision_nr.h" />
     <ClInclude Include="..\..\src\shared\revision_sql.h" />
     <ClInclude Include="..\..\src\shared\ServiceWin32.h" />
     <ClInclude Include="..\..\src\shared\Threading.h" />

--- a/win/VC100/shared.vcxproj.filters
+++ b/win/VC100/shared.vcxproj.filters
@@ -172,7 +172,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\shared\Common.h" />
     <ClInclude Include="..\..\src\shared\LockedQueue.h" />
-    <ClInclude Include="..\..\src\shared\revision_nr.h" />
     <ClInclude Include="..\..\src\shared\revision_sql.h" />
     <ClInclude Include="..\..\src\shared\ServiceWin32.h" />
     <ClInclude Include="..\..\src\shared\Threading.h" />

--- a/win/VC110/shared.vcxproj
+++ b/win/VC110/shared.vcxproj
@@ -488,7 +488,6 @@
     <ClInclude Include="..\..\src\shared\LockedQueue.h" />
     <ClInclude Include="..\..\src\shared\Log.h" />
     <ClInclude Include="..\..\src\shared\ProgressBar.h" />
-    <ClInclude Include="..\..\src\shared\revision_nr.h" />
     <ClInclude Include="..\..\src\shared\revision_sql.h" />
     <ClInclude Include="..\..\src\shared\ServiceWin32.h" />
     <ClInclude Include="..\..\src\shared\Threading.h" />

--- a/win/VC110/shared.vcxproj.filters
+++ b/win/VC110/shared.vcxproj.filters
@@ -172,7 +172,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\shared\Common.h" />
     <ClInclude Include="..\..\src\shared\LockedQueue.h" />
-    <ClInclude Include="..\..\src\shared\revision_nr.h" />
     <ClInclude Include="..\..\src\shared\revision_sql.h" />
     <ClInclude Include="..\..\src\shared\ServiceWin32.h" />
     <ClInclude Include="..\..\src\shared\Threading.h" />

--- a/win/VC120/shared.vcxproj
+++ b/win/VC120/shared.vcxproj
@@ -488,7 +488,6 @@
     <ClInclude Include="..\..\src\shared\LockedQueue.h" />
     <ClInclude Include="..\..\src\shared\Log.h" />
     <ClInclude Include="..\..\src\shared\ProgressBar.h" />
-    <ClInclude Include="..\..\src\shared\revision_nr.h" />
     <ClInclude Include="..\..\src\shared\revision_sql.h" />
     <ClInclude Include="..\..\src\shared\ServiceWin32.h" />
     <ClInclude Include="..\..\src\shared\Threading.h" />

--- a/win/VC120/shared.vcxproj.filters
+++ b/win/VC120/shared.vcxproj.filters
@@ -172,7 +172,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\shared\Common.h" />
     <ClInclude Include="..\..\src\shared\LockedQueue.h" />
-    <ClInclude Include="..\..\src\shared\revision_nr.h" />
     <ClInclude Include="..\..\src\shared\revision_sql.h" />
     <ClInclude Include="..\..\src\shared\ServiceWin32.h" />
     <ClInclude Include="..\..\src\shared\Threading.h" />


### PR DESCRIPTION
Use git_id for sql updates only

This tool hinders workflow and is only useful for database updates. git_id will now silently exit except if new sql updates are found in which case it does the usual git_id sql magic.

Notes for devs:
* You need to rebuild git_id.exe
* Keep in mind that as before you need to push changes between git commits with sql updates as the last version is checked using the git remote.
* There is no longer any version check between script library (ScriptDev2) and core

Advantages:
* Reduce amount of change conflicts
* Able to merge PRs using github UI
* Less of a hassle when working in git with rebases, branches, etc.
* Make backporting easier and more fun
