### PR TITLE
Add stack rules for Wintergarde Invisibility Spells

### DIFF
--- a/sql/scriptdev2/scriptdev2.sql
+++ b/sql/scriptdev2/scriptdev2.sql
@@ -733,6 +733,7 @@ INSERT INTO scripted_event_id VALUES
 /* DRAGONBLIGHT */
 UPDATE creature_template SET ScriptName='npc_destructive_ward' WHERE entry=27430;
 UPDATE creature_template SET ScriptName='npc_crystalline_ice_giant' WHERE entry=26809;
+UPDATE gameobject_template SET ScriptName='go_scrying_orb' WHERE entry=189292;
 UPDATE gameobject_template SET ScriptName='go_portal_to_orgrimmar' WHERE entry=193948;
 UPDATE gameobject_template SET ScriptName='go_portal_to_undercity' WHERE entry=193955;
 

--- a/src/game/AI/ScriptDevAI/scripts/northrend/dragonblight.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/dragonblight.cpp
@@ -316,6 +316,19 @@ struct CorrosiveSpit : public SpellScript
     }
 };
 
+/*######
+## go_scrying_orb
+######*/
+
+struct go_scrying_orb : public GameObjectAI
+{
+    go_scrying_orb(GameObject* go) : GameObjectAI(go)
+    {
+        go->GetVisibilityData().SetInvisibilityMask(1, true);
+        go->GetVisibilityData().AddInvisibilityValue(1, 1000);
+    }
+};
+
 void AddSC_dragonblight()
 {
     Script* pNewScript = new Script;
@@ -335,4 +348,9 @@ void AddSC_dragonblight()
     RegisterSpellScript<DropOffVillager>("spell_drop_off_villager");
     RegisterAuraScript<ArmyOfTheDead>("spell_army_of_the_dead");
     RegisterSpellScript<CorrosiveSpit>("spell_corrosive_spit");
+
+    pNewScript = new Script;
+    pNewScript->Name = "go_scrying_orb";
+    pNewScript->GetGameObjectAI = &GetNewAIInstance<go_scrying_orb>;
+    pNewScript->RegisterSelf();
 }

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -1849,6 +1849,11 @@ bool SpellMgr::IsNoStackSpellDueToSpell(SpellEntry const* spellInfo_1, SpellEntr
                             (spellInfo_2->Id == 47418 && spellInfo_1->Id == 47396))
                         return false;
 
+                    // See Wintergarde Invisibility Type B and See Wintergarde Invisibility Type C
+                    if ((spellInfo_1->Id == 48358 && spellInfo_2->Id == 48797) ||
+                        (spellInfo_2->Id == 48797 && spellInfo_1->Id == 48358))
+                        return false;
+
                     // Cool Down (See PeriodicAuraTick())
                     if ((spellInfo_1->Id == 52441 && spellInfo_2->Id == 52443) ||
                             (spellInfo_2->Id == 52441 && spellInfo_1->Id == 52443))


### PR DESCRIPTION
See Wintergarde Invisibility Type B - allow to see npcs
See Wintergarde Invisibility Type C - allow to see gobject
Req. for q.12282 'Imprints on the Past'
