### PR TITLE
Fix compile errors on PlayerBot

### DIFF
--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -177,7 +177,7 @@ bool PlayerbotAI::CanReachWithSpellAttack(Unit* target)
             continue;
 
         // ignore non-ranged spells
-        if (!spellInfo->HasAttribute(SPELL_ATTR_RANGED))
+        if (!spellInfo->HasAttribute(SPELL_ATTR_USES_RANGED_SLOT))
             continue;
 
         float maxrange = itr->second;
@@ -4342,7 +4342,7 @@ bool PlayerbotAI::IsRegenerating()
         if (spell->Category == 59 || spell->Category == 11)
             return true;
         // Specific drinking / eating after patch 2.0.1, especially conjured goods
-        if(spell->HasAttribute(SPELL_ATTR_CASTABLE_WHILE_SITTING))
+        if(spell->HasAttribute(SPELL_ATTR_ALLOW_WHILE_SITTING))
         {
             for (uint32 i = EFFECT_INDEX_0; i < MAX_EFFECT_INDEX; ++i)
             {


### PR DESCRIPTION
Fixes compilation errors when building CMangos-Wotlk with Playerbot enabled, due to the recent refactoring of the spell attributes enum.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
