### PR TITLE
Fix extractors build on freebsd

### DIFF
--- a/contrib/vmap_extractor/CMakeLists.txt
+++ b/contrib/vmap_extractor/CMakeLists.txt
@@ -22,8 +22,16 @@ ADD_DEFINITIONS("-DIOMAP_DEBUG")
 # build setup currently only supports libmpq 0.4.x
 ADD_DEFINITIONS("-DUSE_LIBMPQ04")
 
-if(UNIX)
+if (UNIX)
   ADD_DEFINITIONS("-ggdb")
+endif()
+
+if (UNIX AND NOT LINUX)
+  add_definitions("-Dfopen64=fopen")
+  add_definitions("-Dfseeko64=fseeko")
+  add_definitions("-Dfseek64=fseek")
+  add_definitions("-Dftell64=ftell")
+  add_definitions("-Dftello64=ftello")
 endif()
 
 if (APPLE)


### PR DESCRIPTION
Fix extractors build on freebsd

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
this patch allow build extractors on freebsd
### Proof
<!-- Link resources as proof -->
try  to build
$HOME/mangos
$HOME/build
$HOME: cd build
$HOME/build/: cmake ../mangos -DCMAKE_INSTALL_PREFIX=\../server -DBUILD_EXTRACTORS=ON -DPCH=0 -DDEBUG=0 -DBUILD_PLAYERBOT=ON
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
build failure on freebsd with -DBUILD_EXTRACTORS=ON
added if (UNIX AND NOT LINUX)

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- local build success after patch

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
