### PR TITLE
Add playerbot setting for forced running

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -3977,7 +3977,7 @@ void PlayerbotAI::DoLoot()
 
     if (m_bot->GetDistance(wo) > CONTACT_DISTANCE + wo->GetObjectBoundingRadius())
     {
-        m_bot->GetMotionMaster()->MovePoint(wo->GetMapId(), wo->GetPositionX(), wo->GetPositionY(), wo->GetPositionZ());
+        m_bot->GetMotionMaster()->MovePoint(wo->GetMapId(), wo->GetPositionX(), wo->GetPositionY(), wo->GetPositionZ(), m_mgr.m_confCollectRun ? FORCED_MOVEMENT_RUN : FORCED_MOVEMENT_NONE);
         // give time to move to point before trying again
         SetIgnoreUpdateTime(1);
         if (m_debugWhisper)
@@ -7569,7 +7569,7 @@ void PlayerbotAI::findNearbyCreature()
             {
                 float x, y, z;
                 wo->GetContactPoint(m_bot, x, y, z, wo->GetObjectBoundingRadius());
-                m_bot->GetMotionMaster()->MovePoint(wo->GetMapId(), x, y, z, FORCED_MOVEMENT_NONE, false);
+                m_bot->GetMotionMaster()->MovePoint(wo->GetMapId(), x, y, z, m_mgr.m_confCollectRun ? FORCED_MOVEMENT_RUN : FORCED_MOVEMENT_NONE, false);
                 // give time to move to point before trying again
                 SetIgnoreUpdateTime(1);
             }
@@ -10609,7 +10609,7 @@ void PlayerbotAI::_HandleCommandFind(std::string& text, Player& fromPlayer)
     }
 
     SetMovementOrder(MOVEMENT_STAY);
-    m_bot->GetMotionMaster()->MovePoint(go->GetMapId(), go->GetPositionX(), go->GetPositionY(), go->GetPositionZ());
+    m_bot->GetMotionMaster()->MovePoint(go->GetMapId(), go->GetPositionX(), go->GetPositionY(), go->GetPositionZ(), m_mgr.m_confCollectRun ? FORCED_MOVEMENT_RUN : FORCED_MOVEMENT_NONE);
     m_lootTargets.clear();
     m_lootCurrent = ObjectGuid();
 }

--- a/src/game/PlayerBot/Base/PlayerbotMgr.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotMgr.cpp
@@ -64,6 +64,7 @@ PlayerbotMgr::PlayerbotMgr(Player* const master) : m_master(master)
     m_confCollectSkin = botConfig.GetBoolDefault("PlayerbotAI.Collect.Skin", true);
     m_confCollectObjects = botConfig.GetBoolDefault("PlayerbotAI.Collect.Objects", true);
     m_confCollectDistanceMax = botConfig.GetIntDefault("PlayerbotAI.Collect.DistanceMax", 50);
+    m_confCollectRun = botConfig.GetBoolDefault("PlayerbotAI.Collect.Run", false);
     gConfigSellLevelDiff = botConfig.GetIntDefault("PlayerbotAI.SellAll.LevelDiff", 10);
     if (m_confCollectDistanceMax > 100)
     {

--- a/src/game/PlayerBot/Base/PlayerbotMgr.h
+++ b/src/game/PlayerBot/Base/PlayerbotMgr.h
@@ -83,6 +83,7 @@ class PlayerbotMgr
         bool m_confCollectLoot;
         bool m_confCollectSkin;
         bool m_confCollectObjects;
+        bool m_confCollectRun;
         uint32 m_confCollectDistance;
         uint32 m_confCollectDistanceMax;
 

--- a/src/game/PlayerBot/playerbot.conf.dist.in
+++ b/src/game/PlayerBot/playerbot.conf.dist.in
@@ -65,6 +65,11 @@ ConfVersion=2018101401
 #        Default distance that bots will search within for collection.
 #        Default: 25 (cannot be more than DistanceMax)
 #
+#    PlayerbotAI.Collect.Run
+#        Enable running to collect objects
+#        Default: 0 - off
+#                 1 - on
+#
 #    PlayerbotAI.SellGarbage
 #        Allow bots to automatically sell all [GRAY|POOR] quality items as the player activates vendor
 #        Default: 0 - off
@@ -92,5 +97,6 @@ PlayerbotAI.Collect.Skin = 1
 PlayerbotAI.Collect.Objects = 1
 PlayerbotAI.Collect.DistanceMax = 50
 PlayerbotAI.Collect.Distance = 25
+PlayerbotAI.Collect.Run = 0
 PlayerbotAI.SellGarbage = 0
 PlayerbotAI.SellAll.LevelDiff = 10


### PR DESCRIPTION
## 🍰 Pullrequest
Currently the bots walk to loot/collect objects or talk to npcs. I added an config option that forced them to run to it instead.

### Proof
- None

### Issues
- None

### How2Test
- Add a bot
- Have them loot a corpse or object
