### PR TITLE
add optional output path to extractor scripts

### DIFF
--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -13,6 +13,8 @@
 ## Expected param 1 to be 'a' for all, else ask some questions
 ## optionally param 1 or param 2 is the path to game client
 
+PREFIX="$(dirname $0)"
+
 ## Normal log file (if not overwritten by second param
 LOG_FILE="MaNGOSExtractor.log"
 ## Detailed log file
@@ -106,7 +108,7 @@ fi
 if [ "$USE_MMAPS_OFFMESH" = "1" ]
 then
   echo "Only extracting offmesh meshes"
-  ./MoveMapGen.sh offmesh $OUTPUT_PATH $LOG_FILE $DETAIL_LOG_FILE
+  $PREFIX/MoveMapGen.sh offmesh $OUTPUT_PATH $LOG_FILE $DETAIL_LOG_FILE
   exit 0
 fi
 
@@ -210,7 +212,7 @@ echo | tee -a $DETAIL_LOG_FILE
 if [ "$USE_AD" = "1" ]
 then
  echo "$(date): Start extraction of DBCs and map files..." | tee -a $LOG_FILE
- ./ad $AD_RES $AD_OPT_RES | tee -a $DETAIL_LOG_FILE
+ $PREFIX/ad $AD_RES $AD_OPT_RES | tee -a $DETAIL_LOG_FILE
  echo "$(date): Extracting of DBCs and map files finished" | tee -a $LOG_FILE
  echo | tee -a $LOG_FILE
  echo | tee -a $DETAIL_LOG_FILE
@@ -220,11 +222,11 @@ fi
 if [ "$USE_VMAPS" = "1" ]
 then
   echo "$(date): Start extraction of vmaps..." | tee -a $LOG_FILE
-  ./vmap_extractor $VMAP_RES $VMAP_OPT_RES | tee -a $DETAIL_LOG_FILE
+  $PREFIX/vmap_extractor $VMAP_RES $VMAP_OPT_RES | tee -a $DETAIL_LOG_FILE
   echo "$(date): Extracting of vmaps finished" | tee -a $LOG_FILE
   mkdir ${OUTPUT_PATH:-.}/vmaps
   echo "$(date): Start assembling of vmaps..." | tee -a $LOG_FILE
-  ./vmap_assembler ${OUTPUT_PATH:-.}/Buildings ${OUTPUT_PATH:-.}/vmaps | tee -a $DETAIL_LOG_FILE
+  $PREFIX/vmap_assembler ${OUTPUT_PATH:-.}/Buildings ${OUTPUT_PATH:-.}/vmaps | tee -a $DETAIL_LOG_FILE
   echo "$(date): Assembling of vmaps finished" | tee -a $LOG_FILE
 
   echo | tee -a $LOG_FILE
@@ -239,5 +241,5 @@ then
     echo "Current time: $(date)"
     sleep $USE_MMAPS_DELAY
   fi
-  sh MoveMapGen.sh $NUM_CPU $OUTPUT_PATH $LOG_FILE $DETAIL_LOG_FILE
+  $PREFIX/MoveMapGen.sh $NUM_CPU $OUTPUT_PATH $LOG_FILE $DETAIL_LOG_FILE
 fi

--- a/contrib/extractor_scripts/ExtractResources.sh
+++ b/contrib/extractor_scripts/ExtractResources.sh
@@ -11,6 +11,7 @@
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 ## Expected param 1 to be 'a' for all, else ask some questions
+## optionally param 1 or param 2 is the path to game client
 
 ## Normal log file (if not overwritten by second param
 LOG_FILE="MaNGOSExtractor.log"
@@ -79,11 +80,33 @@ else
   fi
 fi
 
