### PR TITLE
MYSQL80 TSQL updates

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/instance_sunken_temple.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/instance_sunken_temple.cpp
@@ -165,6 +165,10 @@ void instance_sunken_temple::SetData(uint32 uiType, uint32 uiData)
             }
             m_auiEncounter[uiType] = uiData;
             break;
+        case TYPE_MALFURION:
+            if (uiData == IN_PROGRESS)
+                m_auiEncounter[uiType] = uiData;
+            break;
         case TYPE_AVATAR:
             if (uiData == SPECIAL)
             {

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.cpp
@@ -48,10 +48,10 @@ bool AreaTrigger_at_shade_of_eranikus(Player* pPlayer, AreaTriggerEntry const* /
                 !pPlayer->GetQuestRewardStatus(QUEST_ERANIKUS_TYRANT_OF_DREAMS) &&
                 pPlayer->GetQuestStatus(QUEST_ERANIKUS_TYRANT_OF_DREAMS) != QUEST_STATUS_COMPLETE)
         {
-            if (pInstance->GetData(TYPE_MALFURION) != DONE)
+            if (pInstance->GetData(TYPE_MALFURION) != IN_PROGRESS)
             {
                 pPlayer->SummonCreature(NPC_MALFURION, aSunkenTempleLocation[2].m_fX, aSunkenTempleLocation[2].m_fY, aSunkenTempleLocation[2].m_fZ, aSunkenTempleLocation[2].m_fO, TEMPSPAWN_DEAD_DESPAWN, 0);
-                pInstance->SetData(TYPE_MALFURION, DONE);
+                pInstance->SetData(TYPE_MALFURION, IN_PROGRESS);
             }
         }
     }
@@ -85,6 +85,7 @@ struct npc_malfurionAI : public ScriptedAI
             m_uiSayTimer = 3000;
         }
 
+        DoCastSpellIfCan(m_creature, SPELL_SPIRIT_SPAWN_IN, TRIGGERED_OLD_TRIGGERED);
         m_creature->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_QUESTGIVER);
     }
 

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/sunken_temple/sunken_temple.h
@@ -71,6 +71,8 @@ enum
 
     SPELL_SUMMON_AVATAR   = 12639,                          // Cast by the shade of hakkar, updates entry to avatar
     SPELL_AVATAR_SUMMONED = 12948,
+    
+    SPELL_SPIRIT_SPAWN_IN = 17321,
 
     SAY_JAMMALAN_INTRO    = -1109005,
     SAY_AVATAR_BRAZIER_1  = -1109006,


### PR DESCRIPTION
I was getting errors during startup due to use of tsql keywords in the SQL queries. the table name 'groups' and the field 'rank' were both flagging as invalid sql and throwing errors. I simply scoped those to the db/table so that they would resolve properly.