### PR TITLE
ACTION_T_SET_HEALTH_OR_POWER

### DIFF
--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -1079,9 +1079,6 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 case 4:
                     m_creature->SetMaxHealth(action.setPower.value);
                     break;
-                case 5:
-                    m_creature->SetHealthPercent((float)action.setPower.percent);
-                    break;
             }
             break;
         }

--- a/src/game/AI/CreatureEventAI.cpp
+++ b/src/game/AI/CreatureEventAI.cpp
@@ -1060,6 +1060,31 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             sLog.outString("Set AI react state to %u for %s", uint32(m_reactState), m_creature->GetGuidStr().c_str());
             break;
         }
+        case ACTION_T_SET_HEALTH_OR_POWER:
+        {
+            switch (action.setPower.powerIndex)
+            {
+                case 0:
+                    m_creature->SetPower(POWER_MANA, action.setPower.value);
+                    break;
+                case 1:
+                    m_creature->SetPower(POWER_RAGE, action.setPower.value);
+                    break;
+                case 2:
+                    m_creature->SetPower(POWER_ENERGY, action.setPower.value);
+                    break;
+                case 3:
+                    m_creature->SetHealth(action.setPower.value);
+                    break;
+                case 4:
+                    m_creature->SetMaxHealth(action.setPower.value);
+                    break;
+                case 5:
+                    m_creature->SetHealthPercent((float)action.setPower.percent);
+                    break;
+            }
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/CreatureEventAI.h
+++ b/src/game/AI/CreatureEventAI.h
@@ -126,6 +126,7 @@ enum EventAI_ActionType
     ACTION_T_CHANGE_MOVEMENT            = 48,               // MovementType, WanderDistance, unused
     ACTION_T_DYNAMIC_MOVEMENT           = 49,               // EnableDynamicMovement (1 = on; 0 = off)
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
+    ACTION_T_SET_HEALTH_OR_POWER        = 51,               // PowerTypeIndex, Value.
 
     ACTION_T_END,
 };
@@ -435,6 +436,13 @@ struct CreatureEventAI_Action
             uint32 unused1;
             uint32 unused2;
         } setReactState;
+        // ACTION_T_SET_HEALTH_OR_POWER                     = 51
+        struct  
+        {
+            uint32 powerIndex;
+            uint32 value;
+            uint32 percent;
+        } setPower;
         // RAW
         struct
         {

--- a/src/game/AI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/CreatureEventAIMgr.cpp
@@ -836,6 +836,7 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     case ACTION_T_RANGED_MOVEMENT:          // Distance, Angle
                     case ACTION_T_CALL_FOR_HELP:            // Distance
                     case ACTION_T_DYNAMIC_MOVEMENT:         // EnableDynamicMovement (1 = on; 0 = off)
+                    case ACTION_T_SET_HEALTH_OR_POWER:      // Set Power or Health (PowerType Index, Value)
                         break;
 
                     case ACTION_T_RANDOM_SAY:


### PR DESCRIPTION
Allow Set Health Or Power without use UNIT_FIELD_FLAGS on all branch.
https://github.com/cmangos/issues/issues/270
Addressed issue.

Update: NoPCH random error.
