### PR TITLE
Fix size of TargetState in SMSG_ATTACKERSTATEUPDATE packet

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -7071,7 +7071,7 @@ void Unit::SendAttackStateUpdate(CalcDamageInfo* calcDamageInfo) const
     // Subdamage count:
     uint32 lines = m_weaponDamageInfo.weapon[calcDamageInfo->attackType].lines;
 
-    WorldPacket data(SMSG_ATTACKERSTATEUPDATE, (4 + 8 + 8 + 4 + 4) + 1 + (lines * (4 + 4 + 4)) + (4 + 4 + 4));
+    WorldPacket data(SMSG_ATTACKERSTATEUPDATE, (4 + 8 + 8 + 4 + 4) + 1 + (lines * (4 + 4 + 4)) + (1 + 4 + 4));
 
     data << uint32(calcDamageInfo->HitInfo);
     data << calcDamageInfo->attacker->GetPackGUID();
@@ -7105,7 +7105,7 @@ void Unit::SendAttackStateUpdate(CalcDamageInfo* calcDamageInfo) const
             data << int32(calcDamageInfo->subDamage[i].resist);
     }
 
-    data << uint32(calcDamageInfo->TargetState);
+    data << uint8(calcDamageInfo->TargetState);
     data << uint32(0);                                      // unknown, usually seen with -1, 0 and 1000
     data << uint32(0);                                      // spell id, seen with heroic strike and disarm as examples.
     // HITINFO_NOACTION normally set if spell

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -718,7 +718,7 @@ struct CalcDamageInfo
     SubDamageInfo subDamage[MAX_ITEM_PROTO_DAMAGES];
     uint32 blocked_amount;
     uint32 HitInfo;
-    uint32 TargetState;
+    uint8  TargetState;
     // Helper
     WeaponAttackType attackType; //
     uint32 procAttacker;


### PR DESCRIPTION
## 🍰 Pullrequest
In WotLK, the field TargetState in SMSG_ATTACKERSTATEUPDATE is one byte long.

Sending it to client as 4-byte long will cause a bug in the combat log: whenever someone blocks an attack, the blocked amount overflows.

Before:
![WoWScrnShot_021322_165108](https://user-images.githubusercontent.com/99603810/153762189-111aaf5d-c9b0-4e54-b37c-847618d992d9.jpg)

After:
![WoWScrnShot_021322_165906](https://user-images.githubusercontent.com/99603810/153762197-715e786d-6fcd-4069-ae10-7363ef4e187e.jpg)


### Proof
<!-- Link resources as proof -->
- [WowPacketParser](https://github.com/TrinityCore/WowPacketParser/commit/5e753e400839dc12409a61580694ee87f64adbf2#diff-5f9cf07fe0e791d35ad0d19bb9f55b4211d424f5e218f7e65968ddbf56e708cfR73) treats is as byte.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Using a character that can block and equipping a shield, get attacked by a mob until you block (easier if you use a Warrior with Shield Block for 100% block chance).
