### PR TITLE
Fixed liquid processing in mmap builder

### DIFF
--- a/contrib/extractor/System.cpp
+++ b/contrib/extractor/System.cpp
@@ -282,7 +282,7 @@ void ReadLiquidTypeTableDBC()
 
 // Map file format data
 static char const* MAP_MAGIC         = "MAPS";
-static char const* MAP_VERSION_MAGIC = "v1.3";
+static char const* MAP_VERSION_MAGIC = "v1.4";
 static char const* MAP_AREA_MAGIC    = "AREA";
 static char const* MAP_HEIGHT_MAGIC  = "MHGT";
 static char const* MAP_LIQUID_MAGIC  = "MLIQ";
@@ -332,13 +332,14 @@ struct map_heightHeader
 #define MAP_LIQUID_TYPE_DARK_WATER  0x10
 #define MAP_LIQUID_TYPE_WMO_WATER   0x20
 
-#define MAP_LIQUID_NO_TYPE    0x0001
-#define MAP_LIQUID_NO_HEIGHT  0x0002
+#define MAP_LIQUID_NO_TYPE    0x01
+#define MAP_LIQUID_NO_HEIGHT  0x02
 
 struct map_liquidHeader
 {
     uint32 fourcc;
-    uint16 flags;
+    uint8 flags;
+    uint8 liquidFlags;
     uint16 liquidType;
     uint8  offsetX;
     uint8  offsetY;
@@ -755,13 +756,14 @@ bool ConvertADT(char* filename, char* filename2, int cell_y, int cell_x, uint32 
     //============================================
     // Pack liquid data
     //============================================
-    uint8 type = liquid_flags[0][0];
+    uint16 firstLiquidEntry = liquid_entry[0][0];
+    uint8 firstLiquidFlag = liquid_flags[0][0];
     bool fullType = false;
     for (int y = 0; y < ADT_CELLS_PER_GRID; y++)
     {
         for (int x = 0; x < ADT_CELLS_PER_GRID; x++)
         {
-            if (liquid_flags[y][x] != type)
+            if (liquid_entry[y][x] != firstLiquidEntry || liquid_flags[y][x] != firstLiquidFlag)
             {
                 fullType = true;
                 y = ADT_CELLS_PER_GRID;
@@ -773,7 +775,7 @@ bool ConvertADT(char* filename, char* filename2, int cell_y, int cell_x, uint32 
     map_liquidHeader liquidHeader;
 
     // no water data (if all grid have 0 liquid type)
-    if (type == 0 && !fullType)
+    if (firstLiquidFlag == 0 && !fullType)
     {
         // No liquid data
         map.liquidMapOffset = 0;
@@ -825,7 +827,10 @@ bool ConvertADT(char* filename, char* filename2, int cell_y, int cell_x, uint32 
             liquidHeader.flags |= MAP_LIQUID_NO_TYPE;
 
         if (liquidHeader.flags & MAP_LIQUID_NO_TYPE)
-            liquidHeader.liquidType = type;
+        {
+            liquidHeader.liquidFlags = firstLiquidFlag;
+            liquidHeader.liquidType = firstLiquidEntry;
+        }
         else
             map.liquidMapSize += sizeof(liquid_entry) + sizeof(liquid_flags);
 

--- a/contrib/mmap/src/MangosMap.h
+++ b/contrib/mmap/src/MangosMap.h
@@ -59,13 +59,14 @@ namespace MaNGOS
         float gridMaxHeight;
     };
 
-#define MAP_LIQUID_NO_TYPE    0x0001
-#define MAP_LIQUID_NO_HEIGHT  0x0002
+#define MAP_LIQUID_NO_TYPE    0x01
+#define MAP_LIQUID_NO_HEIGHT  0x02
 
     struct GridMapLiquidHeader
     {
         uint32 fourcc;
-        uint16 flags;
+        uint8 flags;
+        uint8 liquidFlags;
         uint16 liquidType;
         uint8 offsetX;
         uint8 offsetY;

--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -118,8 +118,10 @@ namespace MMAP
         // data used later
         uint16 holes[16][16];
         memset(holes, 0, sizeof(holes));
-        uint8 liquid_type[16][16];
-        memset(liquid_type, 0, sizeof(liquid_type));
+        uint16 liquid_entry[16][16];
+        memset(liquid_entry, 0, sizeof(liquid_entry));
+        uint8 liquid_flags[16][16];
+        memset(liquid_flags, 0, sizeof(liquid_flags));
         bool liquid_type_loaded = false;
         G3D::Array<int> ltriangles;
         G3D::Array<int> ttriangles;
@@ -216,8 +218,14 @@ namespace MMAP
             {
                 if (!(lheader.flags & MAP_LIQUID_NO_TYPE))
                 {
-                    if (fread(liquid_type, sizeof(liquid_type), 1, mapFile) == 1)
+                    if (fread(liquid_entry, sizeof(liquid_entry), 1, mapFile) == 1 &&
+                        fread(liquid_flags, sizeof(liquid_flags), 1, mapFile) == 1)
                         liquid_type_loaded = true;
+                }
+                else
+                {
+                    std::fill_n(&liquid_entry[0][0], 16 * 16, lheader.liquidType);
+                    std::fill_n(&liquid_flags[0][0], 16 * 16, lheader.liquidFlags);
                 }
 
                 if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
@@ -232,65 +240,62 @@ namespace MMAP
                 }
             }
 
-            if (liquid_map)
+            int count = meshData.liquidVerts.size() / 3;
+            float xoffset = (float(tileX) - 32) * GRID_SIZE;
+            float yoffset = (float(tileY) - 32) * GRID_SIZE;
+
+            float coord[3];
+            int row, col;
+
+            // generate coordinates
+            if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
             {
-                int count = meshData.liquidVerts.size() / 3;
-                float xoffset = (float(tileX) - 32) * GRID_SIZE;
-                float yoffset = (float(tileY) - 32) * GRID_SIZE;
-
-                float coord[3];
-                int row, col;
-
-                // generate coordinates
-                if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
+                int j = 0;
+                for (int i = 0; i < V9_SIZE_SQ; ++i)
                 {
-                    int j = 0;
-                    for (int i = 0; i < V9_SIZE_SQ; ++i)
+                    row = i / V9_SIZE;
+                    col = i % V9_SIZE;
+
+                    if (row < lheader.offsetY || row >= lheader.offsetY + lheader.height ||
+                            col < lheader.offsetX || col >= lheader.offsetX + lheader.width)
                     {
-                        row = i / V9_SIZE;
-                        col = i % V9_SIZE;
-
-                        if (row < lheader.offsetY || row >= lheader.offsetY + lheader.height ||
-                                col < lheader.offsetX || col >= lheader.offsetX + lheader.width)
-                        {
-                            // dummy vert using invalid height
-                            meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, INVALID_MAP_LIQ_HEIGHT, (yoffset + row * GRID_PART_SIZE) * -1);
-                            continue;
-                        }
-
-                        getLiquidCoord(i, j, xoffset, yoffset, coord, liquid_map);
-                        meshData.liquidVerts.append(coord[0]);
-                        meshData.liquidVerts.append(coord[2]);
-                        meshData.liquidVerts.append(coord[1]);
-                        j++;
+                        // dummy vert using invalid height
+                        meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, INVALID_MAP_LIQ_HEIGHT, (yoffset + row * GRID_PART_SIZE) * -1);
+                        continue;
                     }
+
+                    getLiquidCoord(i, j, xoffset, yoffset, coord, liquid_map);
+                    meshData.liquidVerts.append(coord[0]);
+                    meshData.liquidVerts.append(coord[2]);
+                    meshData.liquidVerts.append(coord[1]);
+                    j++;
                 }
-                else
-                {
-                    for (int i = 0; i < V9_SIZE_SQ; ++i)
-                    {
-                        row = i / V9_SIZE;
-                        col = i % V9_SIZE;
-                        meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, lheader.liquidLevel, (yoffset + row * GRID_PART_SIZE) * -1);
-                    }
-                }
-
-                delete[] liquid_map;
-
-                int indices[3], loopStart, loopEnd, loopInc, triInc;
-                getLoopVars(portion, loopStart, loopEnd, loopInc);
-                triInc = BOTTOM - TOP;
-
-                // generate triangles
-                for (int i = loopStart; i < loopEnd; i += loopInc)
-                    for (int j = TOP; j <= BOTTOM; j += triInc)
-                    {
-                        getHeightTriangle(i, Spot(j), indices, true);
-                        ltriangles.append(indices[2] + count);
-                        ltriangles.append(indices[1] + count);
-                        ltriangles.append(indices[0] + count);
-                    }
             }
+            else
+            {
+                for (int i = 0; i < V9_SIZE_SQ; ++i)
+                {
+                    row = i / V9_SIZE;
+                    col = i % V9_SIZE;
+                    meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, lheader.liquidLevel, (yoffset + row * GRID_PART_SIZE) * -1);
+                }
+            }
+
+            delete[] liquid_map;
+
+            int indices[3], loopStart, loopEnd, loopInc, triInc;
+            getLoopVars(portion, loopStart, loopEnd, loopInc);
+            triInc = BOTTOM - TOP;
+
+            // generate triangles
+            for (int i = loopStart; i < loopEnd; i += loopInc)
+                for (int j = TOP; j <= BOTTOM; j += triInc)
+                {
+                    getHeightTriangle(i, Spot(j), indices, true);
+                    ltriangles.append(indices[2] + count);
+                    ltriangles.append(indices[1] + count);
+                    ltriangles.append(indices[0] + count);
+                }
         }
 
         fclose(mapFile);
@@ -333,29 +338,21 @@ namespace MMAP
                     useLiquid = false;
                 else
                 {
-                    liquidType = getLiquidType(i, liquid_type);
-                    switch (liquidType)
+                    liquidType = getLiquidType(i, liquid_flags);
+                    if (liquidType & MAP_LIQUID_TYPE_DARK_WATER)
                     {
-                        default:
-                            useLiquid = false;
-                            break;
-                        case MAP_LIQUID_TYPE_WATER:
-                        case MAP_LIQUID_TYPE_OCEAN:
-                            // merge different types of water
-                            liquidType = NAV_WATER;
-                            break;
-                        case MAP_LIQUID_TYPE_MAGMA:
-                            liquidType = NAV_MAGMA;
-                            break;
-                        case MAP_LIQUID_TYPE_SLIME:
-                            liquidType = NAV_SLIME;
-                            break;
-                        case MAP_LIQUID_TYPE_DARK_WATER:
-                            // players should not be here, so logically neither should creatures
-                            useTerrain = false;
-                            useLiquid = false;
-                            break;
+                        // players should not be here, so logically neither should creatures
+                        useTerrain = false;
+                        useLiquid = false;
                     }
+                    else if ((liquidType & (MAP_LIQUID_TYPE_WATER | MAP_LIQUID_TYPE_OCEAN)) != 0)
+                        liquidType = NAV_WATER;
+                    else if (liquidType & MAP_LIQUID_TYPE_MAGMA)
+                        liquidType = NAV_MAGMA;
+                    else if (liquidType & MAP_LIQUID_TYPE_SLIME)
+                        liquidType = NAV_SLIME;
+                    else
+                        useLiquid = false;
                 }
 
                 // if there is no terrain, don't use terrain

--- a/contrib/mmap/src/TerrainBuilder.h
+++ b/contrib/mmap/src/TerrainBuilder.h
@@ -62,7 +62,7 @@ namespace MMAP
     // see following files:
     // contrib/extractor/system.cpp
     // src/game/GridMap.cpp
-    static char const* MAP_VERSION_MAGIC = "v1.3";
+    static char const* MAP_VERSION_MAGIC = "v1.4";
 
     struct MeshData
     {

--- a/src/game/Maps/GridMap.h
+++ b/src/game/Maps/GridMap.h
@@ -70,13 +70,14 @@ struct GridMapHeightHeader
     float gridMaxHeight;
 };
 
-#define MAP_LIQUID_NO_TYPE    0x0001
-#define MAP_LIQUID_NO_HEIGHT  0x0002
+#define MAP_LIQUID_NO_TYPE    0x01
+#define MAP_LIQUID_NO_HEIGHT  0x02
 
 struct GridMapLiquidHeader
 {
     uint32 fourcc;
-    uint16 flags;
+    uint8 flags;
+    uint8 liquidFlags;
     uint16 liquidType;
     uint8 offsetX;
     uint8 offsetY;
@@ -139,7 +140,8 @@ class GridMap
         };
 
         // Liquid data
-        uint16 m_liquidType;
+        uint16 m_liquidGlobalEntry;
+        uint8 m_liquidGlobalFlags;
         uint8 m_liquid_offX;
         uint8 m_liquid_offY;
         uint8 m_liquid_width;


### PR DESCRIPTION
Also fixes detecting liquid id from LiquidType.dbc when entire grid is filling with the same type

This corrects my fuckup from 5 years ago.

Bonus fix (also related to liquids in mmaps), using switch() on flags is not a good idea.