### PR TITLE
Implement SCRIPT_COMMAND_UPDATE_TEMPLATE

### DIFF
--- a/src/game/ScriptMgr.cpp
+++ b/src/game/ScriptMgr.cpp
@@ -734,6 +734,20 @@ void ScriptMgr::LoadScripts(ScriptMapMapName& scripts, const char* tablename)
             }
             case SCRIPT_COMMAND_RESET_GO:                   // 43
                 break;
+            case SCRIPT_COMMAND_UPDATE_TEMPLATE:            // 44
+            {
+                if (!sCreatureStorage.LookupEntry<CreatureInfo>(tmp.updateTemplate.newTemplate))
+                {
+                    sLog.outErrorDb("Table `%s` uses nonexistent creature entry %u in SCRIPT_COMMAND_PLAYER_LEARN_SPELL for script id %u.", tablename, tmp.updateTemplate.newTemplate, tmp.id);
+                    continue;
+                }
+                if (tmp.updateTemplate.newFactionTeam != 0 && tmp.updateTemplate.newFactionTeam != 1)
+                {
+                    sLog.outErrorDb("Table `%s` uses nonexistent faction team %u in SCRIPT_COMMAND_PLAYER_LEARN_SPELL for script id %u.", tablename, tmp.updateTemplate.newFactionTeam, tmp.id);
+                    continue;
+                }
+                break;
+            }
             default:
             {
                 sLog.outErrorDb("Table `%s` unknown command %u, skipping.", tablename, tmp.command);
@@ -2051,6 +2065,19 @@ bool ScriptAction::HandleScriptStep()
                     sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u failed for gameobject(buddyEntry: %u). Gameobject is not a door or button", m_table, m_script->id, m_script->command, m_script->buddyEntry);
                     break;
             }
+            break;
+        }
+        case SCRIPT_COMMAND_UPDATE_TEMPLATE:
+        {
+            if (LogIfNotCreature(pSource))
+                return false;
+
+            Creature* pCSource = static_cast<Creature*>(pSource);
+
+            if (pCSource->GetEntry() != m_script->updateTemplate.newTemplate)
+                pCSource->UpdateEntry(m_script->updateTemplate.newTemplate, m_script->updateTemplate.newFactionTeam ? HORDE : ALLIANCE);
+            else
+                sLog.outErrorDb(" DB-SCRIPTS: Process table `%s` id %u, command %u failed. Source already has specified creature entry.", m_table, m_script->id, m_script->command);
             break;
         }
         default:

--- a/src/game/ScriptMgr.h
+++ b/src/game/ScriptMgr.h
@@ -126,6 +126,9 @@ enum ScriptCommand                                          // resSource, resTar
                                                             // datalong = resetDefault: bool 0=false, 1=true
                                                             // dataint = main hand slot; dataint2 = off hand slot; dataint3 = ranged slot
     SCRIPT_COMMAND_RESET_GO                 = 43,           // resTarget = GameObject
+    SCRIPT_COMMAND_UPDATE_TEMPLATE          = 44,           // resSource = Creature
+                                                            // datalong = new Creature entry
+                                                            // datalong2 = Alliance(0) Horde(1), other values throw error
 };
 
 #define MAX_TEXT_ID 4                                       // used for SCRIPT_COMMAND_TALK, SCRIPT_COMMAND_EMOTE, SCRIPT_COMMAND_CAST_SPELL, SCRIPT_COMMAND_TERMINATE_SCRIPT
@@ -390,6 +393,12 @@ struct ScriptInfo
         } setEquipment;
 
         // datalong unsed                                   // SCRIPT_COMMAND_RESET_GO (43)
+
+        struct                                              // SCRIPT_COMMAND_UPDATE_TEMPLATE (44)
+        {
+            uint32 newTemplate;                             // datalong
+            uint32 newFactionTeam;                          // datalong2
+        } updateTemplate;
 
         struct
         {


### PR DESCRIPTION
Implement new feature for dbscripts, change creature template. This feature was already done in EventAI so this is just an addition because of consistency. Some quests in TBC require this change.

Datalong is new creature entry and datalong2 is 0 for FactionAlliance or 1 for FactionHorde in DB.