### PR TITLE
Add Areatrigger 171 into ScriptDev2

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -12,61 +12,8 @@ UPDATE world_template SET ScriptName='';
 /*  */
 
 /* AREATRIGGER */
-DELETE FROM scripted_areatrigger WHERE entry=4591;
-INSERT INTO scripted_areatrigger VALUES (4591,'at_coilfang_waterfall');
-DELETE FROM scripted_areatrigger WHERE entry=4560;
-INSERT INTO scripted_areatrigger VALUES (4560,'at_legion_teleporter');
-DELETE FROM scripted_areatrigger WHERE entry=3066;
-INSERT INTO scripted_areatrigger VALUES (3066,'at_ravenholdt');
-DELETE FROM scripted_areatrigger WHERE entry IN (4871,4872,4873);
-INSERT INTO scripted_areatrigger VALUES
-(4871,'at_warsong_farms'),
-(4872,'at_warsong_farms'),
-(4873,'at_warsong_farms');
-DELETE FROM scripted_areatrigger WHERE entry IN (5046,5047);
-INSERT INTO scripted_areatrigger VALUES
-(5046,'at_waygate'),
-(5047,'at_waygate');
-DELETE FROM scripted_areatrigger WHERE entry BETWEEN 5284 AND 5287;
-INSERT INTO scripted_areatrigger VALUES
-(5284,'at_aldurthar_gate'),
-(5285,'at_aldurthar_gate'),
-(5286,'at_aldurthar_gate'),
-(5287,'at_aldurthar_gate');
-DELETE FROM scripted_areatrigger WHERE entry IN (4112,4113);
-INSERT INTO scripted_areatrigger VALUES
-(4112,'at_naxxramas'),
-(4113,'at_naxxramas');
-DELETE FROM scripted_areatrigger WHERE entry=5108;
-INSERT INTO scripted_areatrigger VALUES (5108,'at_stormwright_shelf');
-DELETE FROM scripted_areatrigger WHERE entry IN (3546,3547,3548,3549,3550,3552);
-INSERT INTO scripted_areatrigger VALUES
-(3546,'at_childrens_week_spot'), -- Darnassian bank
-(3547,'at_childrens_week_spot'), -- Undercity - thone room
-(3548,'at_childrens_week_spot'), -- Stonewrought Dam
-(3549,'at_childrens_week_spot'), -- The Mor'shan Rampart
-(3550,'at_childrens_week_spot'), -- Ratchet Docks
-(3552,'at_childrens_week_spot'); -- Westfall Lighthouse
-DELETE FROM scripted_areatrigger WHERE entry IN (2026,2046,2066,2067);
-INSERT INTO scripted_areatrigger VALUES
-(2026,'at_blackrock_spire'),
-(2046,'at_blackrock_spire'),
-(2066,'at_blackrock_spire'),
-(2067,'at_blackrock_spire');
-DELETE FROM scripted_areatrigger WHERE entry=5030;
-INSERT INTO scripted_areatrigger VALUES (5030,'at_spearborn_encampment');
-DELETE FROM scripted_areatrigger WHERE entry IN (3958,3960);
-INSERT INTO scripted_areatrigger VALUES
-(3958,'at_zulgurub'),
-(3960,'at_zulgurub');
-DELETE FROM scripted_areatrigger WHERE entry=3626;
-INSERT INTO scripted_areatrigger VALUES (3626,'at_vaelastrasz');
-DELETE FROM scripted_areatrigger WHERE entry=4937;
-INSERT INTO scripted_areatrigger VALUES (4937,'at_sunwell_plateau');
-DELETE FROM scripted_areatrigger WHERE entry=4524;
-INSERT INTO scripted_areatrigger VALUES (4524,'at_shattered_halls');
-DELETE FROM scripted_areatrigger WHERE entry BETWEEN 1726 AND 1740;
-INSERT INTO scripted_areatrigger VALUES
+INSERT INTO scripted_areatrigger (entry,ScriptName) VALUES
+(171, 'at_huldar_miran'),
 (1726,'at_scent_larkorwi'),
 (1727,'at_scent_larkorwi'),
 (1728,'at_scent_larkorwi'),
