### PR TITLE
Fixed build g3dlite in X64 configuration.

### DIFF
--- a/dep/src/g3dlite/System.cpp
+++ b/dep/src/g3dlite/System.cpp
@@ -32,6 +32,7 @@
 
 #include <cstring>
 #include <cstdio>
+#include <intrin.h>
 
 // Uncomment the following line to turn off G3D::System memory
 // allocation and use the operating system's malloc.


### PR DESCRIPTION
Fixed issue #Compilation error: identifier __cpuid not found #1367

Signed-off-by: Konstantin <gawrilyako@gmail.com>