+if [ "$1" != "a" ] && [ "x$1" != "x" ] && [ -d "$1" ]
+then
+  CLIENT_PATH="$1"
+  OUTPUT_PATH="$2"
+elif [ "x$2" != "x" ] && [ -d "$2" ]
+then
+  CLIENT_PATH="$2"
+  OUTPUT_PATH=$3
+fi
+
+if [ "x$CLIENT_PATH" != "x" ]
+then
+  AD_OPT_RES="-i $CLIENT_PATH"
+  VMAP_OPT_RES="-d $CLIENT_PATH/Data"
+fi
+
+if [ "x$OUTPUT_PATH" != "x" ] && [ -d "$OUTPUT_PATH" ]
+then
+  AD_OPT_RES="$AD_OPT_RES -o $OUTPUT_PATH"
+  VMAP_OPT_RES="$VMAP_OPT_RES -o $OUTPUT_PATH"
+fi
+
 ## Special case: Only reextract offmesh tiles
 if [ "$USE_MMAPS_OFFMESH" = "1" ]
 then
   echo "Only extracting offmesh meshes"
-  MoveMapGen.sh offmesh $LOG_FILE $DETAIL_LOG_FILE
+  ./MoveMapGen.sh offmesh $OUTPUT_PATH $LOG_FILE $DETAIL_LOG_FILE
   exit 0
 fi
 
@@ -187,7 +210,7 @@ echo | tee -a $DETAIL_LOG_FILE
 if [ "$USE_AD" = "1" ]
 then
  echo "$(date): Start extraction of DBCs and map files..." | tee -a $LOG_FILE
- ./ad $AD_RES | tee -a $DETAIL_LOG_FILE
+ ./ad $AD_RES $AD_OPT_RES | tee -a $DETAIL_LOG_FILE
  echo "$(date): Extracting of DBCs and map files finished" | tee -a $LOG_FILE
  echo | tee -a $LOG_FILE
  echo | tee -a $DETAIL_LOG_FILE
@@ -197,11 +220,11 @@ fi
 if [ "$USE_VMAPS" = "1" ]
 then
   echo "$(date): Start extraction of vmaps..." | tee -a $LOG_FILE
-  ./vmap_extractor $VMAP_RES | tee -a $DETAIL_LOG_FILE
+  ./vmap_extractor $VMAP_RES $VMAP_OPT_RES | tee -a $DETAIL_LOG_FILE
   echo "$(date): Extracting of vmaps finished" | tee -a $LOG_FILE
-  mkdir vmaps
+  mkdir ${OUTPUT_PATH:-.}/vmaps
   echo "$(date): Start assembling of vmaps..." | tee -a $LOG_FILE
-  ./vmap_assembler Buildings vmaps | tee -a $DETAIL_LOG_FILE
+  ./vmap_assembler ${OUTPUT_PATH:-.}/Buildings ${OUTPUT_PATH:-.}/vmaps | tee -a $DETAIL_LOG_FILE
   echo "$(date): Assembling of vmaps finished" | tee -a $LOG_FILE
 
   echo | tee -a $LOG_FILE
@@ -216,5 +239,5 @@ then
     echo "Current time: $(date)"
     sleep $USE_MMAPS_DELAY
   fi
-  sh MoveMapGen.sh $NUM_CPU $LOG_FILE $DETAIL_LOG_FILE
+  sh MoveMapGen.sh $NUM_CPU $OUTPUT_PATH $LOG_FILE $DETAIL_LOG_FILE
 fi

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -59,18 +59,34 @@ badParam()
  echo "For further fine-tuning edit this helper script"
  echo
 }
-
-if [ "$#" = "3" ]
+if [ "$#" = "4" ]
 then
- LOG_FILE=$2
- DETAIL_LOG_FILE=$3
+ OUTPUT_PATH="$2"
+ LOG_FILE=$3
+ DETAIL_LOG_FILE=$4
+elif [ "$#" = "3" ]
+then
+ if [ -d "$2" ]
+ then
+  OUTPUT_PATH="$2"
+  LOG_FILE=$3
+ else
+  LOG_FILE=$2
+  DETAIL_LOG_FILE=$3
+ fi
 elif [ "$#" = "2" ]
 then
