### PR TITLE
sync: Avoid using Soul Stones when you already have Healthstone

### DIFF
--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -473,6 +473,8 @@ class Spell
         uint32 getState() const { return m_spellState; }
         void setState(uint32 state) { m_spellState = state; }
 
+        uint32 GetUsableHealthStoneItemType(Unit* unitTarget);
+
         bool DoCreateItem(SpellEffectIndex eff_idx, uint32 itemtype);
 
         void WriteSpellGoTargets(WorldPacket& data);
@@ -494,6 +496,8 @@ class Spell
         void SendChannelUpdate(uint32 time, uint32 lastTick = 0) const;
         void SendChannelStart(uint32 duration);
         void SendResurrectRequest(Player* target) const;
+
+        void StopCast(SpellCastResult castResult);
 
         void HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOTarget, SpellEffectIndex i, float DamageMultiplier = 1.0);
         void HandleThreatSpells();

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -11292,57 +11292,9 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     if (!unitTarget)
                         return;
 
-                    uint32 itemtype;
-                    uint32 rank = 0;
-                    Unit::AuraList const& mDummyAuras = unitTarget->GetAurasByType(SPELL_AURA_DUMMY);
-                    for (auto mDummyAura : mDummyAuras)
-                    {
-                        if (mDummyAura->GetId() == 18692)
-                        {
-                            rank = 1;
-                            break;
-                        }
-                        if (mDummyAura->GetId() == 18693)
-                        {
-                            rank = 2;
-                            break;
-                        }
-                    }
-
-                    static uint32 const itypes[8][3] =
-                    {
-                        { 5512, 19004, 19005},              // Minor Healthstone
-                        { 5511, 19006, 19007},              // Lesser Healthstone
-                        { 5509, 19008, 19009},              // Healthstone
-                        { 5510, 19010, 19011},              // Greater Healthstone
-                        { 9421, 19012, 19013},              // Major Healthstone
-                        {22103, 22104, 22105},              // Master Healthstone
-                        {36889, 36890, 36891},              // Demonic Healthstone
-                        {36892, 36893, 36894}               // Fel Healthstone
-                    };
-
-                    switch (m_spellInfo->Id)
-                    {
-                        case  6201:
-                            itemtype = itypes[0][rank]; break; // Minor Healthstone
-                        case  6202:
-                            itemtype = itypes[1][rank]; break; // Lesser Healthstone
-                        case  5699:
-                            itemtype = itypes[2][rank]; break; // Healthstone
-                        case 11729:
-                            itemtype = itypes[3][rank]; break; // Greater Healthstone
-                        case 11730:
-                            itemtype = itypes[4][rank]; break; // Major Healthstone
-                        case 27230:
-                            itemtype = itypes[5][rank]; break; // Master Healthstone
-                        case 47871:
-                            itemtype = itypes[6][rank]; break; // Demonic Healthstone
-                        case 47878:
-                            itemtype = itypes[7][rank]; break; // Fel Healthstone
-                        default:
-                            return;
-                    }
-                    DoCreateItem(eff_idx, itemtype);
+                    uint32 itemType = GetUsableHealthStoneItemType(unitTarget);
+                    if (itemType)
+                        DoCreateItem(eff_idx, itemType);
                     return;
                 }
                 case 47193:                                 // Demonic Empowerment
@@ -13499,4 +13451,54 @@ void Spell::EffectCreateTamedPet(SpellEffectIndex eff_idx)
 
     newTamedPet->SavePetToDB(PET_SAVE_AS_CURRENT);
     ((Player*)unitTarget)->PetSpellInitialize();
+}
+
+uint32 Spell::GetUsableHealthStoneItemType(Unit* target)
+{
+    if (!target || target->GetTypeId() != TYPEID_PLAYER)
+        return 0;
+
+    uint32 itemtype;
+    uint32 rank = 0;
+    Unit::AuraList const& mDummyAuras = target->GetAurasByType(SPELL_AURA_DUMMY);
+    for (auto mDummyAura : mDummyAuras)
+    {
+        if (mDummyAura->GetId() == 18692)
+        {
+            rank = 1;
+            break;
+        }
+        if (mDummyAura->GetId() == 18693)
+        {
+            rank = 2;
+            break;
+        }
+    }
+
+    static uint32 const itypes[6][3] =
+    {
+        { 5512, 19004, 19005},              // Minor Healthstone
+        { 5511, 19006, 19007},              // Lesser Healthstone
+        { 5509, 19008, 19009},              // Healthstone
+        { 5510, 19010, 19011},              // Greater Healthstone
+        { 9421, 19012, 19013},              // Major Healthstone
+        {22103, 22104, 22105}               // Master Healthstone
+    };
+
+    switch (m_spellInfo->Id)
+    {
+    case  6201:
+        itemtype = itypes[0][rank]; break; // Minor Healthstone
+    case  6202:
+        itemtype = itypes[1][rank]; break; // Lesser Healthstone
+    case  5699:
+        itemtype = itypes[2][rank]; break; // Healthstone
+    case 11729:
+        itemtype = itypes[3][rank]; break; // Greater Healthstone
+    case 11730:
+        itemtype = itypes[4][rank]; break; // Major Healthstone
+    case 27230:
+        itemtype = itypes[5][rank]; break; // Master Healthstone
+    }
+    return itemtype;
 }


### PR DESCRIPTION
See: https://github.com/cmangos/mangos-tbc/pull/288

This is modified from the TBC version to account for any Healthstone (unique item no matter the rank).