### PR TITLE
Fix possitive/negative effect for spells 37097 and 50312

### DIFF
--- a/src/game/SpellMgr.cpp
+++ b/src/game/SpellMgr.cpp
@@ -860,6 +860,7 @@ bool IsPositiveEffect(SpellEntry const* spellproto, SpellEffectIndex effIndex)
                     {
                         case 36897:                         // Transporter Malfunction (race mutation to horde)
                         case 36899:                         // Transporter Malfunction (race mutation to alliance)
+                        case 37097:                         // Crate Disguise
                             return false;
                     }
                     break;
@@ -869,6 +870,7 @@ bool IsPositiveEffect(SpellEntry const* spellproto, SpellEffectIndex effIndex)
                     {
                         case 802:                           // Mutate Bug, wrongly negative by target modes
                         case 38449:                         // Blessing of the Tides
+                        case 50312:                         // Unholy Frenzy
                             return true;
                         case 36900:                         // Soul Split: Evil!
                         case 36901:                         // Soul Split: Good


### PR DESCRIPTION
corrected:
spell:37097 Should have negative effect (players shouldn't be able to remove it)
spell:50312 Should have positive effect (can be casted on friendly unit)