@@ -81,30 +28,51 @@ INSERT INTO scripted_areatrigger VALUES
 (1737,'at_scent_larkorwi'),
 (1738,'at_scent_larkorwi'),
 (1739,'at_scent_larkorwi'),
-(1740,'at_scent_larkorwi');
-DELETE FROM scripted_areatrigger WHERE entry in (4288,4485);
-INSERT INTO scripted_areatrigger VALUES
-(4288,'at_dark_portal'),
-(4485,'at_dark_portal');
-DELETE FROM scripted_areatrigger WHERE entry=1966;
-INSERT INTO scripted_areatrigger VALUES (1966,'at_murkdeep');
-DELETE FROM scripted_areatrigger WHERE entry IN (4047,4052);
-INSERT INTO scripted_areatrigger VALUES
+(1740,'at_scent_larkorwi'), 
+(1966,'at_murkdeep'),
+(2026,'at_blackrock_spire'),
+(2046,'at_blackrock_spire'),
+(2066,'at_blackrock_spire'),
+(2067,'at_blackrock_spire'),
+(3066,'at_ravenholdt'),
+(3546,'at_childrens_week_spot'), -- Darnassian bank
+(3547,'at_childrens_week_spot'), -- Undercity - thone room
+(3548,'at_childrens_week_spot'), -- Stonewrought Dam
+(3549,'at_childrens_week_spot'), -- The Mor'shan Rampart
+(3550,'at_childrens_week_spot'), -- Ratchet Docks
+(3552,'at_childrens_week_spot'), -- Westfall Lighthouse
+(3587,'at_ancient_leaf'),
+(3626,'at_vaelastrasz'),
+(3958,'at_zulgurub'),
+(3960,'at_zulgurub'),
 (4047,'at_temple_ahnqiraj'),
-(4052,'at_temple_ahnqiraj');
-DELETE FROM scripted_areatrigger WHERE entry IN (5710,5711,5712,5714,5715,5716);
-INSERT INTO scripted_areatrigger VALUES
-(5710, 'at_hot_on_the_trail'),
-(5711, 'at_hot_on_the_trail'),
-(5712, 'at_hot_on_the_trail'),
-(5714, 'at_hot_on_the_trail'),
-(5715, 'at_hot_on_the_trail'),
-(5716, 'at_hot_on_the_trail');
-DELETE FROM scripted_areatrigger WHERE entry=3587;
-INSERT INTO scripted_areatrigger VALUES (3587,'at_ancient_leaf');
-DELETE FROM scripted_areatrigger WHERE entry=4479;
-INSERT INTO scripted_areatrigger VALUES (4479,'at_haramad_teleport');
-
+(4052,'at_temple_ahnqiraj'),
+(4112,'at_naxxramas'),
+(4113,'at_naxxramas'),
+(4288,'at_dark_portal'),
+(4479,'at_haramad_teleport'),
+(4485,'at_dark_portal'),
+(4524,'at_shattered_halls'),
+(4560,'at_legion_teleporter'),
+(4591,'at_coilfang_waterfall'),
+(4871,'at_warsong_farms'),
+(4872,'at_warsong_farms'),
+(4873,'at_warsong_farms'),
+(4937,'at_sunwell_plateau'),
+(5030,'at_spearborn_encampment'),
+(5046,'at_waygate'),
+(5047,'at_waygate'),
+(5108,'at_stormwright_shelf'),
+(5284,'at_aldurthar_gate'),
+(5285,'at_aldurthar_gate'),
+(5286,'at_aldurthar_gate'),
+(5287,'at_aldurthar_gate'),
+(5710,'at_hot_on_the_trail'),
+(5711,'at_hot_on_the_trail'),
+(5712,'at_hot_on_the_trail'),
+(5714,'at_hot_on_the_trail'),
+(5715,'at_hot_on_the_trail'),
+(5716,'at_hot_on_the_trail');
 
 /* BATTLEGROUNDS */
 UPDATE creature_template SET ScriptName='npc_spirit_guide' WHERE entry IN (13116, 13117);

--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -12,59 +12,8 @@ UPDATE world_template SET ScriptName='';
 /*  */
 
 /* AREATRIGGER */
