### PR TITLE
AHBot fixes and balancing

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -193,13 +193,13 @@ void AuctionHouseBot::Update()
         }
 
         // remove items we've overridden (AddChance > 0) and add using given AddChance and stack size
-        for (auto itemData : m_itemData)
+        for (auto& itemData : m_itemData)
         {
             if (itemData.second.AddChance > 0) // replace normal loot sources with custom chance of adding item
                 itemMap[itemData.first] = urand(0, 99) < itemData.second.AddChance ? urand(itemData.second.MinAmount, itemData.second.MaxAmount) : 0;
         }
 
-        for (auto itemEntry : itemMap)
+        for (auto& itemEntry : itemMap)
         {
             ItemPrototype const* prototype = ObjectMgr::GetItemPrototype(itemEntry.first);
             if (!prototype || prototype->GetMaxStackSize() == 0)

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -30,7 +30,7 @@
 
 INSTANTIATE_SINGLETON_1(AuctionHouseBot);
 
-AuctionHouseBot::AuctionHouseBot() : m_configFileName(_AUCTIONHOUSEBOT_CONFIG), m_houseAction(-1), m_chanceSell(0), m_chanceBuy(0)
+AuctionHouseBot::AuctionHouseBot() : m_configFileName(_AUCTIONHOUSEBOT_CONFIG), m_houseAction(-1)
 {
 }
 
@@ -42,6 +42,9 @@ void AuctionHouseBot::Initialize()
 {
     if (!m_ahBotCfg.SetSource(m_configFileName))
     {
+        // set buy/sell chance to 0, this prevents Update() from accessing uninitialized variables
+        m_chanceBuy = 0;
+        m_chanceSell = 0;
         sLog.outString("AHBot is disabled. Unable to open configuration file(%s).", m_configFileName.c_str());
         return;
     }

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -30,7 +30,7 @@
 
 INSTANTIATE_SINGLETON_1(AuctionHouseBot);
 
-AuctionHouseBot::AuctionHouseBot() : m_configFileName(_AUCTIONHOUSEBOT_CONFIG), m_houseAction(-1)
+AuctionHouseBot::AuctionHouseBot() : m_configFileName(_AUCTIONHOUSEBOT_CONFIG), m_houseAction(-1), m_chanceSell(0), m_chanceBuy(0)
 {
 }
 

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -210,9 +210,9 @@ void AuctionHouseBot::Update()
             if (iterator == m_itemData.end() || iterator->second.AddChance == 0)
             {
                 if (prototype->Bonding == BIND_WHEN_PICKED_UP || prototype->Bonding == BIND_QUEST_ITEM)
-                    continue; // nor BoP and quest items
+                    continue; // no BoP and quest items
                 if (prototype->Flags & ITEM_FLAG_HAS_LOOT)
-                    continue; // no items containing loot
+                    continue; // nor items containing loot
                 if (m_itemValue[prototype->Quality][prototype->Class] == 0)
                     continue; // item class is filtered out
             }
@@ -241,6 +241,8 @@ void AuctionHouseBot::Update()
             if (auction->owner == 0 && auction->bid == 0)
                 continue; // ignore bidding/buying auctions that were created by ahbot and not bidded on by player
             Item* item = sAuctionMgr.GetAItem(auction->itemGuidLow);
+            if (!item)
+                continue; // shouldn't happen, but apparently it does(?)
             auto prototype = item->GetProto();
             if (!prototype)
                 continue; // shouldn't happen

--- a/src/game/AuctionHouseBot/ahbot.conf.dist.in
+++ b/src/game/AuctionHouseBot/ahbot.conf.dist.in
@@ -3,7 +3,7 @@
 ################################################
 
 [AhbotConf]
-ConfVersion=2020010101
+ConfVersion=2021011201
 
 ###################################################################################################################
 # Probability in percent of AHBot selling/buying items at the AH.
@@ -48,10 +48,10 @@ AuctionHouseBot.Loot.Creature.Elite     =    30, 34,  1,  2
 AuctionHouseBot.Loot.Creature.RareElite =  -10,  2,  1,  1
 AuctionHouseBot.Loot.Creature.WorldBoss =  -20,  1,  1,  1
 
-AuctionHouseBot.Loot.Disenchant =    0,  2,  1,  1
-AuctionHouseBot.Loot.Fishing    =    0,  1, 30, 40
+AuctionHouseBot.Loot.Disenchant =   10, 12,  1,  1
+AuctionHouseBot.Loot.Fishing    =    3,  5, 30, 40
 AuctionHouseBot.Loot.Gameobject =   13, 16,  7, 11
-AuctionHouseBot.Loot.Skinning   =   -4,  1, 50, 50
+AuctionHouseBot.Loot.Skinning   =    3,  5, 50, 50
 
 ###################################################################################################################
 # Profession craftable items added to AH.
@@ -62,9 +62,12 @@ AuctionHouseBot.Loot.Skinning   =   -4,  1, 50, 50
 #
 # This setting is slightly different from the Loot.* settings, the 4 values are:
 #   <min items>, <max items>, <min percent stack size>, <max percent stack size>
-# Default values are: 30, 50, 100, 100
+# A stack will always contain at least 1 item, hence setting <min/max percent stack size> to 0 will not prevent
+# craftable items from being added to the Auction House.
+# To prevent craftable items from being added to the Auction House set <min items> and <max items> to 0.
+# Default values are: 80, 90, 0, 50
 ###################################################################################################################
-AuctionHouseBot.Items.Profession = 30, 50, 100, 100
+AuctionHouseBot.Items.Profession = 80, 90, 0, 50
 
 ###################################################################################################################
 # Item value
@@ -93,15 +96,16 @@ AuctionHouseBot.Items.Profession = 30, 50, 100, 100
 # 13: Key
 # 14: Permanent (obsolete, value ignored)
 # 15: Misc
+# 16: Glyph
 ###################################################################################################################
-# Class                             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15
-AuctionHouseBot.Value.Poor      =   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
-AuctionHouseBot.Value.Normal    = 100,100,  0,  0,  0,100,100,100,  0,100,  0,100,100,100,  0,100
-AuctionHouseBot.Value.Uncommon  = 200,200,200,  0,200,200,200,200,  0,200,  0,200,200,200,  0,200
-AuctionHouseBot.Value.Rare      = 400,400,400,  0,400,400,400,400,  0,400,  0,400,400,400,  0,400
-AuctionHouseBot.Value.Epic      = 800,800,800,  0,800,800,800,800,  0,800,  0,800,800,800,  0,800
-AuctionHouseBot.Value.Legendary =   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
-AuctionHouseBot.Value.Artifact  =   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
+# Class                             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16
+AuctionHouseBot.Value.Poor      =   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
+AuctionHouseBot.Value.Normal    = 100,100,  0,100,  0,100,100,100,  0,100,  0,100,100,100,  0,100,100
+AuctionHouseBot.Value.Uncommon  = 200,200,200,200,200,200,200,200,  0,200,  0,200,200,200,  0,200,200
+AuctionHouseBot.Value.Rare      = 400,400,400,400,400,400,400,400,  0,400,  0,400,400,400,  0,400,400
+AuctionHouseBot.Value.Epic      = 800,800,800,800,800,800,800,800,  0,800,  0,800,800,800,  0,800,800
+AuctionHouseBot.Value.Legendary =   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
+AuctionHouseBot.Value.Artifact  =   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
 
 ###################################################################################################################
 # Vendor item value override
@@ -149,6 +153,6 @@ AuctionHouseBot.Time.Max = 24
 # A value of 90 means that the AHBot will at most pay 9 gold for an item at the AH that the bot itself would put
 # up for auction at 10 gold (± AuctionHouseBot.Value.Variance).
 # Setting this lower than 100 also means that the AHBot is less likely to outbid players.
-# Value must be in range 0-200. Default value is 90.
+# Value must be in range 0-200. Default value is 80.
 ###################################################################################################################
-AuctionHouseBot.Buy.Value = 90
+AuctionHouseBot.Buy.Value = 80


### PR DESCRIPTION
## 🍰 Pullrequest
These changes fixes a crash I can't really explain why happens in the first place (did not occur in Classic core), and it improves item balance as well as adding some items that were missing for WotLK core. It also prevents certain items (notably arrows/bullets) from being valued extremely high, which made engineering unreasonably lucrative .
Changes should be compatible with Classic core and presumably (not tested) TBC core as well.

As for the crash, I captured the following stack trace (not a debug-build):
```
Thread 12 "mangosd" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fed2d481700 (LWP 1165)]
0x0000557a4f2c32f5 in Item::GetProto() const ()
#0  0x0000557a4f2c32f5 in Item::GetProto() const ()
#1  0x0000557a4f1fdb08 in AuctionHouseBot::Update() ()
#2  0x0000557a4f65a1b2 in World::Update(unsigned int) ()
#3  0x0000557a4f1cdd3f in WorldRunnable::run() ()
#4  0x00007fed31287d84 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007fed31d88609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#6  0x00007fed30f75293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
There's only one call to `Item::GetProto()` within `AuctionHouseBot::Update()` and there was no check for `nullptr` before invoking the method. I don't know how `Item* item = sAuctionMgr.GetAItem(auction->itemGuidLow);` could result in a `nullptr` when we're iterating `auctionHouse->GetAuctionsBounds()`, but in any case, the extra check seems to prevent crashes.

### Proof
- None

### Issues
- Might fix https://github.com/cmangos/issues/issues/2349

### How2Test
- None

### Todo / Checklist
- [X] None
