### PR TITLE
allow PlayerBot to pick up quest items

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -2382,7 +2382,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                 p.read_skip<uint32>();  // 4 randomPropertyId
                 p >> lootslot_type;     // 1 LootSlotType
 
-                if (lootslot_type != LOOT_SLOT_NORMAL)
+                if (lootslot_type != LOOT_SLOT_NORMAL && lootslot_type != LOOT_SLOT_OWNER)
                     continue;
 
                 // skinning or collect loot flag = just auto loot everything for getting object


### PR DESCRIPTION
Fixes Issue 1498.
Added LOOT_TYPE_OWNER items to list that is allowed.