### PR TITLE
Fix MM Hunter talent Wild Quiver

### DIFF
--- a/sql/updates/mangos/13983_01_mangos_spell_template.sql
+++ b/sql/updates/mangos/13983_01_mangos_spell_template.sql
@@ -1,0 +1,3 @@
+ALTER TABLE db_version CHANGE COLUMN required_13982_01_mangos_event_ai required_13983_01_mangos_spell_template bit;
+
+UPDATE `wotlkmangos`.`spell_template` SET `EffectSpellClassMask1_1` = 4097 WHERE id IN (53215, 53216, 53217);

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5082,7 +5082,9 @@ void Spell::TakeAmmo() const
 {
     if (m_attackType == RANGED_ATTACK && m_caster->GetTypeId() == TYPEID_PLAYER)
     {
-        Item* pItem = ((Player*)m_caster)->GetWeaponForAttack(RANGED_ATTACK, true, false);
+        auto player = (Player*)m_caster;
+
+        Item* pItem = player->GetWeaponForAttack(RANGED_ATTACK, true, false);
 
         // wands don't have ammo
         if (!pItem || pItem->GetProto()->SubClass == ITEM_SUBCLASS_WEAPON_WAND)
@@ -5093,17 +5095,17 @@ void Spell::TakeAmmo() const
             if (pItem->GetMaxStackCount() == 1)
             {
                 // decrease durability for non-stackable throw weapon
-                ((Player*)m_caster)->DurabilityPointLossForEquipSlot(EQUIPMENT_SLOT_RANGED);
+                player->DurabilityPointLossForEquipSlot(EQUIPMENT_SLOT_RANGED);
             }
             else
             {
                 // decrease items amount for stackable throw weapon
                 uint32 count = 1;
-                ((Player*)m_caster)->DestroyItemCount(pItem, count, true);
+                player->DestroyItemCount(pItem, count, true);
             }
         }
-        else if (uint32 ammo = ((Player*)m_caster)->GetUInt32Value(PLAYER_AMMO_ID))
-            ((Player*)m_caster)->DestroyItemCount(ammo, 1, true);
+        else if (uint32 ammo = player->GetUInt32Value(PLAYER_AMMO_ID))
+            player->DestroyItemCount(ammo, 1, true);
     }
 }
 

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5104,8 +5104,15 @@ void Spell::TakeAmmo() const
                 player->DestroyItemCount(pItem, count, true);
             }
         }
-        else if (uint32 ammo = player->GetUInt32Value(PLAYER_AMMO_ID))
+        else if (uint32 ammo = player->GetUInt32Value(PLAYER_AMMO_ID)) {
+            // some spells may be exempt from ammo cost (Wild Quiver talent for MM Hunters)
+            for (const auto& aura : player->GetAurasByType(AuraType::SPELL_AURA_ABILITY_CONSUME_NO_AMMO)) {
+                if (aura->isAffectedOnSpell(m_spellInfo)) {
+                    return;
+                }
+            }
             player->DestroyItemCount(ammo, 1, true);
+        }
     }
 }
 

--- a/src/game/Spells/SpellAuraDefines.h
+++ b/src/game/Spells/SpellAuraDefines.h
@@ -413,7 +413,7 @@ enum AuraType
     SPELL_AURA_MOD_DAMAGE_FROM_CASTER = 271,
     SPELL_AURA_MAELSTROM_WEAPON = 272,
     SPELL_AURA_X_RAY = 273,
-    SPELL_AURA_274 = 274,
+    SPELL_AURA_ABILITY_CONSUME_NO_AMMO = 274,
     SPELL_AURA_MOD_IGNORE_SHAPESHIFT = 275,
     SPELL_AURA_276 = 276,                                   // Only "Test Mod Damage % Mechanic" spell, possible mod damage done
     SPELL_AURA_MOD_MAX_AFFECTED_TARGETS = 277,

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -890,8 +890,14 @@ bool Aura::isAffectedOnSpell(SpellEntry const* spell) const
     return spell->IsFitToFamily(SpellFamily(GetSpellProto()->SpellFamilyName), GetAuraSpellClassMask());
 }
 
