### PR TITLE
SD2: Script update for NPC Emilly

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/grizzly_hills.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/grizzly_hills.cpp
@@ -512,6 +512,8 @@ struct npc_emilyAI : public npc_escortAI
             case 28:
                 if (Creature* pFloppy = m_creature->GetMap()->GetCreature(m_floppyGuid))
                     pFloppy->ForcedDespawn();
+                SetEscortPaused(true);
+                m_creature->ForcedDespawn(1000);
                 break;
         }
     }


### PR DESCRIPTION
she must despawn on quests complete instead of running back to spawn point
