### PR TITLE
Eventai update (2)

### DIFF
--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -121,7 +121,7 @@ For all ACTION_T_RANDOM Actions, When a Particular Param is selected for the Eve
 12   ACTION_T_SUMMON                        CreatureID, Target, Duration    Summons a Creature ID (Param1) for (Param3) duration after Evade (In MS) and orders it to attack (Param2) target (specified below). Spawns on top of NPC who summons it.
 13   ACTION_T_THREAT_SINGLE_PCT             Threat%, Target                 Modifies a threat by (Param1) percent on a target (Param2).
 14   ACTION_T_THREAT_ALL_PCT                Threat%                         Modifies a threat by (Param1) on all targets in the threat list (using -100% here will result in full aggro dump).
-15   ACTION_T_QUEST_EVENT                   QuestID, Target                 Calls AreaExploredOrEventHappens with (Param1) for a target in (Param2).
+15   ACTION_T_QUEST_EVENT                   QuestID, Target, RewardGroup    Calls AreaExploredOrEventHappens with (Param1) for a target in (Param2). Param3 decides if award entire group (1 = yes, 0 = no).
 16   ACTION_T_QUEST_CASTCREATUREGO          CreatureID, SpellId, Target     Sends CastCreatureOrGo for a creature specified by CreatureId (Param1) with provided spell id (Param2) for a target in (Param3).
 17   ACTION_T_SET_UNIT_FIELD                Field_Number, Value, Target     Sets a unit field (Param1) to provided value (Param2) on a target in (Param3).
 18   ACTION_T_SET_UNIT_FLAG                 Flags, Target                   Sets flag (flags can be used together to modify multiple flags at once) on a target (Param2).
@@ -616,6 +616,7 @@ This is commonly used to allow an NPC to drop threat for all players to zero.
 --------------------------
 Parameter 1: QuestID - The Quest Template ID. The value here must be a valid quest template ID. Furthermore, the quest should have SpecialFlags | 2 as it would need to be completed by an external event which is the activation of this action.
 Parameter 2: Target - The Target Type defining whom the quest should be completed for. The value in this field needs to be a valid target type as specified in the reference tables below.
+Parameter 3: RewardGroup - Used to decide if entire group should be rewarded (1 = entire group, 0 = single target)
 
 This action will satisfy the external completion requirement for the quest for the specified target defined by the target type.
 NOTE: This action can only be used with player targets so it must be ensured that the target type will point to a player.

--- a/doc/EventAI.txt
+++ b/doc/EventAI.txt
@@ -1007,6 +1007,8 @@ Target types are used by certain actions and may effect actions differently
 10   TARGET_T_EVENT_SENDER              Creature who sent a received AIEvent - only triggered by EVENT_T_RECEIVE_AI_EVENT
 11   TARGET_T_SUMMONER                  Summoner of given Unit if it has one
 12   TARGET_T_EVENT_SPECIFIC            Filled by Event - EVENT_T_SELECT_ATTACKING_TARGET fills target selected
+13   TARGET_T_PLAYER_INVOKER            Player who initiated hostile contact with this npc
+14   TARGET_T_PLAYER_TAPPED             Player who currently holds the kill credit for the npc
 
 =========================================
 Cast Flags

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -767,14 +767,22 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
             break;
         }
         case ACTION_T_QUEST_EVENT:
+        {
             if (Unit* target = GetTargetByType(action.quest_event.target, pActionInvoker, pAIEventSender, reportTargetError))
             {
                 if (target->GetTypeId() == TYPEID_PLAYER)
-                    ((Player*)target)->AreaExploredOrEventHappens(action.quest_event.questId);
+                {
+                    Player* playerTarget = static_cast<Player*>(target);
+                    if (action.quest_event.rewardGroup)
+                        playerTarget->GroupEventHappens(action.quest_event.questId, m_creature);
+                    else
+                        playerTarget->AreaExploredOrEventHappens(action.quest_event.questId);
+                }
             }
             else if (reportTargetError)
                 sLog.outErrorEventAI("Event %u - NULL target for ACTION_T_QUEST_EVENT(%u), target-type %u", EventId, action.type, action.quest_event.target);
             break;
+        }
         case ACTION_T_CAST_EVENT:
             if (Unit* target = GetTargetByType(action.cast_event.target, pActionInvoker, pAIEventSender, reportTargetError, 0, SELECT_FLAG_PLAYER))
             {

--- a/src/game/AI/EventAI/CreatureEventAI.cpp
+++ b/src/game/AI/EventAI/CreatureEventAI.cpp
@@ -1637,6 +1637,26 @@ inline Unit* CreatureEventAI::GetTargetByType(uint32 Target, Unit* pActionInvoke
             if (!m_eventTarget)
                 isError = true;
             return m_eventTarget;
+        case TARGET_T_PLAYER_INVOKER:
+        {
+            if (!m_creature->HasLootRecipient())
+            {
+                isError = true;
+                return nullptr;
+            }
+
+            return m_creature->GetOriginalLootRecipient();
+        }
+        case TARGET_T_PLAYER_TAPPED:
+        {
+            if (!m_creature->HasLootRecipient())
+            {
+                isError = true;
+                return nullptr;
+            }
+
+            return m_creature->GetLootRecipient();
+        }
         default:
             isError = true;
             return nullptr;

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -163,6 +163,10 @@ enum Target
 
     // Event specific targeting
     TARGET_T_EVENT_SPECIFIC                 = 12,           // Filled by specific event
+
+    // Player associations
+    TARGET_T_PLAYER_INVOKER                 = 13,           // Player who initiated hostile contact with this npc
+    TARGET_T_PLAYER_TAPPED                  = 14,           // Player who currently holds to score the kill credit from the npc
 };
 
 enum EventFlags

--- a/src/game/AI/EventAI/CreatureEventAI.h
+++ b/src/game/AI/EventAI/CreatureEventAI.h
@@ -266,6 +266,7 @@ struct CreatureEventAI_Action
         {
             uint32 questId;
             uint32 target;
+            uint32 rewardGroup;
         } quest_event;
         // ACTION_T_CAST_EVENT                              = 16
         struct

--- a/src/game/AI/EventAI/CreatureEventAIMgr.cpp
+++ b/src/game/AI/EventAI/CreatureEventAIMgr.cpp
@@ -243,6 +243,8 @@ bool IsValidTargetType(EventAI_Type eventType, EventAI_ActionType actionType, ui
             return true;
         case TARGET_T_SUMMONER:
         case TARGET_T_EVENT_SPECIFIC:
+        case TARGET_T_PLAYER_INVOKER:
+        case TARGET_T_PLAYER_TAPPED:
             return true;
         default:
             sLog.outErrorEventAI("Event %u Action%u uses incorrect Target type", eventId, action);


### PR DESCRIPTION
Moved the 3 lesser controversial commits from the more heavily debated one per request, one has been merged already (thanks @killerwife), these are the remaining 2.

This commit; https://github.com/cmangos/mangos-wotlk/pull/231/commits/92229a1da183a27017092e1cdf91d3c936d420a5 makes this action; ACTION_T_QUEST_EVENT_ALL (26) redundant (deprecated) and the one single mob in wotlk-db which uses that action can with this commit use the party functionality from this commit in the normal ACTION_T_QUEST_EVENT (15) combined with one of the targets from the commit mentioned below and most likely be more blizzlike for it.

ACTION_T_CASTCREATUREGO_ALL (27) needs the same sort of attention. Rewarding creatureorgo to everyone on the threatlist will reward players who are not in party with the person/people who hold the kill credit. (same problem as with action 26) While this is not a problem in instances (obviously) - for world mobs it not only seems wrong, it is wrong, this sort of rewarding everyone with quest credit regardless if they hold the kill credit is something blizzard first introduced with Legion.

This commit: https://github.com/cmangos/mangos-wotlk/pull/231/commits/b4697b515b6b351964c3d56b74d6e766aaef8a8a allows the action ACTION_T_QUEST_EVENT (15) to select the correct target, the credit holder, rather than having to rely on the threat list which may be infected with a whole arsenal of people who do not hold the credit, especially top aggro may very well be a tanking class who is not in party with the person/group who pulled and holds the kill credit for the mob. Using TARGET_T_PLAYER_TAPPED in combination with the party functionality added in the commit mentioned above allows to correctly identify and reward the entire party that is supposed to be rewarded with the quest event according to kill credit. Using TARGET_T_PLAYER_INVOKER allows to correctly identify and reward the entire party that is supposed to be rewarded with the quest event according to who initially aggroed the mob.
This means that every mob which uses action 15 in eventai will probably have to be checked if their target can be optimised using one of those 2 new targets and if it also can be improved by rewarding the entire group using the added party functionality.