-DELETE FROM scripted_areatrigger WHERE entry=4591;
-INSERT INTO scripted_areatrigger VALUES (4591,'at_coilfang_waterfall');
-DELETE FROM scripted_areatrigger WHERE entry=4560;
-INSERT INTO scripted_areatrigger VALUES (4560,'at_legion_teleporter');
-DELETE FROM scripted_areatrigger WHERE entry=3066;
-INSERT INTO scripted_areatrigger VALUES (3066,'at_ravenholdt');
-DELETE FROM scripted_areatrigger WHERE entry IN (4871,4872,4873);
-INSERT INTO scripted_areatrigger VALUES
-(4871,'at_warsong_farms'),
-(4872,'at_warsong_farms'),
-(4873,'at_warsong_farms');
-DELETE FROM scripted_areatrigger WHERE entry IN (5046,5047);
-INSERT INTO scripted_areatrigger VALUES
-(5046,'at_waygate'),
-(5047,'at_waygate');
-DELETE FROM scripted_areatrigger WHERE entry BETWEEN 5284 AND 5287;
-INSERT INTO scripted_areatrigger VALUES
-(5284,'at_aldurthar_gate'),
-(5285,'at_aldurthar_gate'),
-(5286,'at_aldurthar_gate'),
-(5287,'at_aldurthar_gate');
-DELETE FROM scripted_areatrigger WHERE entry IN (4112,4113);
-INSERT INTO scripted_areatrigger VALUES
-(4112,'at_naxxramas'),
-(4113,'at_naxxramas');
-DELETE FROM scripted_areatrigger WHERE entry=5108;
-INSERT INTO scripted_areatrigger VALUES (5108,'at_stormwright_shelf');
-DELETE FROM scripted_areatrigger WHERE entry IN (3546,3547,3548,3549,3550,3552);
-INSERT INTO scripted_areatrigger VALUES
-(3546,'at_childrens_week_spot'), -- Darnassian bank
-(3547,'at_childrens_week_spot'), -- Undercity - thone room
-(3548,'at_childrens_week_spot'), -- Stonewrought Dam
-(3549,'at_childrens_week_spot'), -- The Mor'shan Rampart
-(3550,'at_childrens_week_spot'), -- Ratchet Docks
-(3552,'at_childrens_week_spot'); -- Westfall Lighthouse
-DELETE FROM scripted_areatrigger WHERE entry IN (2026,2046);
-INSERT INTO scripted_areatrigger VALUES
-(2026,'at_blackrock_spire'),
-(2046,'at_blackrock_spire');
-DELETE FROM scripted_areatrigger WHERE entry=5030;
-INSERT INTO scripted_areatrigger VALUES (5030,'at_spearborn_encampment');
-DELETE FROM scripted_areatrigger WHERE entry IN (3958,3960);
-INSERT INTO scripted_areatrigger VALUES
-(3958,'at_zulgurub'),
-(3960,'at_zulgurub');
-DELETE FROM scripted_areatrigger WHERE entry=3626;
-INSERT INTO scripted_areatrigger VALUES (3626,'at_vaelastrasz');
-DELETE FROM scripted_areatrigger WHERE entry=4937;
-INSERT INTO scripted_areatrigger VALUES (4937,'at_sunwell_plateau');
-DELETE FROM scripted_areatrigger WHERE entry=4524;
-INSERT INTO scripted_areatrigger VALUES (4524,'at_shattered_halls');
-DELETE FROM scripted_areatrigger WHERE entry BETWEEN 1726 AND 1740;
-INSERT INTO scripted_areatrigger VALUES
+INSERT INTO scripted_areatrigger (entry,ScriptName) VALUES
+(171, 'at_huldar_miran'),
 (1726,'at_scent_larkorwi'),
 (1727,'at_scent_larkorwi'),
 (1728,'at_scent_larkorwi'),
@@ -79,30 +28,49 @@ INSERT INTO scripted_areatrigger VALUES
 (1737,'at_scent_larkorwi'),
 (1738,'at_scent_larkorwi'),
 (1739,'at_scent_larkorwi'),
