### PR TITLE
Oversight in porting (from 2016)

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -6549,8 +6549,8 @@ bool Spell::DoSummonCritter(CreatureSummonPositions& list, SummonPropertiesEntry
     // summon new pet
     Pet* critter = new Pet(MINI_PET);
 
-    uint32 pet_number = sObjectMgr.GeneratePetNumber();
-    if (!critter->Create(m_caster->GetMap()->GenerateLocalLowGuid(HIGHGUID_PET), pos, cInfo, pet_number))
+
+    if (!critter->Create(m_caster->GetMap()->GenerateLocalLowGuid(HIGHGUID_PET), pos, cInfo, pet_entry))
     {
         sLog.outError("Spell::EffectSummonCritter, spellid %u: no such creature entry %u", m_spellInfo->Id, pet_entry);
         delete critter;


### PR DESCRIPTION
Missed bit of change from porting from classic/tbc to wotlk

Change can be seen here; https://github.com/cmangos/mangos-classic/pull/124/commits/47274eb44943a92e1d60a0268655dd11b6b1183c#diff-6e2ad27531ee8eb7bafce8a41909816aR4730

and this is the wotlk commit which is missing this change; https://github.com/cmangos/mangos-wotlk/pull/192/commits/5eb9809fc08991ebf8dbb0f8d9e755af873466ce

relates to https://github.com/cmangos/issues/issues/869 and https://github.com/cmangos/issues/issues/107 but I'm not sure it actually solves it (even though it's working as intended on classic and tbc, perhaps wotlk is missing something else, something more)