### PR TITLE
fix death pact targeting returning early error

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -5605,7 +5605,8 @@ SpellCastResult Spell::CheckCast(bool strict)
                 }
             }
 
-            if ((m_targets.m_targetMask == TARGET_FLAG_SELF || m_trueCaster == target) && m_spellInfo->HasAttribute(SPELL_ATTR_EX_CANT_TARGET_SELF))
+            if ((m_targets.m_targetMask == TARGET_FLAG_SELF || m_trueCaster == target) && m_spellInfo->HasAttribute(SPELL_ATTR_EX_CANT_TARGET_SELF) 
+                && m_spellInfo->Id != 48743)        // targeting is handled later
             {
                 if (IsOnlySelfTargeting(m_spellInfo))
                     sLog.outCustomLog("Spell ID %u cast at self explicitly even though it has SPELL_ATTR_EX_CANT_TARGET_SELF", m_spellInfo->Id);


### PR DESCRIPTION
fix https://github.com/cmangos/issues/issues/2959

not sure it's the best way to do this tho, it's stopping the spell here because of SPELL_EFFECT_DUMMY having TARGET_UNIT_CASTER as implicitTargetA, so skiping this using spell Id works fine, but might be a bit too brutal ?