### PR TITLE
fixing objects no longer lootable if related to quests

### DIFF
--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -1104,6 +1104,9 @@ bool GameObject::ActivateToQuest(Player* pTarget) const
         {
             if (pTarget->GetQuestStatus(GetGOInfo()->chest.questId) == QUEST_STATUS_INCOMPLETE)
                 return true;
+
+            if (LootTemplates_Gameobject.HaveQuestLootForPlayer(GetGOInfo()->GetLootId(), pTarget))
+                return true;
             break;
         }
         case GAMEOBJECT_TYPE_GENERIC:


### PR DESCRIPTION
## 🍰 Pullrequest
This was apparently removed in the rework of all that battleground stuff which leads Objects (related to Quests) to no longer being lootable. ^^

[related commit](https://github.com/cmangos/mangos-wotlk/commit/047b43f63003006b453604b718555e194bb3dc8d#diff-ea9456fe07807485d5cd91e79c49dcfdL1109)

related issue: [#2287](https://github.com/cmangos/issues/issues/2287)

tested and works once again. :)
