### PR TITLE
Fix extractors build on freebsd 12

### DIFF
--- a/contrib/vmap_extractor/CMakeLists.txt
+++ b/contrib/vmap_extractor/CMakeLists.txt
@@ -34,4 +34,12 @@ if (APPLE)
   add_definitions("-Dftello64=ftello")
 endif()
 
+if (UNIX AND NOT LINUX AND NOT APPLE)
+  add_definitions("-Dfopen64=fopen")
+  add_definitions("-Dfseeko64=fseeko")
+  add_definitions("-Dfseek64=fseek")
+  add_definitions("-Dftell64=ftell")
+  add_definitions("-Dftello64=ftello")
+endif()
+
 add_subdirectory(vmapextract)


### PR DESCRIPTION
freebsd is UNIX but NOT LINUX. extractors build failure fix.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Fix extractors build on freebsd 12
### Proof
<!-- Link resources as proof -->
in contrib/vmap_extractor/CMakeLists.txt not described true UNIX :)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
extractors build failure (freebsd 12)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- 
- 
-->
- try build with -DBUILD_EXTRACTORS=ON  on freebsd machine
- try build after patch

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
