### PR TITLE
Keep Units visible default unless flag is set

### DIFF
--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -2523,7 +2523,7 @@ class Unit : public WorldObject
         void DespawnSummonsOnDeath();
 
         // false if only visible to set and not equal
-        virtual bool IsOnlyVisibleTo(ObjectGuid guid) const { return false; }
+        virtual bool IsOnlyVisibleTo(ObjectGuid guid) const { return true; }
 
         virtual bool IsNoMountedFollow() const { return false; }
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Without a WotLK client or server I cannot be 100% sure, but this virtual function may be responsible for players currently being invisible to other players or to hostile NPCs (until they have engaged said hostile NPCs in combat on their own)

See link for reasoning and surrounding commit: https://github.com/cmangos/mangos-wotlk/commit/ffe9d0ff63a6189825ab021aded56a44c40eb9f6#r64471224

### Proof
<!-- Link resources as proof -->
- Per request

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Discord Support Request

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Log in with 2 separate accounts in the same location and check visibility of the other account

