### PR TITLE
Fix for branching within exclusiveGroup questline

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -13827,6 +13827,9 @@ bool Player::SatisfyQuestPreviousQuest(Quest const* qInfo, bool msg) const
                     return true;
 
                 // each-from-all exclusive group ( < 0)
+				// given a group with 2+ quests, and one of those has a branch that is not restricted by the group, return true
+				if (qInfo->GetPrevQuestId() != 0 && qPrevInfo->GetNextQuestId() != qInfo->GetPrevQuestId())
+					return true;
                 // can be start if only all quests in prev quest exclusive group completed and rewarded
                 ExclusiveQuestGroupsMapBounds bounds = sObjectMgr.GetExclusiveQuestGroupsMapBounds(qPrevInfo->GetExclusiveGroup());
 
@@ -13861,6 +13864,9 @@ bool Player::SatisfyQuestPreviousQuest(Quest const* qInfo, bool msg) const
                     return true;
 
                 // each-from-all exclusive group ( < 0)
+				// given a group with 2+ quests, and one of those has a branch that is not restricted by the group, return true
+				if (qInfo->GetPrevQuestId() != 0 && qPrevInfo->GetNextQuestId() != abs(qInfo->GetPrevQuestId()))
+					return true;
                 // can be start if only all quests in prev quest exclusive group active
                 ExclusiveQuestGroupsMapBounds bounds = sObjectMgr.GetExclusiveQuestGroupsMapBounds(qPrevInfo->GetExclusiveGroup());
 


### PR DESCRIPTION
Fixed a special case when quest A has prequest B, that has
exclusiveGroup<0, and exclusiveGroup relates to quest C, hence quest A
should continue just after parent activation/completion not whole
exclusiveGroup completion.