-(1740,'at_scent_larkorwi');
-DELETE FROM scripted_areatrigger WHERE entry in (4288,4485);
-INSERT INTO scripted_areatrigger VALUES
-(4288,'at_dark_portal'),
-(4485,'at_dark_portal');
-DELETE FROM scripted_areatrigger WHERE entry=1966;
-INSERT INTO scripted_areatrigger VALUES (1966,'at_murkdeep');
-DELETE FROM scripted_areatrigger WHERE entry IN (4047,4052);
-INSERT INTO scripted_areatrigger VALUES
+(1740,'at_scent_larkorwi'), 
+(1966,'at_murkdeep'),
+(2026,'at_blackrock_spire'),
+(2046,'at_blackrock_spire'),
+(3066,'at_ravenholdt'),
+(3546,'at_childrens_week_spot'), -- Darnassian bank
+(3547,'at_childrens_week_spot'), -- Undercity - thone room
+(3548,'at_childrens_week_spot'), -- Stonewrought Dam
+(3549,'at_childrens_week_spot'), -- The Mor'shan Rampart
+(3550,'at_childrens_week_spot'), -- Ratchet Docks
+(3552,'at_childrens_week_spot'), -- Westfall Lighthouse
+(3587,'at_ancient_leaf'),
+(3626,'at_vaelastrasz'),
+(3958,'at_zulgurub'),
+(3960,'at_zulgurub'),
 (4047,'at_temple_ahnqiraj'),
-(4052,'at_temple_ahnqiraj');
-DELETE FROM scripted_areatrigger WHERE entry IN (5710,5711,5712,5714,5715,5716);
-INSERT INTO scripted_areatrigger VALUES
-(5710, 'at_hot_on_the_trail'),
-(5711, 'at_hot_on_the_trail'),
-(5712, 'at_hot_on_the_trail'),
-(5714, 'at_hot_on_the_trail'),
-(5715, 'at_hot_on_the_trail'),
-(5716, 'at_hot_on_the_trail');
-DELETE FROM scripted_areatrigger WHERE entry=3587;
-INSERT INTO scripted_areatrigger VALUES (3587,'at_ancient_leaf');
-DELETE FROM scripted_areatrigger WHERE entry=4479;
-INSERT INTO scripted_areatrigger VALUES (4479,'at_haramad_teleport');
-
+(4052,'at_temple_ahnqiraj'),
+(4112,'at_naxxramas'),
+(4113,'at_naxxramas'),
+(4288,'at_dark_portal'),
+(4479,'at_haramad_teleport'),
+(4485,'at_dark_portal'),
+(4524,'at_shattered_halls'),
+(4560,'at_legion_teleporter'),
+(4591,'at_coilfang_waterfall'),
+(4871,'at_warsong_farms'),
+(4872,'at_warsong_farms'),
+(4873,'at_warsong_farms'),
+(4937,'at_sunwell_plateau'),
+(5030,'at_spearborn_encampment'),
+(5046,'at_waygate'),
+(5047,'at_waygate'),
+(5108,'at_stormwright_shelf'),
+(5284,'at_aldurthar_gate'),
+(5285,'at_aldurthar_gate'),
+(5286,'at_aldurthar_gate'),
+(5287,'at_aldurthar_gate'),
+(5710,'at_hot_on_the_trail'),
+(5711,'at_hot_on_the_trail'),
+(5712,'at_hot_on_the_trail'),
+(5714,'at_hot_on_the_trail'),
+(5715,'at_hot_on_the_trail'),
+(5716,'at_hot_on_the_trail');
 
 /* BATTLEGROUNDS */
 UPDATE creature_template SET ScriptName='npc_spirit_guide' WHERE entry IN (13116, 13117);

--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -12,8 +12,59 @@ UPDATE world_template SET ScriptName='';
 /*  */
 
 /* AREATRIGGER */
