### PR TITLE
MySQL 8.0+ compatibility on FreeBSD

### DIFF
--- a/src/shared/Database/DatabaseMysql.h
+++ b/src/shared/Database/DatabaseMysql.h
@@ -27,6 +27,15 @@
 
 #include <mysql.h>
 
+// MySQL 8.0+ compatibility on FreeBSD
+#ifdef __FreeBSD__
+  #if !defined(MARIADB_BASE_VERSION) && !defined(MARIADB_VERSION_ID) && defined(MYSQL_VERSION_ID)
+    #if (MYSQL_VERSION_ID >= 80001)
+      typedef bool my_bool;
+    #endif
+  #endif
+#endif
+
 // MySQL prepared statement class
 class MySqlPreparedStatement : public SqlPreparedStatement
 {


### PR DESCRIPTION
MySQL 8.0+ compatibility on FreeBSD.
Fix build with MySql 8.0+ on FreeBSD system.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- Unavailable to build any cmangos src on UNIX LIKE with MySql 8.0
```
In file included from /opt/wow/mangos/src/shared/Database/DatabaseEnv.h:41:
/opt/wow/mangos/src/shared/Database/DatabaseMysql.h:59:75: error: unknown type name 'my_bool'
        static enum_field_types ToMySQLType(const SqlStmtFieldData& data, my_bool& bUnsigned);
```
### Issues
<!-- Which Issues does this fix, which are related?
-->
- fix build cmangos on FreeBSD with MySql 8.0+

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
-->
- try to build on freebsd12+mysql80-server

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
