### PR TITLE
Extractors build on freebsd

### DIFF
--- a/contrib/vmap_extractor/vmapextract/vmapexport.cpp
+++ b/contrib/vmap_extractor/vmapextract/vmapexport.cpp
@@ -292,7 +292,11 @@ bool scan_patches(char* scanmatch, std::vector<std::string>& pArchiveNames)
             sprintf(path, "%s.MPQ", scanmatch);
         }
 #ifndef _WIN32
+#ifdef __FreeBSD__
+        if (FILE* h = fopen(path, "rb"))
+#else
         if (FILE* h = fopen64(path, "rb"))
+#endif
 #else
         if (FILE* h = fopen(path, "rb"))
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
Fix extractors build on freebsd
### Proof
try to build
OS: Freebsd from 9 to latest 12.0-RELEASE-p6 amd64
build failure on freebsd with -DBUILD_EXTRACTORS=ON
Got error vmapexport.cpp:295 use of undeclared identifier 'fopen64';
### Issues
Missing FreeBSD OS definition
Added OS definition in vmapexport.cpp after 294 line
```
#ifdef __FreeBSD__
        if (FILE* h = fopen(path, "rb"))
#else
        if (FILE* h = fopen64(path, "rb"))
#endif
```
### How2Test
patch and build
on FreeBSD with cmake -DBUILD_EXTRACTORS=ON -DPCH=0 -DDEBUG=0 -DBUILD_PLAYERBOT=0 -DBUILD_GAME_SERVER=0 -DBUILD_LOGIN_SERVER=0 -DBUILD_SCRIPTDEV=0

