### PR TITLE
Fix travis clang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ language: cpp
 git:
   depth: 1
 
+# make use of the new container based infrastructure at travis to improve performance (we don't need sudo)
+sudo: false
+
 # only run travis on the master branch
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,23 @@ compiler:
   - gcc
   - clang
 
+addons:
+  apt:
+    sources:
+      - kalakris-cmake
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - build-essential
+      - libtool
+      - gcc-4.8
+      - g++-4.8
+      - make
+      - cmake
+
+# overwrite GCC version for GCC build only
 before_install:
-  - echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
-  - echo "yes" | sudo add-apt-repository ppa:boost-latest/ppa
-  - echo "yes" | sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install build-essential libtool gcc-4.8 g++-4.8 make cmake
-  - export CXX="g++-4.8"
-  - export CC="gcc-4.8"
+  - if [ $CC = "gcc" ] ; then export CC=gcc-4.8 CXX=g++-4.8 ; fi
 
 script:
   - test -d _build || mkdir _build

--- a/dep/src/g3dlite/uint128.cpp
+++ b/dep/src/g3dlite/uint128.cpp
@@ -17,8 +17,9 @@ static void addAndCarry(const uint64& _a, const uint64& _b, uint64& carry, uint6
         
     // Break each number into 4 32-bit chunks. Since we are using uints, right-shifting will fill with zeros.
     // This eliminates the need to and with 0xFFFFFFFF.
-    uint32 a [2] = {_a & 0xFFFFFFFF, _a >> 32};
-    uint32 b [2] = {_b & 0xFFFFFFFF, _b >> 32};
+    /* G3DFIX: fix adding explicit use of static_cast */
+    uint32 a [2] = {static_cast<unsigned int>(_a & 0xFFFFFFFF), static_cast<unsigned int>(_a >> 32)};
+    uint32 b [2] = {static_cast<unsigned int>(_b & 0xFFFFFFFF), static_cast<unsigned int>(_b >> 32)};
 
     uint64 tmp = uint64(a[0]) + b[0];
 
@@ -35,8 +36,9 @@ void multiplyAndCarry(const uint64& _a, const uint64& _b, uint64& carry, uint64&
 
     // Break each number into 4 32-bit chunks. Since we are using uints, right-shifting will fill with zeros.
     // This eliminates the need to and with 0xFFFFFFFF.
-    uint32 a [2] = {_a & 0xFFFFFFFF, _a >> 32};
-    uint32 b [2] = {_b & 0xFFFFFFFF, _b >> 32};
+    /* G3DFIX: fix adding explicit use of static_cast */
+    uint32 a[2] = { static_cast<unsigned int>(_a & 0xFFFFFFFF), static_cast<unsigned int>(_a >> 32) };
+    uint32 b[2] = { static_cast<unsigned int>(_b & 0xFFFFFFFF), static_cast<unsigned int>(_b >> 32) };
 
     uint64 prod [2][2];
     for(int i = 0; i < 2; ++i) {

--- a/src/game/vmap/RegularGrid.h
+++ b/src/game/vmap/RegularGrid.h
@@ -107,7 +107,7 @@ class RegularGrid2D
 
             static Cell ComputeCell(float fx, float fy)
             {
-                Cell c = {fx* (1.f / CELL_SIZE) + (CELL_NUMBER / 2), fy* (1.f / CELL_SIZE) + (CELL_NUMBER / 2)};
+                Cell c = { static_cast<int>(fx* (1.f / CELL_SIZE) + (CELL_NUMBER / 2)), static_cast<int>(fy* (1.f / CELL_SIZE) + (CELL_NUMBER / 2)) };
                 return c;
             }
 


### PR DESCRIPTION
The clang build on travis has been broken (or rather: replaced by another
GCC build) since commit 7b68f38 because the install part always set GCC as
the compiler. Using built-in travis addons to install the sources fixes
this problem.