### PR TITLE
[EventAI] update events; aura and missing aura

### DIFF
--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -403,9 +403,6 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& pHolder, Unit* pAction
             break;
         case EVENT_T_AURA:
         {
-            if (!m_creature->isInCombat())
-                return false;
-
             SpellAuraHolder* holder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
             if (!holder || holder->GetStackAmount() < event.buffed.amount)
                 return false;
@@ -431,9 +428,6 @@ bool CreatureEventAI::ProcessEvent(CreatureEventAIHolder& pHolder, Unit* pAction
         }
         case EVENT_T_MISSING_AURA:
         {
-            if (!m_creature->isInCombat())
-                return false;
-
             SpellAuraHolder* holder = m_creature->GetSpellAuraHolder(event.buffed.spellId);
             if (holder && holder->GetStackAmount() >= event.buffed.amount)
                 return false;


### PR DESCRIPTION
There's no reason the npc needs to be in combat for this, do that logic
in the ACID script itself, don't hardcore enforce it here.