- LOG_FILE=$2
+ if [ -d "$2" ]
+ then
+  OUTPUT_PATH="$2"
+ else
+  LOG_FILE=$2
+ fi
 fi
 
 # Offmesh file provided?
 OFFMESH=""
+MMG_RES="--workdir ${OUTPUT_PATH:-.}/"
 if [ "$OFFMESH_FILE" != "" ]
 then
  if [ ! -f "$OFFMESH_FILE" ]
@@ -95,7 +111,7 @@ createMMaps()
        continue 2
      fi
    done
-   ./MoveMapGen $PARAMS $OFFMESH $i | tee -a $DETAIL_LOG_FILE
+   ./MoveMapGen $PARAMS $OFFMESH $MMG_RES $i | tee -a $DETAIL_LOG_FILE
    echo "`date`: (Re)created map $i" | tee -a $LOG_FILE
  done
 }
@@ -114,7 +130,7 @@ createHeader()
 # Create mmaps directory if not exist
 if [ ! -d mmaps ]
 then
- mkdir mmaps
+ mkdir ${OUTPUT_PATH:-.}/mmaps
 fi
 
 # Param control
@@ -151,7 +167,7 @@ case "$1" in
    echo "Recreate offmeshs from file $OFFMESH_FILE" | tee -a $DETAIL_LOG_FILE
    while read map tile line
    do
-     ./MoveMapGen $PARAMS $OFFMESH $map --tile $tile | tee -a $DETAIL_LOG_FILE
+     ./MoveMapGen $PARAMS $OFFMESH $MMG_RES $map --tile $tile | tee -a $DETAIL_LOG_FILE
      echo "`date`: Recreated $map $tile from $OFFMESH_FILE" | tee -a $LOG_FILE
    done < $OFFMESH_FILE &
    ;;

--- a/contrib/extractor_scripts/MoveMapGen.sh
+++ b/contrib/extractor_scripts/MoveMapGen.sh
@@ -15,6 +15,8 @@
 ## Second param can be an additional filename for storing log
 ## Third param can be an addition filename for storing detailed log
 
+PREFIX="$(dirname $0)"
+
 ## Additional Parameters to be forwarded to MoveMapGen, see mmaps/readme for instructions
 PARAMS="--silent"
 
@@ -111,7 +113,7 @@ createMMaps()
        continue 2
      fi
    done
-   ./MoveMapGen $PARAMS $OFFMESH $MMG_RES $i | tee -a $DETAIL_LOG_FILE
+   $PREFIX/MoveMapGen $PARAMS $OFFMESH $MMG_RES $i | tee -a $DETAIL_LOG_FILE
    echo "`date`: (Re)created map $i" | tee -a $LOG_FILE
  done
 }
@@ -167,7 +169,7 @@ case "$1" in
    echo "Recreate offmeshs from file $OFFMESH_FILE" | tee -a $DETAIL_LOG_FILE
    while read map tile line
    do
-     ./MoveMapGen $PARAMS $OFFMESH $MMG_RES $map --tile $tile | tee -a $DETAIL_LOG_FILE
+     $PREFIX/MoveMapGen $PARAMS $OFFMESH $MMG_RES $map --tile $tile | tee -a $DETAIL_LOG_FILE
      echo "`date`: Recreated $map $tile from $OFFMESH_FILE" | tee -a $LOG_FILE
    done < $OFFMESH_FILE &
    ;;

--- a/contrib/mmap/src/IntermediateValues.cpp
+++ b/contrib/mmap/src/IntermediateValues.cpp
@@ -29,7 +29,7 @@ namespace MMAP
         rcFreePolyMeshDetail(polyMeshDetail);
     }
 
