### PR TITLE
Fix Gift of the Harvester

### DIFF
--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -10933,7 +10933,7 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     }
                     return;
                 }
-                case 52479:                                 // Gift of the Harvester
+                case 52481:                                 // Gift of the Harvester
                 {
                     if (m_caster->GetTypeId() != TYPEID_PLAYER || !unitTarget)
                         return;


### PR DESCRIPTION
Item casts spell 52481 instead of 52479. Cross referenced with sql and wowhead.

## 🍰 Pullrequest
Quest: The Gift that Keeps on Giving
Item: Gift of the Harvester not creating Scarlet Ghouls because it is looking for the wrong spell in code.

### Proof
Item casts this spellID
https://www.wowhead.com/spell=52479/gift-of-the-harvester

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Have a DK with the item Gift of the Harvester, 39253
- Attempt several times to turn a Scarlet Miner into a Scarlet Ghoul in the mines.
- Test this before and after the change.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] None