-bool Aura::CanProcFrom(SpellEntry const* spell, uint32 /*procFlag*/, uint32 EventProcEx, uint32 procEx, bool active, bool useClassMask) const
+bool Aura::CanProcFrom(SpellEntry const* spell, uint32 procFlag, uint32 EventProcEx, uint32 procEx, bool active, bool useClassMask) const
 {
+    // successful melee / ranged hits seem to ignore SpellClassMask (see spells 53215 - 53217)
+    if ((procFlag & PROC_FLAG_SUCCESSFUL_MELEE_HIT) && spell->Id == 6603 ||
+        (procFlag & PROC_FLAG_SUCCESSFUL_RANGED_HIT) && spell->Id == 75) {
+        return true;
+    }
+
     // Check EffectClassMask
     ClassFamilyMask const& mask  = GetAuraSpellClassMask();
 

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -890,14 +890,8 @@ bool Aura::isAffectedOnSpell(SpellEntry const* spell) const
     return spell->IsFitToFamily(SpellFamily(GetSpellProto()->SpellFamilyName), GetAuraSpellClassMask());
 }
 
-bool Aura::CanProcFrom(SpellEntry const* spell, uint32 procFlag, uint32 EventProcEx, uint32 procEx, bool active, bool useClassMask) const
+bool Aura::CanProcFrom(SpellEntry const* spell, uint32 /*procFlag*/, uint32 EventProcEx, uint32 procEx, bool active, bool useClassMask) const
 {
-    // successful melee / ranged hits seem to ignore SpellClassMask (see spells 53215 - 53217)
-    if ((procFlag & PROC_FLAG_SUCCESSFUL_MELEE_HIT) && spell->Id == 6603 ||
-        (procFlag & PROC_FLAG_SUCCESSFUL_RANGED_HIT) && spell->Id == 75) {
-        return true;
-    }
-
     // Check EffectClassMask
     ClassFamilyMask const& mask  = GetAuraSpellClassMask();
 

--- a/src/shared/revision_sql.h
+++ b/src/shared/revision_sql.h
@@ -2,5 +2,5 @@
 #define __REVISION_SQL_H__
  #define REVISION_DB_REALMD "required_13970_01_realmd_totp"
  #define REVISION_DB_CHARACTERS "required_13977_01_characters_taxi_system_format_update"
- #define REVISION_DB_MANGOS "required_13982_01_mangos_event_ai"
+ #define REVISION_DB_MANGOS "required_13983_01_mangos_spell_template"
 #endif // __REVISION_SQL_H__


### PR DESCRIPTION
This PR aims to fix the currently non-functional MM Hunter talent 'Wild Quiver'. The spell data of the talent ranks (53215, 53216, 53217) is a bit inconsistent and posed quite a challenge to actually implement the aura proc. It utilises a currently unused aura that removes ammo cost from specific spells (which, as of 3.3.5 is only this talent).

The way the proc system in this specific case currently works is that it checks whether the mask of the proc causing spell matches the effect class mask, like a white list. Multishot, which matches the effect class mask and is a "Successful Ranged attack by Spell that uses a ranged weapon" triggers the proc even if it is not stated in the tooltip. I didn't play hunter during WotLK so I don't know if Wild Quiver worked that way, but the spell data implies it does so.

Spell 75 (Ranged Auto Attack) however does not appear in that list, so the [current proc handler implementation](https://github.com/cmangos/mangos-wotlk/blob/55b0b3b833911973d0a1f01bb3af3f32e48a2e5a/src/game/Spells/UnitAuraProcHandler.cpp#L606) rejects the aura proc because the mask check fails.
It appears to me that ProcFlag 06 (Successful Ranged attack (and wand spell cast)) seems to be exempt from the effect mask check.

I would appreciate some help on commit 9292ca1 because I think it feels out of place and maybe with your experience can be implemented better.

Tests when using this branch:

1. Learn any of the talent spells 53215 - 53217
2. .cast 53254 - it should not consume ammo
3. Auto attack or cast Multi Shot - it should sometimes fire an additional bullet (trigger 53254) without consuming ammo.