### PR TITLE
Fixed disenchantment rolls not giving out items

### DIFF
--- a/src/game/Loot/LootMgr.cpp
+++ b/src/game/Loot/LootMgr.cpp
@@ -862,11 +862,10 @@ void GroupLootRoll::Finish(RollVoteMap::const_iterator& winnerItr)
             {
                 m_lootItem->isReleased = true;
                 m_lootItem->allowedGuid.clear();
-                ItemPrototype const* pProto = sObjectMgr.GetItemPrototype(m_lootItem->itemId);
-                ItemPosCountVec dest;
-                InventoryResult msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, m_lootItem->itemId, m_lootItem->count);
-                Loot loot;
-                loot.FillLoot(pProto->DisenchantID, LootTemplates_Disenchant, player, true);
+                
+                ItemPrototype const* pProto = sObjectMgr.GetItemPrototype(m_lootItem->itemId);                   
+                Loot loot(player, pProto->DisenchantID, LOOT_DISENCHANTING);
+
                 if (!loot.AutoStore(player, true))
                 {
                     LootItemList itemList;
@@ -2007,6 +2006,10 @@ Loot::Loot(Player* player, uint32 id, LootType type) :
             FillLoot(id, LootTemplates_Spell, player, true, true);
             m_clientLootType = CLIENT_LOOT_PICKPOCKETING;
             break;
+        case LOOT_DISENCHANTING:
+            FillLoot(id, LootTemplates_Disenchant, player, true, true);
+            m_clientLootType = CLIENT_LOOT_PICKPOCKETING;
+            break;            
         default:
             sLog.outError("Loot::Loot> invalid loot type passed to loot constructor.");
             break;


### PR DESCRIPTION
## 🍰 Pullrequest
I created an additional disenchanting case for one of the Loot() constructors. This allows the loot object to have it's owner set when creating the temporary loot object for disenchanting rolls.

### Proof
- None

### Issues
- Fixes #2463 https://github.com/cmangos/issues/issues/2463

### How2Test
- Be in a group with an enchanter
- Roll disenchant on the item and win the roll