### PR TITLE
EventAI update

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -159,6 +159,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 50   ACTION_T_SET_REACT_STATE               ReactState                      Change react state of the creature
 51   ACTION_T_PAUSE_WAYPOINTS               DoPause                         Pause waypoints of creature
 52   ACTION_T_INTERRUPT_SPELL               SpellType - CurrentSpellTypes   Interrupt spell in given slot for creature
+53   ACTION_T_RESET_COMBAT                  No params                       Stops attacking, removes auras and clears threat list and clears temp. faction.
 
 * = Use -1 where the param is expected to do nothing. Random constant is generated for each event, so if you have a random yell and a random sound, they will be linked up with each other (ie. param2 with param2).
 
@@ -949,6 +950,12 @@ CURRENT_AUTOREPEAT_SPELL        = 2
 CURRENT_CHANNELED_SPELL         = 3
 Melee spells, generic spells and autorepeat spells have their interruptability based on interrupt flags, albeit this flag is wrongly missing for some spells.
 Main purpose of this command is to research and find channeled spells, which do not interrupt as a result of not having found an interrupt flag.
+
+---------------------------
+53 = ACTION_T_RESET_COMBAT:
+---------------------------
+This is used for mobs that need to stop attacking and leave combat without evading.
+Since the Threat List is cleared with combat stopping special targets are needed for events such as quest event after that point until resetting.
 
 =========================================
 Target Types

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1102,6 +1102,14 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             m_creature->InterruptSpell((CurrentSpellTypes)action.interruptSpell.currentSpellType);
             break;
         }
+        case ACTION_T_RESET_COMBAT:
+        {
+            m_creature->RemoveAllAurasOnEvade();
+            m_creature->ClearTemporaryFaction();
+            m_creature->CombatStop(true);
+            m_creature->DeleteThreatList();
+            break;
+        }
         default:
             sLog.outError("CreatureEventAi::ProcessAction(): action(%u) not implemented", static_cast<uint32>(action.type));
             break;

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -129,6 +129,7 @@ enum EventAI_ActionType
     ACTION_T_SET_REACT_STATE            = 50,               // React state, unused, unused
     ACTION_T_PAUSE_WAYPOINTS            = 51,               // DoPause 0: unpause waypoint 1: pause waypoint, unused, unused
     ACTION_T_INTERRUPT_SPELL            = 52,               // SpellType enum CurrentSpellTypes, unused, unused
+    ACTION_T_RESET_COMBAT               = 53,               // No Params
 
     ACTION_T_END,
 };

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -848,6 +848,7 @@ void CreatureEventAIMgr::LoadCreatureEventAI_Scripts()
                     case ACTION_T_FLEE_FOR_ASSIST:          // No Params
                     case ACTION_T_DIE:                      // No Params
                     case ACTION_T_ZONE_COMBAT_PULSE:        // No Params
+                    case ACTION_T_RESET_COMBAT:             // No Params
                     case ACTION_T_FORCE_DESPAWN:            // Delay
                     case ACTION_T_AUTO_ATTACK:              // AllowAttackState (0 = stop attack, anything else means continue attacking)
                     case ACTION_T_COMBAT_MOVEMENT:          // AllowCombatMovement (0 = stop combat based movement, anything else continue attacking)


### PR DESCRIPTION
~~2 new actions local evade and despawn guardians, 2 new targets, player invoker and player tapped, one updated action, quest event. check the individual commits for details.~~

Edit*; renamed local evade to reset combat as per suggestion and moved the 3 commits not related to resetting combat to another PR as per request.

Removed the option to not clear the threat list from my initial proposed commit; there is no reason you'd want to use any one of these 4 core functions that are called (removeauras, removethreatlist, cleartempfaction, stopcombat) without using the others, so making any one of these optional with parameters would be redundant, but there are a bucketload of quest mobs which potentially could very well be moved to db scripting / eventAI instead of being handled in the more heavy scriptdev using this.

There's someone like Balos Jacken in dustwallow (involved in the alliance vanilla quest The Deserters) as well as a good portion of the mobs from the alliance vanilla quest The Missing Diplomat (there's at least 3 mobs with this sort of behaviour just in that one questline, the dwarf in stormwind, the human in wetlands (which is the one used here linked by grz3s to showcase the use of all the 4 commits stemming from this pr) and the human in dustwallow). And that's 4 mobs just in the level 30 - 40 range.