### PR TITLE
Pass along player owner to SavePetToDB

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -366,16 +366,14 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry /*= 0*/, uint32 petnumber
     owner->SetPet(this);                                    // in DB stored only full controlled creature
     DEBUG_LOG("New Pet has guid %u", GetGUIDLow());
 
-    if (owner->GetTypeId() == TYPEID_PLAYER)
-    {
-        ((Player*)owner)->PetSpellInitialize();
-        if (((Player*)owner)->GetGroup())
-            ((Player*)owner)->SetGroupUpdateFlag(GROUP_UPDATE_PET);
+    owner->PetSpellInitialize();
 
-        ((Player*)owner)->SendTalentsInfoData(true);
-    }
+    if (owner->GetGroup())
+        owner->SetGroupUpdateFlag(GROUP_UPDATE_PET);
 
-    if (owner->GetTypeId() == TYPEID_PLAYER && getPetType() == HUNTER_PET)
+    owner->SendTalentsInfoData(true);
+
+    if (getPetType() == HUNTER_PET)
     {
         result = CharacterDatabase.PQuery("SELECT genitive, dative, accusative, instrumental, prepositional FROM character_pet_declinedname WHERE owner = '%u' AND id = '%u'", owner->GetGUIDLow(), GetCharmInfo()->GetPetNumber());
 
@@ -396,11 +394,11 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry /*= 0*/, uint32 petnumber
 
     SynchronizeLevelWithOwner();
 
-    SavePetToDB(PET_SAVE_AS_CURRENT);
+    SavePetToDB(PET_SAVE_AS_CURRENT, owner);
     return true;
 }
 
-void Pet::SavePetToDB(PetSaveMode mode)
+void Pet::SavePetToDB(PetSaveMode mode, Player* owner)
 {
     if (!GetEntry())
         return;
@@ -409,16 +407,8 @@ void Pet::SavePetToDB(PetSaveMode mode)
     if (!isControlled())
         return;
 
-    // dont save not player pets
-    if (!GetOwnerGuid().IsPlayer())
-        return;
-
-    Player* pOwner = (Player*)GetOwner();
-    if (!pOwner)
-        return;
-
     // dont save shadowfiend
-    if (pOwner->getClass() == CLASS_PRIEST)
+    if (owner->getClass() == CLASS_PRIEST)
         return;
 
     // current/stable/not_in_slot
@@ -428,8 +418,8 @@ void Pet::SavePetToDB(PetSaveMode mode)
         if (mode == PET_SAVE_REAGENTS)
             mode = PET_SAVE_NOT_IN_SLOT;
         // not save pet as current if another pet temporary unsummoned
-        else if (mode == PET_SAVE_AS_CURRENT && pOwner->GetTemporaryUnsummonedPetNumber() &&
-                 pOwner->GetTemporaryUnsummonedPetNumber() != m_charmInfo->GetPetNumber())
+        else if (mode == PET_SAVE_AS_CURRENT && owner->GetTemporaryUnsummonedPetNumber() &&
+                 owner->GetTemporaryUnsummonedPetNumber() != m_charmInfo->GetPetNumber())
         {
             // pet will lost anyway at restore temporary unsummoned
             if (getPetType() == HUNTER_PET)
@@ -779,13 +769,15 @@ void Pet::Unsummon(PetSaveMode mode, Unit* owner /*= nullptr*/)
 
     if (owner)
     {
+        Player* p_owner = nullptr;
+
         if (GetOwnerGuid() != owner->GetObjectGuid())
             return;
 
-        Player* p_owner = owner->GetTypeId() == TYPEID_PLAYER ? (Player*)owner : nullptr;
-
         if (p_owner)
         {
+            p_owner = static_cast<Player*>(owner);
+
             // not save secondary permanent pet as current
             if (mode == PET_SAVE_AS_CURRENT && p_owner->GetTemporaryUnsummonedPetNumber() &&
                     p_owner->GetTemporaryUnsummonedPetNumber() != GetCharmInfo()->GetPetNumber())
@@ -841,9 +833,11 @@ void Pet::Unsummon(PetSaveMode mode, Unit* owner /*= nullptr*/)
                     owner->SetPet(nullptr);
                 break;
         }
+
+        if (p_owner)
+            SavePetToDB(mode, p_owner);
     }
 
-    SavePetToDB(mode);
     AddObjectToRemoveList();
     m_removed = true;
 }

--- a/src/game/Entities/Pet.h
+++ b/src/game/Entities/Pet.h
@@ -155,7 +155,7 @@ class Pet : public Creature
         bool Create(uint32 guidlow, CreatureCreatePos& cPos, CreatureInfo const* cinfo, uint32 pet_number);
         bool CreateBaseAtCreature(Creature* creature);
         bool LoadPetFromDB(Player* owner, uint32 petentry = 0, uint32 petnumber = 0, bool current = false, uint32 healthPercentage = 0, bool permanentOnly = false, bool forced = false);
-        void SavePetToDB(PetSaveMode mode);
+        void SavePetToDB(PetSaveMode mode, Player* owner);
         bool isLoading() const { return m_loading; }
         void SetLoading(bool state) { m_loading = state; }
         void Unsummon(PetSaveMode mode, Unit* owner = nullptr);

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -17808,7 +17808,7 @@ void Player::SaveToDB()
 
     // save pet (hunter pet level and experience and all type pets health/mana except priest pet).
     if (Pet* pet = GetPet())
-        pet->SavePetToDB(PET_SAVE_AS_CURRENT);
+        pet->SavePetToDB(PET_SAVE_AS_CURRENT, this);
 }
 
 // fast save function for item/money cheating preventing - save only inventory and money state

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -13458,6 +13458,8 @@ void Spell::EffectCreateTamedPet(SpellEffectIndex eff_idx)
     m_caster->SetPet(newTamedPet);
 
     Player* _player = static_cast<Player*>(unitTarget);
+    // This check is theoretically redundant as only players can be the hunter class
+    // yet I kind of want to keep it in just in case the typecast fails (?)
     if (_player)
     {
         newTamedPet->SavePetToDB(PET_SAVE_AS_CURRENT, _player);


### PR DESCRIPTION
Should hopefully fix the locking error occuring when using the command .saveall

LoadPetFromDB looks to see if the owner is a player towards the end of the function, which in of itself seems ridiculous considering owner in this context is a player type object, not a unit type, and if the owner wasn't an actual player it would have returned false at the beginning where it checks the character database. (there's also some typecasting player into player which is just weird)

Everywhere the pet is saved to the db the owner is checked to be a player first, so the checks inside the function itself are redundant if we can pass along the owner in the function call.

Player.cpp only has 1 instance of SavePetToDB (this is the 1 instance which causes the issue). Easy enough to pass on itself in this case.

Spelleffects has a few instances, but all of them are related to a player caster so we just pass along what we got.

Specifically in EffectSummonPet which I helped to write there is quite a bit of redundant typecasting, it's done everry single time we wanna do something in related to the player owner of the pet, so I've replaced all of that with a single static cast and used that everywhere in that function instead.

Port of cmangos/mangos-classic#390 and https://github.com/cmangos/mangos-tbc/pull/310