-INSERT INTO scripted_areatrigger (entry,ScriptName) VALUES
-(171, 'at_huldar_miran'),
+DELETE FROM scripted_areatrigger WHERE entry=4591;
+INSERT INTO scripted_areatrigger VALUES (4591,'at_coilfang_waterfall');
+DELETE FROM scripted_areatrigger WHERE entry=4560;
+INSERT INTO scripted_areatrigger VALUES (4560,'at_legion_teleporter');
+DELETE FROM scripted_areatrigger WHERE entry=3066;
+INSERT INTO scripted_areatrigger VALUES (3066,'at_ravenholdt');
+DELETE FROM scripted_areatrigger WHERE entry IN (4871,4872,4873);
+INSERT INTO scripted_areatrigger VALUES
+(4871,'at_warsong_farms'),
+(4872,'at_warsong_farms'),
+(4873,'at_warsong_farms');
+DELETE FROM scripted_areatrigger WHERE entry IN (5046,5047);
+INSERT INTO scripted_areatrigger VALUES
+(5046,'at_waygate'),
+(5047,'at_waygate');
+DELETE FROM scripted_areatrigger WHERE entry BETWEEN 5284 AND 5287;
+INSERT INTO scripted_areatrigger VALUES
+(5284,'at_aldurthar_gate'),
+(5285,'at_aldurthar_gate'),
+(5286,'at_aldurthar_gate'),
+(5287,'at_aldurthar_gate');
+DELETE FROM scripted_areatrigger WHERE entry IN (4112,4113);
+INSERT INTO scripted_areatrigger VALUES
+(4112,'at_naxxramas'),
+(4113,'at_naxxramas');
+DELETE FROM scripted_areatrigger WHERE entry=5108;
+INSERT INTO scripted_areatrigger VALUES (5108,'at_stormwright_shelf');
+DELETE FROM scripted_areatrigger WHERE entry IN (3546,3547,3548,3549,3550,3552);
+INSERT INTO scripted_areatrigger VALUES
+(3546,'at_childrens_week_spot'), -- Darnassian bank
+(3547,'at_childrens_week_spot'), -- Undercity - thone room
+(3548,'at_childrens_week_spot'), -- Stonewrought Dam
+(3549,'at_childrens_week_spot'), -- The Mor'shan Rampart
+(3550,'at_childrens_week_spot'), -- Ratchet Docks
+(3552,'at_childrens_week_spot'); -- Westfall Lighthouse
+DELETE FROM scripted_areatrigger WHERE entry IN (2026,2046);
+INSERT INTO scripted_areatrigger VALUES
+(2026,'at_blackrock_spire'),
+(2046,'at_blackrock_spire');
+DELETE FROM scripted_areatrigger WHERE entry=5030;
+INSERT INTO scripted_areatrigger VALUES (5030,'at_spearborn_encampment');
+DELETE FROM scripted_areatrigger WHERE entry IN (3958,3960);
+INSERT INTO scripted_areatrigger VALUES
+(3958,'at_zulgurub'),
+(3960,'at_zulgurub');
+DELETE FROM scripted_areatrigger WHERE entry=3626;
+INSERT INTO scripted_areatrigger VALUES (3626,'at_vaelastrasz');
+DELETE FROM scripted_areatrigger WHERE entry=4937;
+INSERT INTO scripted_areatrigger VALUES (4937,'at_sunwell_plateau');
+DELETE FROM scripted_areatrigger WHERE entry=4524;
+INSERT INTO scripted_areatrigger VALUES (4524,'at_shattered_halls');
+DELETE FROM scripted_areatrigger WHERE entry BETWEEN 1726 AND 1740;
+INSERT INTO scripted_areatrigger VALUES
 (1726,'at_scent_larkorwi'),
 (1727,'at_scent_larkorwi'),
 (1728,'at_scent_larkorwi'),
@@ -28,49 +79,30 @@ INSERT INTO scripted_areatrigger (entry,ScriptName) VALUES
 (1737,'at_scent_larkorwi'),
 (1738,'at_scent_larkorwi'),
 (1739,'at_scent_larkorwi'),
