### PR TITLE
Fix Skeram Earth Shock

### DIFF
--- a/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_skeram.cpp
+++ b/src/scriptdev2/scripts/kalimdor/temple_of_ahnqiraj/boss_skeram.cpp
@@ -213,6 +213,18 @@ struct boss_skeramAI : public ScriptedAI
         else
             m_uiBlinkTimer -= uiDiff;
 
+        // Earth Shock is cast every 1.2s on the victim if Skeram can't reach them or they are not auto attacking him
+        if (m_uiEarthShockTimer < uiDiff)
+        {
+            if (!m_creature->CanReachWithMeleeAttack(pVictim) || !pVictim->hasUnitState(UNIT_STAT_MELEE_ATTACKING))
+            {
+                DoCastSpellIfCan(pVictim, SPELL_EARTH_SHOCK);
+                m_uiEarthShockTimer = 1200;
+            }
+        }
+        else
+            m_uiEarthShockTimer -= uiDiff;
+
         // Summon images at 75%, 50% and 25%
         if (!m_bIsImage && m_creature->GetHealthPercent() < m_fHpCheck)
         {
@@ -224,21 +236,6 @@ struct boss_skeramAI : public ScriptedAI
                 m_creature->SetVisibility(VISIBILITY_OFF);
                 m_uiBlinkTimer = 2000;
             }
-        }
-
-        // Earth Shock is cast each 1.2s on a random target if Skeram can't reach his victim or the victim is not auto attacking him
-        if (!m_creature->CanReachWithMeleeAttack(pVictim) || !pVictim->hasUnitState(UNIT_STAT_MELEE_ATTACKING))
-        {
-            if (m_uiEarthShockTimer < uiDiff)
-            {
-                if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
-                {
-                    DoCastSpellIfCan(pTarget, SPELL_EARTH_SHOCK);
-                    m_uiEarthShockTimer = 1200;
-                }
-            }
-            else
-                m_uiEarthShockTimer -= uiDiff;
         }
 
         DoMeleeAttackIfReady();


### PR DESCRIPTION
As of now, if you engage The Prophet Skeram in AQ40 he instakills you by spamming Earth Shock, because the spell gets cast on each update call of the ai script.
This commit fixes the spell spam and also corrects the spell mechanic itself: Skeram only uses Earth Shock if the the victim is not auto attacking him *or* Skeram cannot reach his current victim.

I went to live for testing the mechanic and found out that contrary to wowwiki ("once every second") he instead casts it every 1.2 seconds. Feel free to comment on / improve the change.

Edit: Removed a weird initial commit from history.

In the updated commit Skeram no longer chooses his Earth Shock target randomly but the victim itself (as stated on wowwiki). I also dewrapped the timer so it ticks regardless whether he would be able cast it or not which is more like a cooldown implementation and also is consistent with the above implemented timers.