### PR TITLE
Extend EventAI to TotemAI

### DIFF
--- a/src/game/AI/BaseAI/TotemAI.h
+++ b/src/game/AI/BaseAI/TotemAI.h
@@ -20,24 +20,26 @@
 #define MANGOS_TOTEMAI_H
 
 #include "AI/BaseAI/CreatureAI.h"
+#include "AI/EventAI/CreatureEventAI.h"
 #include "Entities/ObjectGuid.h"
+#include "Timer.h"
 
 class Creature;
 class Totem;
 
-class TotemAI : public CreatureAI
+class TotemAI : public CreatureEventAI
 {
     public:
-
         explicit TotemAI(Creature* c);
-
-        void MoveInLineOfSight(Unit*) override;
-        void AttackStart(Unit*) override;
-        void EnterEvadeMode() override;
-        bool IsVisible(Unit*) const override;
-
-        void UpdateAI(const uint32) override;
         static int Permissible(const Creature*);
+
+        virtual void MoveInLineOfSight(Unit*) override;
+        virtual void AttackStart(Unit*) override;
+        virtual void EnterEvadeMode() override;
+        virtual bool IsVisible(Unit*) const override;
+
+        virtual void UpdateAI(const uint32) override;
+
     protected:
         Totem& getTotem() const;
 


### PR DESCRIPTION
Should allow for totems to have scripted behaviour through ACID

Which means all totems scripted through scriptdev can be moved to ACID, or at least most of them.

For instance;

https://github.com/cmangos/mangos-wotlk/blob/master/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/zulgurub/boss_jindo.cpp#L172
and
https://github.com/cmangos/mangos-wotlk/blob/master/src/game/AI/ScriptDevAI/scripts/northrend/borean_tundra.cpp#L1165