### PR TITLE
Convert item_instance blob with SQL query 14025_00_characters_item_instance_data_drop.sql

### DIFF
--- a/sql/updates/characters/14025_00_characters_item_instance_data_drop.sql
+++ b/sql/updates/characters/14025_00_characters_item_instance_data_drop.sql
@@ -8,8 +8,6 @@ CREATE TABLE item_instance_backup_pre_data_field_drop AS (SELECT * FROM item_ins
 
 TRUNCATE `item_instance`;
 
-ALTER TABLE `item_instance` DROP `data`;
-
 ALTER TABLE `item_instance`
  ADD `itemEntry` MEDIUMINT(8) UNSIGNED NOT NULL DEFAULT '0' AFTER `owner_guid`,
  ADD `creatorGuid` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `itemEntry`,
@@ -22,3 +20,41 @@ ALTER TABLE `item_instance`
  ADD `randomPropertyId` SMALLINT(5) NOT NULL DEFAULT '0' AFTER `enchantments`,
  ADD `durability` INT(5) UNSIGNED NOT NULL DEFAULT '0' AFTER `randomPropertyId`,
  ADD `playedTime` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `durability`;
+ 
+ -- Temporarily change delimiter to prevent SQL syntax errors
+DELIMITER ||
+
+-- Function to convert ints from unsigned to signed
+DROP FUNCTION IF EXISTS `uint32toint32`||
+CREATE FUNCTION `uint32toint32`(input INT(10) UNSIGNED) RETURNS BIGINT(20) SIGNED DETERMINISTIC
+BEGIN
+  RETURN CAST((input<<32) AS SIGNED)/(1<<32);
+END||
+
+-- Restore original delimiter
+DELIMITER ;
+
+-- Move data to new fields
+UPDATE `item_instance` SET
+`itemEntry` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',3))+2, length(SUBSTRING_INDEX(`data`,' ',3+1))-length(SUBSTRING_INDEX(data,' ',3))-1),
+`creatorGuid` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',10))+2, length(SUBSTRING_INDEX(`data`,' ',10+1))-length(SUBSTRING_INDEX(data,' ',10))-1),
+`giftCreatorGuid` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',12))+2, length(SUBSTRING_INDEX(`data`,' ',12+1))-length(SUBSTRING_INDEX(data,' ',12))-1),
+`count` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',14))+2, length(SUBSTRING_INDEX(`data`,' ',14+1))-length(SUBSTRING_INDEX(data,' ',14))-1),
+`duration` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',15))+2, length(SUBSTRING_INDEX(`data`,' ',15+1))-length(SUBSTRING_INDEX(data,' ',15))-1),
+`charges` = CONCAT_WS(' ',
+ uint32toint32(SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',16))+2, length(SUBSTRING_INDEX(`data`,' ',16+1))-length(SUBSTRING_INDEX(data,' ',16))-1)),
+ uint32toint32(SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',17))+2, length(SUBSTRING_INDEX(`data`,' ',17+1))-length(SUBSTRING_INDEX(data,' ',17))-1)),
+ uint32toint32(SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',18))+2, length(SUBSTRING_INDEX(`data`,' ',18+1))-length(SUBSTRING_INDEX(data,' ',18))-1)),
+ uint32toint32(SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',19))+2, length(SUBSTRING_INDEX(`data`,' ',19+1))-length(SUBSTRING_INDEX(data,' ',19))-1)),
+ uint32toint32(SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',20))+2, length(SUBSTRING_INDEX(`data`,' ',20+1))-length(SUBSTRING_INDEX(data,' ',20))-1)) ),
+`flags` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',21))+2, length(SUBSTRING_INDEX(`data`,' ',21+1))-length(SUBSTRING_INDEX(data,' ',21))-1),
+`enchantments` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',22))+2, length(SUBSTRING_INDEX(`data`,' ',57+1))-length(SUBSTRING_INDEX(data,' ',22))-1),
+`randomPropertyId` = uint32toint32(SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',59))+2, length(SUBSTRING_INDEX(`data`,' ',59+1))-length(SUBSTRING_INDEX(data,' ',59))-1)),
+`durability` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',60))+2, length(SUBSTRING_INDEX(`data`,' ',60+1))-length(SUBSTRING_INDEX(data,' ',60))-1),
+`playedTime` = SUBSTRING(`data`, length(SUBSTRING_INDEX(`data`,' ',62))+2, length(SUBSTRING_INDEX(`data`,' ',62+1))-length(SUBSTRING_INDEX(data,' ',62))-1);
+
+-- Drop function
+DROP FUNCTION IF EXISTS `uint32toint32`;
+
+-- Drop old field
+ALTER TABLE `item_instance` DROP `data`;


### PR DESCRIPTION
Convert the blob to fields. 

It is based on https://github.com/eilwin/TrinityCore/blob/master/sql/gc/mangos_converter.sql

Not tested on WOTLK core. I just changed last SUBSTRING indexes from the TBC PR (taken from the GO script). For TLK, 'itemTextId' is replaced by 'playedTime'.

To do tests safely, comment the "ALTER TABLE..." line or, the best, copy the table and change the table name 'item_instance' in queries (and do backup !).