-(1740,'at_scent_larkorwi'), 
-(1966,'at_murkdeep'),
-(2026,'at_blackrock_spire'),
-(2046,'at_blackrock_spire'),
-(3066,'at_ravenholdt'),
-(3546,'at_childrens_week_spot'), -- Darnassian bank
-(3547,'at_childrens_week_spot'), -- Undercity - thone room
-(3548,'at_childrens_week_spot'), -- Stonewrought Dam
-(3549,'at_childrens_week_spot'), -- The Mor'shan Rampart
-(3550,'at_childrens_week_spot'), -- Ratchet Docks
-(3552,'at_childrens_week_spot'), -- Westfall Lighthouse
-(3587,'at_ancient_leaf'),
-(3626,'at_vaelastrasz'),
-(3958,'at_zulgurub'),
-(3960,'at_zulgurub'),
-(4047,'at_temple_ahnqiraj'),
-(4052,'at_temple_ahnqiraj'),
-(4112,'at_naxxramas'),
-(4113,'at_naxxramas'),
+(1740,'at_scent_larkorwi');
+DELETE FROM scripted_areatrigger WHERE entry in (4288,4485);
+INSERT INTO scripted_areatrigger VALUES
 (4288,'at_dark_portal'),
-(4479,'at_haramad_teleport'),
-(4485,'at_dark_portal'),
-(4524,'at_shattered_halls'),
-(4560,'at_legion_teleporter'),
-(4591,'at_coilfang_waterfall'),
-(4871,'at_warsong_farms'),
-(4872,'at_warsong_farms'),
-(4873,'at_warsong_farms'),
-(4937,'at_sunwell_plateau'),
-(5030,'at_spearborn_encampment'),
-(5046,'at_waygate'),
-(5047,'at_waygate'),
-(5108,'at_stormwright_shelf'),
-(5284,'at_aldurthar_gate'),
-(5285,'at_aldurthar_gate'),
-(5286,'at_aldurthar_gate'),
-(5287,'at_aldurthar_gate'),
-(5710,'at_hot_on_the_trail'),
-(5711,'at_hot_on_the_trail'),
-(5712,'at_hot_on_the_trail'),
-(5714,'at_hot_on_the_trail'),
-(5715,'at_hot_on_the_trail'),
-(5716,'at_hot_on_the_trail');
+(4485,'at_dark_portal');
+DELETE FROM scripted_areatrigger WHERE entry=1966;
+INSERT INTO scripted_areatrigger VALUES (1966,'at_murkdeep');
+DELETE FROM scripted_areatrigger WHERE entry IN (4047,4052);
+INSERT INTO scripted_areatrigger VALUES
+(4047,'at_temple_ahnqiraj'),
+(4052,'at_temple_ahnqiraj');
+DELETE FROM scripted_areatrigger WHERE entry IN (5710,5711,5712,5714,5715,5716);
+INSERT INTO scripted_areatrigger VALUES
+(5710, 'at_hot_on_the_trail'),
+(5711, 'at_hot_on_the_trail'),
+(5712, 'at_hot_on_the_trail'),
+(5714, 'at_hot_on_the_trail'),
+(5715, 'at_hot_on_the_trail'),
+(5716, 'at_hot_on_the_trail');
+DELETE FROM scripted_areatrigger WHERE entry=3587;
+INSERT INTO scripted_areatrigger VALUES (3587,'at_ancient_leaf');
+DELETE FROM scripted_areatrigger WHERE entry=4479;
+INSERT INTO scripted_areatrigger VALUES (4479,'at_haramad_teleport');
+
 
 /* BATTLEGROUNDS */
 UPDATE creature_template SET ScriptName='npc_spirit_guide' WHERE entry IN (13116, 13117);

--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -32,8 +32,6 @@ INSERT INTO scripted_areatrigger (entry,ScriptName) VALUES
 (1966,'at_murkdeep'),
 (2026,'at_blackrock_spire'),
 (2046,'at_blackrock_spire'),
-(2066,'at_blackrock_spire'),
-(2067,'at_blackrock_spire'),
 (3066,'at_ravenholdt'),
 (3546,'at_childrens_week_spot'), -- Darnassian bank
 (3547,'at_childrens_week_spot'), -- Undercity - thone room
@@ -3194,15 +3192,15 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 
 (-1229004,'Excellent... it would appear as if the meddlesome insects have arrived just in time to feed my legion. Welcome, mortals!',0,1,0,1,'nefarius SAY_INTRO_1'),
 (-1229005,'Let not even a drop of their blood remain upon the arena floor, my children. Feast on their souls!',0,1,0,1,'nefarius SAY_INTRO_2'),
