### PR TITLE
Fix periodic eating emote

### DIFF
--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -2479,6 +2479,9 @@ class Player : public Unit
         void ClearQueuedSpell();
         void CastQueuedSpell(SpellCastTargets& targets);
     protected:
+
+        uint32 m_foodEmoteTimerCount;
+
         /*********************************************************/
         /***               BATTLEGROUND SYSTEM                 ***/
         /*********************************************************/

--- a/src/game/Spells/SpellDefines.h
+++ b/src/game/Spells/SpellDefines.h
@@ -42,4 +42,10 @@ enum TriggerCastFlags : uint32
     TRIGGERED_FULL_MASK                         = 0xFFFFFFFF
 };
 
+enum SpellVisualKit
+{
+    SPELL_VISUAL_KIT_FOOD           = 406,
+    SPELL_VISUAL_KIT_DRINK          = 438
+};
+
 #endif


### PR DESCRIPTION
Update 09/12/21 - This PR should be abandoned and replaced with changes contained in:
https://github.com/TrinityCore/TrinityCore/pull/25822

Original author: @Ovahlord

https://github.com/TrinityCore/TrinityCore/pull/21280

No clue if this code is actually valid as I didn't review any sniffs to confirm, but it does appear to "fix" the missing food eating animation.

The same problem exists currently on all three CMaNGOS cores (Classic, TBC, and WotLK) - Drinking causes the visual emote, but eating doesn't?
The character sits with the food in hand, but never raises it to their mouth:
![image](https://user-images.githubusercontent.com/16798471/126912040-57ad8dbe-70dd-42db-9f25-d05c6aee3424.png)

Reference Issues:
https://github.com/cmangos/issues/issues/2253
https://github.com/TrinityCore/TrinityCore/issues/12567