### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,9 @@ env:
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-10.15
@@ -33,6 +36,8 @@ jobs:
         run: cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}}
 
   notify:
+    permissions:
+      contents: none
     name: Discord Notification
     runs-on: ubuntu-20.04
     needs: # make sure the notification is sent AFTER the jobs you want included have completed

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -82,6 +82,8 @@ jobs:
         run: cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}}
 
   notify:
+    permissions:
+      contents: none
     name: Discord Notification
     runs-on: ubuntu-20.04
     needs: # make sure the notification is sent AFTER the jobs you want included have completed

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -92,6 +92,8 @@ jobs:
           path: "bin/${{env.ARCHIVE_FILENAME}}"
 
   upload:
+    permissions:
+      contents: write  # for marvinpinto/action-automatic-releases to generate pre-release
     runs-on: windows-2019
     needs: build
     steps:
@@ -135,6 +137,8 @@ jobs:
           files: all_snapshots
 
   notify:
+    permissions:
+      contents: none
     name: Discord Notification
     runs-on: ubuntu-20.04
     needs: # make sure the notification is sent AFTER the jobs you want included have completed

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,6 +74,8 @@ jobs:
           path: "bin/${{env.ARCHIVE_FILENAME}}"
 
   notify:
+    permissions:
+      contents: none
     name: Discord Notification
     runs-on: ubuntu-20.04
     needs: # make sure the notification is sent AFTER the jobs you want included have completed


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
