### PR TITLE
Remove master only requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ git:
 # make use of the new container based infrastructure at travis to improve performance (we don't need sudo)
 sudo: false
 
-# only run travis on the master branch
-branches:
-  only:
-    - master
-
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
This way forks can use travis without removing this and adding it back if a PR is made.
Not sure why this is here in the first place. If a branch should not be compiled then rather block that branch instead of blocking all branches.