### PR TITLE
Fix for the so-called "target bug"

### DIFF
--- a/src/game/MiscHandler.cpp
+++ b/src/game/MiscHandler.cpp
@@ -1079,8 +1079,6 @@ void WorldSession::HandleInspectOpcode(WorldPacket& recv_data)
     recv_data >> guid;
     DEBUG_LOG("Inspected guid is %s", guid.GetString().c_str());
 
-    _player->SetSelectionGuid(guid);
-
     Player* plr = sObjectMgr.GetPlayer(guid);
     if (!plr)                                               // wrong player
         return;


### PR DESCRIPTION
Inspect handler should not silently (server-side only) change player's current selection. This behaviour leads to unwanted side-effects such as summons landing on wrong group members. Its intended for inspect target and real player target to be separate, as many addons rely on background inspect queries to function properly.