-    void IntermediateValues::writeIV(uint32 mapID, uint32 tileX, uint32 tileY)
+    void IntermediateValues::writeIV(const char* workdir, uint32 mapID, uint32 tileX, uint32 tileY)
     {
         char fileName[255];
         char tileString[25];
@@ -37,11 +37,11 @@ namespace MMAP
 
         printf("%sWriting debug output...                       \r", tileString);
 
-        string name("meshes/%03u%02i%02i.");
+        string name("%s/meshes/%03u%02i%02i.");
 
 #define DEBUG_WRITE(fileExtension,data) \
         do { \
-            sprintf(fileName, (name + fileExtension).c_str(), mapID, tileY, tileX); \
+            sprintf(fileName, (name + fileExtension).c_str(), workdir, mapID, tileY, tileX); \
             FILE* file = fopen(fileName, "wb"); \
             if (!file) \
             { \
@@ -199,10 +199,10 @@ namespace MMAP
         fwrite(mesh->meshes, sizeof(int), mesh->nmeshes * 4, file);
     }
 
-    void IntermediateValues::generateObjFile(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData)
+    void IntermediateValues::generateObjFile(const char* workdir, uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData)
     {
         char objFileName[255];
-        sprintf(objFileName, "meshes/map%03u%02u%02u.obj", mapID, tileY, tileX);
+        sprintf(objFileName, "%s/meshes/map%03u%02u%02u.obj", workdir, mapID, tileY, tileX);
 
         FILE* objFile = fopen(objFileName, "wb");
         if (!objFile)
@@ -239,7 +239,7 @@ namespace MMAP
         sprintf(tileString, "[%02u,%02u]: ", tileY, tileX);
         printf("%sWriting debug output...                       \r", tileString);
 
-        sprintf(objFileName, "meshes/%03u.map", mapID);
+        sprintf(objFileName, "%s/meshes/%03u.map", workdir, mapID);
 
         objFile = fopen(objFileName, "wb");
         if (!objFile)
@@ -254,7 +254,7 @@ namespace MMAP
         fwrite(&b, sizeof(char), 1, objFile);
         fclose(objFile);
 
-        sprintf(objFileName, "meshes/%03u%02u%02u.mesh", mapID, tileY, tileX);
+        sprintf(objFileName, "%s/meshes/%03u%02u%02u.mesh", mapID, tileY, tileX);
         objFile = fopen(objFileName, "wb");
         if (!objFile)
         {

--- a/contrib/mmap/src/IntermediateValues.h
+++ b/contrib/mmap/src/IntermediateValues.h
@@ -40,7 +40,7 @@ namespace MMAP
             contours(NULL), polyMesh(NULL), polyMeshDetail(NULL) {}
         ~IntermediateValues();
 
-        void writeIV(uint32 mapID, uint32 tileX, uint32 tileY);
+        void writeIV(const char* workdir, uint32 mapID, uint32 tileX, uint32 tileY);
 
         void debugWrite(FILE* file, const rcHeightfield* mesh);
         void debugWrite(FILE* file, const rcCompactHeightfield* chf);
@@ -48,7 +48,7 @@ namespace MMAP
         void debugWrite(FILE* file, const rcPolyMesh* mesh);
         void debugWrite(FILE* file, const rcPolyMeshDetail* mesh);
 
-        void generateObjFile(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData);
+        void generateObjFile(const char* workdir, uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData);
     };
 }
 #endif

--- a/contrib/mmap/src/MapBuilder.cpp
+++ b/contrib/mmap/src/MapBuilder.cpp
@@ -33,7 +33,7 @@ namespace MMAP
 {
     MapBuilder::MapBuilder(float maxWalkableAngle, bool skipLiquid,
                            bool skipContinents, bool skipJunkMaps, bool skipBattlegrounds,
-                           bool debugOutput, bool bigBaseUnit, const char* offMeshFilePath) :
+                           bool debugOutput, bool bigBaseUnit, const char* offMeshFilePath, const char* workdir) :
         m_terrainBuilder(NULL),
         m_debugOutput(debugOutput),
         m_skipContinents(skipContinents),
@@ -42,9 +42,10 @@ namespace MMAP
         m_maxWalkableAngle(maxWalkableAngle),
         m_bigBaseUnit(bigBaseUnit),
         m_rcContext(NULL),
-        m_offMeshFilePath(offMeshFilePath)
+        m_offMeshFilePath(offMeshFilePath),
+        m_workdir(workdir)
     {
-        m_terrainBuilder = new TerrainBuilder(skipLiquid);
+        m_terrainBuilder = new TerrainBuilder(skipLiquid, workdir);
 
         m_rcContext = new rcContext(false);
 
@@ -70,9 +71,12 @@ namespace MMAP
         std::vector<std::string> files;
         uint32 mapID, tileX, tileY, tileID, count = 0;
         char filter[12];
+        char maps_dir[1024];
+        char vmaps_dir[1024];
 
         printf("Discovering maps... ");
-        getDirContents(files, "maps");
+        sprintf(maps_dir, "%s/maps", m_workdir);
+        getDirContents(files, maps_dir);
         for (uint32 i = 0; i < files.size(); ++i)
         {
             mapID = uint32(atoi(files[i].substr(0, 3).c_str()));
@@ -84,7 +88,8 @@ namespace MMAP
         }
 
         files.clear();
-        getDirContents(files, "vmaps", "*.vmtree");
+        sprintf(vmaps_dir, "%s/vmaps", m_workdir);
+        getDirContents(files, vmaps_dir, "*.vmtree");
         for (uint32 i = 0; i < files.size(); ++i)
         {
             mapID = uint32(atoi(files[i].substr(0, 3).c_str()));
@@ -102,7 +107,7 @@ namespace MMAP
 
             sprintf(filter, "%03u*.vmtile", mapID);
             files.clear();
-            getDirContents(files, "vmaps", filter);
+            getDirContents(files, vmaps_dir, filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
                 tileX = uint32(atoi(files[i].substr(7, 2).c_str()));
@@ -115,7 +120,7 @@ namespace MMAP
 
             sprintf(filter, "%03u*", mapID);
             files.clear();
-            getDirContents(files, "maps", filter);
+            getDirContents(files, maps_dir, filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
                 tileY = uint32(atoi(files[i].substr(3, 2).c_str()));
@@ -361,8 +366,8 @@ namespace MMAP
             return;
         }
 
-        char fileName[25];
-        sprintf(fileName, "mmaps/%03u.mmap", mapID);
+        char fileName[1024];
+        sprintf(fileName, "%s/mmaps/%03u.mmap", m_workdir, mapID);
 
         FILE* file = fopen(fileName, "wb");
         if (!file)
@@ -643,7 +648,7 @@ namespace MMAP
         do
         {
             // these values are checked within dtCreateNavMeshData - handle them here
-            // so we have a clear error message
+            // so we have a clear error messages
             if (params.nvp > DT_VERTS_PER_POLYGON)
             {
                 printf("%s Invalid verts-per-polygon value!                   \n", tileString);
@@ -697,8 +702,8 @@ namespace MMAP
             }
 
             // file output
-            char fileName[255];
-            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+            char fileName[1024];
+            sprintf(fileName, "%s/mmaps/%03u%02i%02i.mmtile", m_workdir, mapID, tileY, tileX);
             FILE* file = fopen(fileName, "wb");
             if (!file)
             {
@@ -736,8 +741,8 @@ namespace MMAP
                 v[2] += (unsigned short)config.borderSize;
             }
 
-            iv.generateObjFile(mapID, tileX, tileY, meshData);
-            iv.writeIV(mapID, tileX, tileY);
+            iv.generateObjFile(m_workdir, mapID, tileX, tileY, meshData);
+            iv.writeIV(m_workdir, mapID, tileX, tileY);
         }
     }
 
@@ -857,7 +862,7 @@ namespace MMAP
     bool MapBuilder::shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY)
     {
         char fileName[255];
-        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+        sprintf(fileName, "%s/mmaps/%03u%02i%02i.mmtile", m_workdir, mapID, tileY, tileX);
         FILE* file = fopen(fileName, "rb");
         if (!file)
             return false;

--- a/contrib/mmap/src/MapBuilder.h
+++ b/contrib/mmap/src/MapBuilder.h
@@ -67,7 +67,8 @@ namespace MMAP
                        bool skipBattlegrounds   = false,
                        bool debugOutput         = false,
                        bool bigBaseUnit         = false,
-                       const char* offMeshFilePath = NULL);
+                       const char* offMeshFilePath = NULL,
+                       const char* workdir = NULL);
 
             ~MapBuilder();
 
@@ -113,6 +114,7 @@ namespace MMAP
             bool m_debugOutput;
 
             const char* m_offMeshFilePath;
+            const char* m_workdir;
             bool m_skipContinents;
             bool m_skipJunkMaps;
             bool m_skipBattlegrounds;

--- a/contrib/mmap/src/TerrainBuilder.cpp
+++ b/contrib/mmap/src/TerrainBuilder.cpp
@@ -29,7 +29,7 @@
 
 namespace MMAP
 {
-    TerrainBuilder::TerrainBuilder(bool skipLiquid) : m_skipLiquid(skipLiquid) { }
+    TerrainBuilder::TerrainBuilder(bool skipLiquid, const char* workdir) : m_skipLiquid(skipLiquid), m_workdir(workdir) { }
     TerrainBuilder::~TerrainBuilder() { }
 
     /**************************************************************************/
@@ -81,7 +81,7 @@ namespace MMAP
     bool TerrainBuilder::loadMap(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData, Spot portion)
     {
         char mapFileName[255];
-        sprintf(mapFileName, "maps/%03u%02u%02u.map", mapID, tileY, tileX);
+        sprintf(mapFileName, "%s/maps/%03u%02u%02u.map", m_workdir, mapID, tileY, tileX);
 
         FILE* mapFile = fopen(mapFileName, "rb");
         if (!mapFile)
@@ -566,8 +566,10 @@ namespace MMAP
     /**************************************************************************/
     bool TerrainBuilder::loadVMap(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData)
     {
+        char vmaps_dir[1024];
         IVMapManager* vmapManager = new VMapManager2();
-        VMAPLoadResult result = vmapManager->loadMap("vmaps", mapID, tileX, tileY);
+        sprintf(vmaps_dir, "%s/vmaps", m_workdir);
+        VMAPLoadResult result = vmapManager->loadMap(vmaps_dir, mapID, tileX, tileY);
         bool retval = false;
 
         do

--- a/contrib/mmap/src/TerrainBuilder.h
+++ b/contrib/mmap/src/TerrainBuilder.h
@@ -81,7 +81,7 @@ namespace MMAP
     class TerrainBuilder
     {
         public:
-            TerrainBuilder(bool skipLiquid);
+            TerrainBuilder(bool skipLiquid, const char* workdir);
             ~TerrainBuilder();
 
             void loadMap(uint32 mapID, uint32 tileX, uint32 tileY, MeshData& meshData);
@@ -106,6 +106,9 @@ namespace MMAP
 
             /// Controls whether liquids are loaded
             bool m_skipLiquid;
+
+            // wokrdir to read and write
+            const char* m_workdir;
 
             /// Load the map terrain from file
             bool loadHeightMap(uint32 mapID, uint32 tileX, uint32 tileY, G3D::Array<float>& vertices, G3D::Array<int>& triangles, Spot portion);

--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -67,15 +67,16 @@ typedef struct
 map_id* map_ids;
 uint16* LiqType = 0;
 uint32 map_count;
-char output_path[128] = ".";
-char input_path[1024] = ".";
+char output_path[path_l] = ".";
+char input_path[path_l] = ".";
 bool hasInputPathParam = false;
+bool hasOutputPathParam = false;
 bool preciseVectorData = false;
 
 // Constants
 
 //static const char * szWorkDirMaps = ".\\Maps";
-const char* szWorkDirWmo = "./Buildings";
+char szWorkDirWmo[path_l + 512];
 const char* szRawVMAPMagic = "VMAP005";
 
 // Local testing functions
@@ -149,10 +150,12 @@ bool ExtractSingleWmo(std::string& fname)
 {
     // Copy files from archive
 
-    char szLocalFile[1024];
+    char szLocalFile[path_l + 512];
+    char path[path_l];
     const char* plain_name = GetPlainName(fname.c_str());
-    sprintf(szLocalFile, "%s/%s", szWorkDirWmo, plain_name);
-    fixnamen(szLocalFile, strlen(szLocalFile));
+    sprintf(path, "%s", plain_name);
+    fixnamen(path, strlen(path));
+    sprintf(szLocalFile, "%s/%s", szWorkDirWmo, path);
 
     if (FileExists(szLocalFile))
         return true;
@@ -313,7 +316,7 @@ bool fillArchiveNameVector(std::vector<std::string>& pArchiveNames)
 
     printf("\nGame path: %s\n", input_path);
 
-    char path[512];
+    char path[path_l + 16];
     string in_path(input_path);
     std::vector<std::string> locales, searchLocales;
 
@@ -392,6 +395,7 @@ bool processArgv(int argc, char** argv)
     bool result = true;
     hasInputPathParam = false;
     preciseVectorData = false;
+    sprintf(szWorkDirWmo, "%s", "./Buildings");
 
     for (int i = 1; i < argc; ++i)
     {
@@ -407,6 +411,22 @@ bool processArgv(int argc, char** argv)
                 strcpy(input_path, argv[i + 1]);
                 if (input_path[strlen(input_path) - 1] != '\\' && input_path[strlen(input_path) - 1] != '/')
                     strcat(input_path, "/");
+                ++i;
+            }
+            else
+            {
+                result = false;
+            }
+        }
+        else if (strcmp("-o", argv[i]) == 0)
+        {
+            if ((i + 1) < argc)
+            {
+                hasOutputPathParam = true;
+                strcpy(output_path, argv[i + 1]);
+                if (output_path[strlen(output_path) - 1] != '\\' && output_path[strlen(output_path) - 1] != '/')
+                    strcat(output_path, "/");
+                sprintf(szWorkDirWmo, "%s/Buildings", output_path);
                 ++i;
             }
             else
@@ -435,6 +455,7 @@ bool processArgv(int argc, char** argv)
         printf("   -s : (default) small size (data size optimization), ~500MB less vmap data.\n");
         printf("   -l : large size, ~500MB more vmap data. (might contain more details)\n");
         printf("   -d <path>: Path to the vector data source folder.\n");
+        printf("   -o <path>: Path to the output folder.\n");
         printf("   -? : This message.\n");
     }
     return result;
@@ -453,6 +474,7 @@ bool processArgv(int argc, char** argv)
 int main(int argc, char** argv)
 {
     bool success = true;
+    char path[path_l + 512];
 
     // Use command line arguments, when some
     if (!processArgv(argc, argv))

--- a/contrib/vmap_extractor/vmapextract/vmapexport.h
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.h
@@ -31,7 +31,8 @@ enum ModelFlags
     MOD_HAS_BOUND = 1 << 2
 };
 
-extern const char* szWorkDirWmo;
+const int path_l = 1024;
+extern char szWorkDirWmo[path_l + 512];
 extern const char* szRawVMAPMagic;                          // vmap magic string for extracted raw vmap data
 
 bool FileExists(const char* file);


### PR DESCRIPTION
## 🍰 Pullrequest
this PR introduces an optional output path used by the extractor scripts.
It should prevent the requirement of writing into the client directory which could be in fact readonly.

### Issues
- https://github.com/cmangos/issues/issues/1965
- https://github.com/cmangos/mangos-classic/pull/399
- https://github.com/cmangos/mangos-tbc/pull/320

### How2Test
```
./ExtractResources.sh a <clientdir> <outputdir>
```
