### PR TITLE
Spell: 17016 Radius corrected

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -20,6 +20,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (13278,'spell_gdr_channel'),
 (13493,'spell_gdr_periodic'),
 (16380,'spell_greater_invisibility_mob'),
+(17016,'spell_placing_beacon_torch'),
 (17244,'spell_anastari_possess'),
 (19832,'spell_possess_razorgore'),
 (19872,'spell_calm_dragonkin'),

--- a/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/western_plaguelands.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/eastern_kingdoms/western_plaguelands.cpp
@@ -31,6 +31,7 @@ EndContentData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "AI/ScriptDevAI/base/escort_ai.h"
+#include "Spells/Scripts/SpellScript.h"
 
 /*######
 ## npc_the_scourge_cauldron
@@ -1102,6 +1103,22 @@ UnitAI* GetAI_npc_tirion_fordring(Creature* creature)
     return new npc_tirion_fordringAI(creature);
 }
 
+/*######
+## spell_placing_beacon_torch
+######*/
+
+struct spell_placing_beacon_torch : public SpellScript
+{
+    void OnRadiusCalculate(Spell* /*spell*/, SpellEffectIndex effIdx, bool /*targetB*/, float& radius) const override
+    {
+        if (effIdx == EFFECT_INDEX_0)
+            radius = 0.f;
+        if (effIdx == EFFECT_INDEX_1)
+            radius = 10.f;
+    }
+};
+
+
 void AddSC_western_plaguelands()
 {
     Script* pNewScript = new Script;
@@ -1132,4 +1149,6 @@ void AddSC_western_plaguelands()
     pNewScript->Name = "npc_tirion_fordring";
     pNewScript->GetAI = &GetAI_npc_tirion_fordring;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<spell_placing_beacon_torch>("spell_placing_beacon_torch");
 }


### PR DESCRIPTION
Radius corrected for both effects
- eff0 must be 0
- eff1 set to 10
Will prevent charges wastege in case of summoned object out of source radius. (spellfocus)