-(-1229006,'Foolsss...Kill the one in the dress!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT1'),
-(-1229007,'Sire, let me join the fray! I shall tear their spines out with my bare hands!',0,1,0,1,'rend SAY_REND_TAUNT1'),
-(-1229008,'Concentrate your attacks upon the healer!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT2'),
-(-1229009,'Inconceivable!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT3'),
-(-1229010,'Do not force my hand, children! I shall use your hides to line my boots.',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT4'),
-(-1229011,'Defilers!',0,1,0,0,'rend SAY_REND_TAUNT2'),
-(-1229012,'Impossible!',0,1,0,0,'rend SAY_REND_TAUNT3'),
-(-1229013,'Your efforts will prove fruitless. None shall stand in our way!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT5'),
-(-1229014,'THIS CANNOT BE!!! Rend, deal with these insects.',0,1,0,1,'nefarius SAY_NEFARIUS_LOSE1'),
+(-1229006,'Foolsss...Kill the one in the dress!',0,1,0,0,'nefarius SAY_ATTACK_1'),
+(-1229007,'Sire, let me join the fray! I shall tear their spines out with my bare hands!',0,1,0,1,'rend SAY_REND_JOIN'),
+(-1229008,'Concentrate your attacks upon the healer!',0,1,0,0,'nefarius SAY_ATTACK_2'),
+(-1229009,'Inconceivable!',0,1,0,0,'nefarius SAY_ATTACK_3'),
+(-1229010,'Do not force my hand, children! I shall use your hides to line my boots.',0,1,0,0,'nefarius SAY_ATTACK_4'),
+(-1229011,'Defilers!',0,1,0,0,'rend SAY_LOSE_1'),
+(-1229012,'Impossible!',0,1,0,0,'rend SAY_LOSE_2'),
+(-1229013,'Your efforts will prove fruitless. None shall stand in our way!',0,1,0,0,'nefarius SAY_LOSE_3'),
+(-1229014,'THIS CANNOT BE!!! Rend, deal with these insects.',0,1,0,1,'nefarius SAY_LOSE_4'),
 (-1229015,'With pleasure...',0,1,0,0,'rend SAY_REND_ATTACK'),
 (-1229016,'The Warchief shall make quick work of you, mortals. Prepare yourselves!',0,1,0,25,'nefarius SAY_WARCHIEF'),
 (-1229017,'Taste in my power!',0,1,0,0,'nefarius SAY_BUFF_GYTH'),
@@ -3210,13 +3208,7 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 
 (-1229019,'%s is knocked off his drake!',0,2,0,0,'rend EMOTE_KNOCKED_OFF'),
 
-(-1229020,'Intruders are destroying our eggs! Stop!!',0,1,0,0,'rookery hatcher - SAY_ROOKERY_EVENT_START'),
-
-(-1229021,'I promise you an eternity of dung clean up duty for this failure!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT6'),
-(-1229022,'Use the freezing breath, imbecile!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT7'),
-(-1229023,'I will wear your skin as a fashion accessory!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT8'),
-(-1229024,'Flee while  you still have chance, mortals. You will pray for a swift death should I enter the arena.',0,1,0,0,'rend SAY_REND_TAUNT3');
-
+(-1229020,'Intruders are destroying our eggs! Stop!!',0,1,0,0,'rookery hatcher - SAY_ROOKERY_EVENT_START');
 
 -- -1 230 000 BLACKROCK DEPTHS
 INSERT INTO script_texts (entry,content_default,sound,type,language,emote,comment) VALUES

--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -32,6 +32,8 @@ INSERT INTO scripted_areatrigger (entry,ScriptName) VALUES
 (1966,'at_murkdeep'),
 (2026,'at_blackrock_spire'),
 (2046,'at_blackrock_spire'),
+(2066,'at_blackrock_spire'),
+(2067,'at_blackrock_spire'),
 (3066,'at_ravenholdt'),
 (3546,'at_childrens_week_spot'), -- Darnassian bank
 (3547,'at_childrens_week_spot'), -- Undercity - thone room
@@ -3192,15 +3194,15 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 
 (-1229004,'Excellent... it would appear as if the meddlesome insects have arrived just in time to feed my legion. Welcome, mortals!',0,1,0,1,'nefarius SAY_INTRO_1'),
 (-1229005,'Let not even a drop of their blood remain upon the arena floor, my children. Feast on their souls!',0,1,0,1,'nefarius SAY_INTRO_2'),
-(-1229006,'Foolsss...Kill the one in the dress!',0,1,0,0,'nefarius SAY_ATTACK_1'),
-(-1229007,'Sire, let me join the fray! I shall tear their spines out with my bare hands!',0,1,0,1,'rend SAY_REND_JOIN'),
-(-1229008,'Concentrate your attacks upon the healer!',0,1,0,0,'nefarius SAY_ATTACK_2'),
-(-1229009,'Inconceivable!',0,1,0,0,'nefarius SAY_ATTACK_3'),
-(-1229010,'Do not force my hand, children! I shall use your hides to line my boots.',0,1,0,0,'nefarius SAY_ATTACK_4'),
-(-1229011,'Defilers!',0,1,0,0,'rend SAY_LOSE_1'),
-(-1229012,'Impossible!',0,1,0,0,'rend SAY_LOSE_2'),
-(-1229013,'Your efforts will prove fruitless. None shall stand in our way!',0,1,0,0,'nefarius SAY_LOSE_3'),
-(-1229014,'THIS CANNOT BE!!! Rend, deal with these insects.',0,1,0,1,'nefarius SAY_LOSE_4'),
+(-1229006,'Foolsss...Kill the one in the dress!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT1'),
+(-1229007,'Sire, let me join the fray! I shall tear their spines out with my bare hands!',0,1,0,1,'rend SAY_REND_TAUNT1'),
+(-1229008,'Concentrate your attacks upon the healer!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT2'),
+(-1229009,'Inconceivable!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT3'),
+(-1229010,'Do not force my hand, children! I shall use your hides to line my boots.',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT4'),
+(-1229011,'Defilers!',0,1,0,0,'rend SAY_REND_TAUNT2'),
+(-1229012,'Impossible!',0,1,0,0,'rend SAY_REND_TAUNT3'),
+(-1229013,'Your efforts will prove fruitless. None shall stand in our way!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT5'),
+(-1229014,'THIS CANNOT BE!!! Rend, deal with these insects.',0,1,0,1,'nefarius SAY_NEFARIUS_LOSE1'),
 (-1229015,'With pleasure...',0,1,0,0,'rend SAY_REND_ATTACK'),
 (-1229016,'The Warchief shall make quick work of you, mortals. Prepare yourselves!',0,1,0,25,'nefarius SAY_WARCHIEF'),
 (-1229017,'Taste in my power!',0,1,0,0,'nefarius SAY_BUFF_GYTH'),
@@ -3208,7 +3210,13 @@ INSERT INTO script_texts (entry,content_default,sound,type,language,emote,commen
 
 (-1229019,'%s is knocked off his drake!',0,2,0,0,'rend EMOTE_KNOCKED_OFF'),
 
-(-1229020,'Intruders are destroying our eggs! Stop!!',0,1,0,0,'rookery hatcher - SAY_ROOKERY_EVENT_START');
+(-1229020,'Intruders are destroying our eggs! Stop!!',0,1,0,0,'rookery hatcher - SAY_ROOKERY_EVENT_START'),
+
+(-1229021,'I promise you an eternity of dung clean up duty for this failure!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT6'),
+(-1229022,'Use the freezing breath, imbecile!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT7'),
+(-1229023,'I will wear your skin as a fashion accessory!',0,1,0,0,'nefarius SAY_NEFARIUS_TAUNT8'),
+(-1229024,'Flee while  you still have chance, mortals. You will pray for a swift death should I enter the arena.',0,1,0,0,'rend SAY_REND_TAUNT3');
+
 
 -- -1 230 000 BLACKROCK DEPTHS
 INSERT INTO script_texts (entry,content_default,sound,type,language,emote,comment) VALUES


### PR DESCRIPTION
* InstallFullDB.sh ...  adds scriptdev2.sql after all DB updates, so
using DB update for scripted_areatriggers is not a good option. - Fixed
* Also - Cleanup for  /* AREATRIGGER */ - we dont need to use
delete/insert if  TRUNCATE scripted_areatrigger is used before.