### PR TITLE
Sapphiron ScriptDev2 Fix

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/naxxramas/boss_sapphiron.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/naxxramas/boss_sapphiron.cpp
@@ -45,7 +45,7 @@ enum
 
     // Ground phase spells
     SPELL_CLEAVE                = 19983,
-    SPELL_TAIL_SWEEP            = 15847,
+    SPELL_TAIL_SWEEP            = 55697,
     SPELL_TAIL_SWEEP_H          = 55696,
     SPELL_LIFE_DRAIN            = 28542,
     SPELL_LIFE_DRAIN_H          = 55665,

--- a/src/game/AI/ScriptDevAI/scripts/northrend/naxxramas/boss_sapphiron.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/naxxramas/boss_sapphiron.cpp
@@ -16,339 +16,398 @@
 
 /* ScriptData
 SDName: Boss_Sapphiron
-SD%Complete: 80
-SDComment: Some spells need core implementation
+SD%Complete: 100
+SDComment:
 SDCategory: Naxxramas
 EndScriptData */
 
-/* Additional comments:
- * Bugged spells:   28560 (needs maxTarget = 1, Summon of 16474 implementation, TODO, 30s duration)
- *                  28526 (needs ScriptEffect to cast 28522 onto random target)
- *
- * Achievement-criteria check needs implementation
- *
- * Frost-Breath ability: the dummy spell 30101 is self cast, so it won't take the needed delay of ~7s until it reaches its target
- *                       As Sapphiron is displayed visually in hight (hovering), and the spell is cast with target=self-location
- *                       which is still on the ground, the client shows a nice slow falling of the visual animation
- *                       Insisting on using the Dummy-Effect to cast the breath-dmg spells, would require, to relocate Sapphi internally,
- *                       and to hack the targeting to be "on the ground" - Hence the prefered way as it is now!
- */
-
+#include "AI/BaseAI/UnitAI.h"
+#include "AI/ScriptDevAI/base/CombatAI.h"
 #include "AI/ScriptDevAI/include/sc_common.h"
+#include "AI/ScriptDevAI/include/sc_grid_searchers.h"
+#include "Entities/ObjectGuid.h"
+#include "Entities/Player.h"
+#include "Entities/Unit.h"
+#include "Globals/SharedDefines.h"
+#include "MotionGenerators/MotionMaster.h"
+#include "Server/DBCEnums.h"
 #include "naxxramas.h"
 
 enum
 {
     EMOTE_BREATH                = -1533082,
     EMOTE_GENERIC_ENRAGED       = -1000003,
-    EMOTE_FLY                   = -1533022,
-    EMOTE_GROUND                = -1533083,
 
-    SPELL_CLEAVE                = 19983,
-    SPELL_TAIL_SWEEP            = 55697,
-    SPELL_TAIL_SWEEP_H          = 55696,
-    SPELL_ICEBOLT               = 28526,
-    SPELL_FROST_BREATH_DUMMY    = 30101,
-    SPELL_FROST_BREATH_A        = 28524,
-    SPELL_FROST_BREATH_B        = 29318,
-    SPELL_FROST_AURA            = 28531,
+    // All phases spells
+    SPELL_FROST_AURA            = 71387,            // Periodically triggers 28531
     SPELL_FROST_AURA_H          = 55799,
+    SPELL_BESERK                = 26662,
+
+    // Ground phase spells
+    SPELL_CLEAVE                = 19983,
+    SPELL_TAIL_SWEEP            = 15847,
+    SPELL_TAIL_SWEEP_H          = 55696,
     SPELL_LIFE_DRAIN            = 28542,
     SPELL_LIFE_DRAIN_H          = 55665,
+    SPELL_SUMMON_BLIZZARD_INIT  = 28560,
+    SPELL_SUMMON_BLIZZARD       = 28561,
+
+    // Air phase spells
+    SPELL_DRAGON_HOVER          = 18430,
+    SPELL_ICEBOLT_INIT          = 28526,            // Triggers spell 28522 (Icebolt)
+    SPELL_ICEBOLT               = 28522,
+    SPELL_ICEBOLT_IMMUNITY      = 31800,
+    SPELL_ICEBLOCK_SUMMON       = 28535,
+    SPELL_FROST_BREATH_DUMMY    = 30101,
+    SPELL_FROST_BREATH          = 28524,            // Triggers spells 29318 (Frost Breath) and 30132 (Despawn Ice Block)
+    SPELL_DESPAWN_ICEBLOCK_GO   = 28523,
+    SPELL_SUMMON_WING_BUFFET    = 29329,
+    SPELL_DESPAWN_WING_BUFFET   = 29330,            // Triggers spell 29336 (Despawn Buffet)
+    //SPELL_WING_BUFFET           = 29328,
+    SPELL_DESPAWN_BUFFET_EFFECT = 29336,
     SPELL_CHILL                 = 28547,
     SPELL_CHILL_H               = 55699,
-    SPELL_SUMMON_BLIZZARD       = 28560,
-    SPELL_BESERK                = 26662,
     SPELL_ACHIEVEMENT_CHECK     = 60539,                    // unused
 
-    NPC_YOU_KNOW_WHO            = 16474,
+    NPC_BLIZZARD                = 16474,
 };
 
 static const float aLiftOffPosition[3] = {3522.386f, -5236.784f, 137.709f};
 
-enum Phases
+enum SapphironPhases
 {
     PHASE_GROUND        = 1,
     PHASE_LIFT_OFF      = 2,
-    PHASE_AIR_BOLTS     = 3,
-    PHASE_AIR_BREATH    = 4,
-    PHASE_LANDING       = 5,
 };
 
-struct boss_sapphironAI : public ScriptedAI
+enum SapphironActions
 {
-    boss_sapphironAI(Creature* pCreature) : ScriptedAI(pCreature)
+    SAPPHIRON_CLEAVE,
+    SAPPHIRON_TAIL_SWEEP,
+    SAPPHIRON_ICEBOLT,
+    SAPPHIRON_FROST_BREATH,
+    SAPPHIRON_LIFE_DRAIN,
+    SAPPHIRON_BLIZZARD,
+    SAPPHIRON_AIR_PHASE,
+    SAPPHIRON_LANDING_PHASE,
+    SAPPHIRON_GROUND_PHASE,
+    SAPPHIRON_BERSERK,
+    SAPPHIRON_ACTION_MAX,
+};
+
+std::unordered_set<ObjectGuid> localIceBlocks;
+
+static const uint32 groundPhaseActions[] = {SAPPHIRON_CLEAVE, SAPPHIRON_TAIL_SWEEP, SAPPHIRON_BLIZZARD, SAPPHIRON_LIFE_DRAIN};
+
+struct boss_sapphironAI : public CombatAI
+{
+    boss_sapphironAI(Creature* creature) : CombatAI(creature, SAPPHIRON_ACTION_MAX), m_instance(static_cast<ScriptedInstance*>(creature->GetInstanceData()))
     {
-        m_pInstance = (instance_naxxramas*)pCreature->GetInstanceData();
-        m_bIsRegularMode = pCreature->GetMap()->IsRegularDifficulty();
-        Reset();
+        AddCombatAction(SAPPHIRON_CLEAVE, 5u * IN_MILLISECONDS);
+        AddCombatAction(SAPPHIRON_TAIL_SWEEP, 12u * IN_MILLISECONDS);
+        AddCombatAction(SAPPHIRON_LIFE_DRAIN, 11u * IN_MILLISECONDS);
+        AddCombatAction(SAPPHIRON_BLIZZARD, 15u * IN_MILLISECONDS);
+        AddCombatAction(SAPPHIRON_FROST_BREATH, true);
+        AddCombatAction(SAPPHIRON_ICEBOLT, true);
+        AddCombatAction(SAPPHIRON_BERSERK, 15u * MINUTE * IN_MILLISECONDS);
+        AddCustomAction(SAPPHIRON_AIR_PHASE, true, [&]() { HandleAirPhase(); });
+        AddCustomAction(SAPPHIRON_LANDING_PHASE, true, [&]() { HandleLandingPhase(); });
+        AddCustomAction(SAPPHIRON_GROUND_PHASE, true, [&]() { HandleGroundPhase(); });
+        m_bIsRegularMode = creature->GetMap()->IsRegularDifficulty();
     }
 
-    instance_naxxramas* m_pInstance;
+    ScriptedInstance* m_instance;
+
+    uint32 m_iceboltCount;
+    SapphironPhases m_phase;
     bool m_bIsRegularMode;
-
-    uint32 m_uiCleaveTimer;
-    uint32 m_uiTailSweepTimer;
-    uint32 m_uiIceboltTimer;
-    uint32 m_uiFrostBreathTimer;
-    uint32 m_uiLifeDrainTimer;
-    uint32 m_uiBlizzardTimer;
-    uint32 m_uiFlyTimer;
-    uint32 m_uiBerserkTimer;
-    uint32 m_uiLandTimer;
-
-    uint32 m_uiIceboltCount;
-    Phases m_Phase;
+    uint32 m_blizzardCount;
 
     void Reset() override
     {
-        m_uiCleaveTimer = 5000;
-        m_uiTailSweepTimer = 12000;
-        m_uiFrostBreathTimer = 7000;
-        m_uiLifeDrainTimer = 11000;
-        m_uiBlizzardTimer = 15000;                          // "Once the encounter starts,based on your version of Naxx, this will be used x2 for normal and x6 on HC"
-        m_uiFlyTimer = 46000;
-        m_uiIceboltTimer = 5000;
-        m_uiLandTimer = 0;
-        m_uiBerserkTimer = 15 * MINUTE * IN_MILLISECONDS;
-        m_Phase = PHASE_GROUND;
-        m_uiIceboltCount = 0;
+        CombatAI:: Reset();
+
+        m_iceboltCount = 0;
+        m_blizzardCount = 0;
+        m_phase = PHASE_GROUND;
 
         SetCombatMovement(true);
-        m_creature->SetLevitate(false);
+        SetDeathPrevention(false);
+        SetMeleeEnabled(true);
+        m_creature->SetHover(false);
     }
 
-    void Aggro(Unit* /*pWho*/) override
+    uint32 GetSubsequentActionTimer(uint32 action)
     {
-        DoCastSpellIfCan(m_creature, m_bIsRegularMode ? SPELL_FROST_AURA : SPELL_FROST_AURA_H);
-
-        if (m_pInstance)
-            m_pInstance->SetData(TYPE_SAPPHIRON, IN_PROGRESS);
+        switch (action)
+        {
+            case SAPPHIRON_CLEAVE: return urand(5, 10) * IN_MILLISECONDS;
+            case SAPPHIRON_TAIL_SWEEP: return urand(7, 10) * IN_MILLISECONDS;
+            case SAPPHIRON_LIFE_DRAIN: return 24u * IN_MILLISECONDS;
+            case SAPPHIRON_BLIZZARD: return urand(10, 30) * IN_MILLISECONDS;
+            case SAPPHIRON_ICEBOLT: return 3u * IN_MILLISECONDS;
+            case SAPPHIRON_BERSERK: return 300u * IN_MILLISECONDS;
+            case SAPPHIRON_AIR_PHASE: return 46u * IN_MILLISECONDS;
+            default: return 0;
+        }
     }
 
-    void JustDied(Unit* /*pKiller*/) override
+    void Aggro(Unit* /*who*/) override
     {
-        if (m_pInstance)
-            m_pInstance->SetData(TYPE_SAPPHIRON, DONE);
+        DoCastSpellIfCan(m_creature, m_bIsRegularMode ? SPELL_FROST_AURA : SPELL_FROST_AURA_H, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
+
+        if (m_instance)
+            m_instance->SetData(TYPE_SAPPHIRON, IN_PROGRESS);
+
+        ResetTimer(SAPPHIRON_AIR_PHASE, GetSubsequentActionTimer(SAPPHIRON_AIR_PHASE));
+    }
+
+    void JustDied(Unit* /*killer*/) override
+    {
+        if (m_instance)
+            m_instance->SetData(TYPE_SAPPHIRON, DONE);
     }
 
     void JustReachedHome() override
     {
-        if (m_pInstance)
-            m_pInstance->SetData(TYPE_SAPPHIRON, FAIL);
+        if (m_instance)
+            m_instance->SetData(TYPE_SAPPHIRON, FAIL);
     }
 
-    void JustSummoned(Creature* pSummoned) override
+    void JustSummoned(Creature* summoned) override
     {
-        if (pSummoned->GetEntry() == NPC_YOU_KNOW_WHO)
+        if (summoned->GetEntry() == NPC_BLIZZARD)
         {
             if (Unit* pEnemy = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0))
-                pSummoned->AI()->AttackStart(pEnemy);
+                summoned->AI()->AttackStart(pEnemy);
         }
     }
 
-    void MovementInform(uint32 uiType, uint32 /*uiPointId*/) override
+    void MovementInform(uint32 type, uint32 /*pointId*/) override
     {
-        if (uiType == POINT_MOTION_TYPE && m_Phase == PHASE_LIFT_OFF)
+        if (type == POINT_MOTION_TYPE && m_phase == PHASE_LIFT_OFF)
         {
-            DoScriptText(EMOTE_FLY, m_creature);
+            // Summon the Wing Buffet NPC and cast the triggered aura to despawn it
+            if (DoCastSpellIfCan(m_creature, SPELL_SUMMON_WING_BUFFET) == CAST_OK)
+                DoCastSpellIfCan(m_creature, SPELL_DESPAWN_WING_BUFFET);
+
+            // Actual take off
             m_creature->HandleEmote(EMOTE_ONESHOT_LIFTOFF);
-            m_creature->SetLevitate(true);
-            m_Phase = PHASE_AIR_BOLTS;
-
-            m_uiFrostBreathTimer = 5000;
-            m_uiIceboltTimer = 5000;
-            m_uiIceboltCount = 0;
+            m_creature->SetHover(true);
+            m_creature->CastSpell(nullptr, SPELL_DRAGON_HOVER, TRIGGERED_OLD_TRIGGERED);
+            ResetCombatAction(SAPPHIRON_ICEBOLT, 8u * IN_MILLISECONDS);
         }
     }
 
-    void UpdateAI(const uint32 uiDiff) override
+    void HandleAirPhase()
     {
-        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
-            return;
-
-        switch (m_Phase)
+        if (m_creature->GetHealthPercent() > 10.f)
         {
-            case PHASE_GROUND:
-                if (m_uiCleaveTimer < uiDiff)
-                {
-                    if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_CLEAVE) == CAST_OK)
-                        m_uiCleaveTimer = urand(5000, 10000);
-                }
-                else
-                    m_uiCleaveTimer -= uiDiff;
-
-                if (m_uiTailSweepTimer < uiDiff)
-                {
-                    if (DoCastSpellIfCan(m_creature, m_bIsRegularMode ? SPELL_TAIL_SWEEP : SPELL_TAIL_SWEEP_H) == CAST_OK)
-                        m_uiTailSweepTimer = urand(7000, 10000);
-                }
-                else
-                    m_uiTailSweepTimer -= uiDiff;
-
-                if (m_uiLifeDrainTimer < uiDiff)
-                {
-                    if (DoCastSpellIfCan(m_creature, m_bIsRegularMode ? SPELL_LIFE_DRAIN : SPELL_LIFE_DRAIN_H) == CAST_OK)
-                        m_uiLifeDrainTimer = 23000;
-                }
-                else
-                    m_uiLifeDrainTimer -= uiDiff;
-
-                if (m_uiBlizzardTimer < uiDiff)
-                {
-                    if (DoCastSpellIfCan(m_creature, SPELL_SUMMON_BLIZZARD) == CAST_OK)
-                        m_uiBlizzardTimer = 20000;
-                }
-                else
-                    m_uiBlizzardTimer -= uiDiff;
-
-                if (m_creature->GetHealthPercent() > 10.0f)
-                {
-                    if (m_uiFlyTimer < uiDiff)
-                    {
-                        m_Phase = PHASE_LIFT_OFF;
-                        SetDeathPrevention(true);
-                        m_creature->InterruptNonMeleeSpells(false);
-                        SetCombatMovement(false);
-                        m_creature->GetMotionMaster()->Clear(false);
-                        m_creature->GetMotionMaster()->MovePoint(1, aLiftOffPosition[0], aLiftOffPosition[1], aLiftOffPosition[2]);
-                        // TODO This should clear the target, too
-
-                        return;
-                    }
-                    m_uiFlyTimer -= uiDiff;
-                }
-
-                // Only Phase in which we have melee attack!
-                DoMeleeAttackIfReady();
-                break;
-            case PHASE_LIFT_OFF:
-                break;
-            case PHASE_AIR_BOLTS:
-                // WOTLK Changed, originally was 5
-                if (m_uiIceboltCount == (uint32)(m_bIsRegularMode ? 2 : 3))
-                {
-                    if (m_uiFrostBreathTimer < uiDiff)
-                    {
-                        m_Phase = PHASE_AIR_BREATH;
-                        DoScriptText(EMOTE_BREATH, m_creature);
-                        DoCastSpellIfCan(m_creature, SPELL_FROST_BREATH_DUMMY);
-                        m_uiFrostBreathTimer = 7000;
-                    }
-                    else
-                        m_uiFrostBreathTimer -= uiDiff;
-                }
-                else
-                {
-                    if (m_uiIceboltTimer < uiDiff)
-                    {
-                        DoCastSpellIfCan(m_creature, SPELL_ICEBOLT);
-
-                        ++m_uiIceboltCount;
-                        m_uiIceboltTimer = 4000;
-                    }
-                    else
-                        m_uiIceboltTimer -= uiDiff;
-                }
-
-                break;
-            case PHASE_AIR_BREATH:
-                if (m_uiFrostBreathTimer)
-                {
-                    if (m_uiFrostBreathTimer <= uiDiff)
-                    {
-                        DoCastSpellIfCan(m_creature, SPELL_FROST_BREATH_A, CAST_TRIGGERED);
-                        DoCastSpellIfCan(m_creature, SPELL_FROST_BREATH_B, CAST_TRIGGERED);
-                        m_uiFrostBreathTimer = 0;
-
-                        m_uiLandTimer = 4000;
-                    }
-                    else
-                        m_uiFrostBreathTimer -= uiDiff;
-                }
-
-                if (m_uiLandTimer)
-                {
-                    if (m_uiLandTimer <= uiDiff)
-                    {
-                        // Begin Landing
-                        DoScriptText(EMOTE_GROUND, m_creature);
-                        m_creature->HandleEmote(EMOTE_ONESHOT_LAND);
-                        m_creature->SetLevitate(false);
-
-                        m_Phase = PHASE_LANDING;
-                        m_uiLandTimer = 2000;
-                    }
-                    else
-                        m_uiLandTimer -= uiDiff;
-                }
-
-                break;
-            case PHASE_LANDING:
-                if (m_uiLandTimer < uiDiff)
-                {
-                    m_Phase = PHASE_GROUND;
-                    SetDeathPrevention(false);
-                    SetCombatMovement(true);
-                    m_creature->GetMotionMaster()->Clear(false);
-                    m_creature->GetMotionMaster()->MoveChase(m_creature->GetVictim());
-
-                    m_uiFlyTimer = 67000;
-                    m_uiLandTimer = 0;
-                }
-                else
-                    m_uiLandTimer -= uiDiff;
-
-                break;
-        }
-
-        // Enrage can happen in any phase
-        if (m_uiBerserkTimer < uiDiff)
-        {
-            if (DoCastSpellIfCan(m_creature, SPELL_BESERK) == CAST_OK)
-            {
-                DoScriptText(EMOTE_GENERIC_ENRAGED, m_creature);
-                m_uiBerserkTimer = 300000;
-            }
+            m_phase = PHASE_LIFT_OFF;
+            for (uint32 action : groundPhaseActions)
+                DisableCombatAction(action);
+            SetDeathPrevention(true);
+            m_creature->InterruptNonMeleeSpells(false);
+            SetCombatMovement(false);
+            SetMeleeEnabled(false);
+            m_creature->AttackStop(false, true);
+            m_creature->SetTarget(nullptr);
+            m_creature->GetMotionMaster()->MovePoint(1, aLiftOffPosition[0], aLiftOffPosition[1], aLiftOffPosition[2], FORCED_MOVEMENT_RUN);
         }
         else
-            m_uiBerserkTimer -= uiDiff;
+            DisableTimer(SAPPHIRON_AIR_PHASE);
+    }
+
+    void HandleLandingPhase()
+    {
+        m_creature->HandleEmote(EMOTE_ONESHOT_LAND);
+        ResetTimer(SAPPHIRON_GROUND_PHASE, 2u * IN_MILLISECONDS);
+    }
+
+    void HandleGroundPhase()
+    {
+        m_phase = PHASE_GROUND;
+        for (uint32 action : groundPhaseActions)
+            ResetCombatAction(action, GetSubsequentActionTimer(action));
+        SetDeathPrevention(false);
+        SetCombatMovement(true);
+        SetMeleeEnabled(true);
+        m_creature->RemoveAurasDueToSpell(SPELL_DRAGON_HOVER);
+        m_creature->SetHover(false);
+        m_creature->GetMotionMaster()->Clear(false);
+        m_creature->GetMotionMaster()->MoveChase(m_creature->GetVictim());
+
+        ResetTimer(SAPPHIRON_AIR_PHASE, GetSubsequentActionTimer(SAPPHIRON_AIR_PHASE));
+    }
+
+    void ExecuteAction(uint32 action) override
+    {
+        switch(action)
+        {
+            case SAPPHIRON_CLEAVE:
+            {
+                if (DoCastSpellIfCan(m_creature->GetVictim(), m_bIsRegularMode ? SPELL_CLEAVE : SPELL_CLEAVE) == CAST_OK)
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
+                return;
+            }
+            case SAPPHIRON_TAIL_SWEEP:
+            {
+                if (DoCastSpellIfCan(m_creature, m_bIsRegularMode ? SPELL_TAIL_SWEEP : SPELL_TAIL_SWEEP_H) == CAST_OK)
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
+                return;
+            }
+            case SAPPHIRON_LIFE_DRAIN:
+            {
+                if (DoCastSpellIfCan(m_creature, m_bIsRegularMode ? SPELL_LIFE_DRAIN : SPELL_LIFE_DRAIN_H) == CAST_OK)
+                    ResetCombatAction(action, GetSubsequentActionTimer(action));
+                return;
+            }
+            case SAPPHIRON_BLIZZARD:
+            {
+                if (m_blizzardCount <= (m_bIsRegularMode ? 2 : 6))
+                {
+                    if (DoCastSpellIfCan(m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0), SPELL_SUMMON_BLIZZARD, TRIGGERED_OLD_TRIGGERED) == CAST_OK)
+                    {
+                        ResetCombatAction(action, GetSubsequentActionTimer(action));
+                        m_blizzardCount++;
+                    }
+                }
+                else
+                {
+                    m_blizzardCount = 0;
+                    DisableCombatAction(action);
+                }
+
+                return;
+
+            }
+            case SAPPHIRON_ICEBOLT:
+            {
+                if (m_iceboltCount < (m_bIsRegularMode ? 2 : 3))
+                {
+                    if (DoCastSpellIfCan(m_creature, SPELL_ICEBOLT_INIT) == CAST_OK)
+                    {
+                        ++m_iceboltCount;
+                        ResetCombatAction(action, GetSubsequentActionTimer(action));
+                    }
+                }
+                else
+                {
+                    m_iceboltCount = 0;
+                    DisableCombatAction(action);
+                    ResetCombatAction(SAPPHIRON_FROST_BREATH, 100u);    // Enough Icebolts were cast, switch to Frost Breath (Ice Bomb) after that
+                }
+                return;
+            }
+            case SAPPHIRON_FROST_BREATH:
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_FROST_BREATH) == CAST_OK)
+                {
+                    DoCastSpellIfCan(m_creature, SPELL_FROST_BREATH_DUMMY, CAST_TRIGGERED);
+                    DoScriptText(EMOTE_BREATH, m_creature);
+                    DisableCombatAction(action);
+                    ResetTimer(SAPPHIRON_LANDING_PHASE, 10u * IN_MILLISECONDS);
+                }
+                return;
+            }
+            case SAPPHIRON_BERSERK:
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_BESERK) == CAST_OK)
+                {
+                    DoScriptText(EMOTE_GENERIC_ENRAGED, m_creature);
+                    DisableCombatAction(action);
+                }
+                return;
+            }
+        }
     }
 };
 
-UnitAI* GetAI_boss_sapphiron(Creature* pCreature)
+bool GOUse_go_sapphiron_birth(Player* /*player*/, GameObject* go)
 {
-    return new boss_sapphironAI(pCreature);
-}
+    ScriptedInstance* instance = (ScriptedInstance*)go->GetInstanceData();
 
-bool GOUse_go_sapphiron_birth(Player* /*pPlayer*/, GameObject* pGo)
-{
-    ScriptedInstance* pInstance = (ScriptedInstance*)pGo->GetInstanceData();
-
-    if (!pInstance)
+    if (!instance)
         return true;
 
-    if (pInstance->GetData(TYPE_SAPPHIRON) != NOT_STARTED)
+    if (instance->GetData(TYPE_SAPPHIRON) != NOT_STARTED)
         return true;
 
     // If already summoned return (safety check)
-    if (pInstance->GetSingleCreatureFromStorage(NPC_SAPPHIRON, true))
+    if (instance->GetSingleCreatureFromStorage(NPC_SAPPHIRON, true))
         return true;
 
     // Set data to special and allow the Go animation to proceed
-    pInstance->SetData(TYPE_SAPPHIRON, SPECIAL);
+    instance->SetData(TYPE_SAPPHIRON, SPECIAL);
     return false;
 }
 
+struct IceBolt : public SpellScript
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex /* effIdx */) const override
+    {
+        if (Unit* caster = spell->GetCaster())
+        {
+            if (Unit* target = ((Creature*)caster)->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, SPELL_ICEBOLT, SELECT_FLAG_PLAYER | SELECT_FLAG_NOT_AURA))
+                caster->CastSpell(target, SPELL_ICEBOLT, TRIGGERED_NONE); // Icebolt
+        }
+    }
+};
+
+struct PeriodicIceBolt : public AuraScript
+{
+    void OnPeriodicTrigger(Aura* aura, PeriodicTriggerData& data) const override
+    {
+        if (Unit* target =  aura->GetTarget())
+        {
+            if (target->IsAlive() && !target->HasAura(SPELL_ICEBOLT_IMMUNITY))
+            {
+                target->CastSpell(target, SPELL_ICEBOLT_IMMUNITY, TRIGGERED_OLD_TRIGGERED);     // Icebolt which causes immunity to frost dmg
+                data.spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(SPELL_ICEBLOCK_SUMMON); // Summon Ice Block
+            }
+        }
+    }
+};
+
+struct DespawnIceBlock : public SpellScript
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex /* effIdx */) const override
+    {
+        if (Unit* unitTarget = spell->GetUnitTarget())
+        {
+            if (unitTarget->GetTypeId() == TYPEID_PLAYER)
+            {
+                unitTarget->RemoveAurasDueToSpell(SPELL_ICEBOLT_IMMUNITY);                          // Icebolt immunity spell
+                unitTarget->RemoveAurasDueToSpell(SPELL_ICEBOLT);                                   // Icebolt stun/damage spell
+                unitTarget->CastSpell(nullptr, SPELL_DESPAWN_ICEBLOCK_GO, TRIGGERED_OLD_TRIGGERED); // Despawn Ice Block (targets Ice Block GOs)
+            }
+        }
+    }
+};
+
+struct DespawnBuffet : public AuraScript
+{
+    void OnPeriodicTrigger(Aura* aura, PeriodicTriggerData& data) const override
+    {
+        if (Unit* target =  aura->GetTarget())
+            data.spellInfo = sSpellTemplate.LookupEntry<SpellEntry>(SPELL_DESPAWN_BUFFET_EFFECT); // Despawn Ice Block
+    }
+};
+
 void AddSC_boss_sapphiron()
 {
-    Script* pNewScript = new Script;
-    pNewScript->Name = "boss_sapphiron";
-    pNewScript->GetAI = &GetAI_boss_sapphiron;
-    pNewScript->RegisterSelf();
+    Script* newScript = new Script;
+    newScript->Name = "boss_sapphiron";
+    newScript->GetAI = &GetNewAIInstance<boss_sapphironAI>;
+    newScript->RegisterSelf();
 
-    pNewScript = new Script;
-    pNewScript->Name = "go_sapphiron_birth";
-    pNewScript->pGOUse = &GOUse_go_sapphiron_birth;
-    pNewScript->RegisterSelf();
+    newScript = new Script;
+    newScript->Name = "go_sapphiron_birth";
+    newScript->pGOUse = &GOUse_go_sapphiron_birth;
+    newScript->RegisterSelf();
+
+    RegisterSpellScript<PeriodicIceBolt>("spell_sapphiron_icebolt_aura");
+    RegisterSpellScript<IceBolt>("spell_sapphiron_icebolt");
+    RegisterSpellScript<DespawnIceBlock>("spell_sapphiron_iceblock");
+    RegisterSpellScript<DespawnBuffet>("spell_sapphiron_despawn_buffet");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the Sapphiron encounter in SD2

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3055

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go to Naxxramas and fight with Sapphiron

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Find the correct value for Amplitude of "Sapphiron's Wing Buffet Despawn"
- [ ] Import the required SQL changes:

```sql
REPLACE INTO spell_scripts(Id, ScriptName) VALUES
(28522,'spell_sapphiron_icebolt_aura'),
(28526,'spell_sapphiron_icebolt'),
(30132,'spell_sapphiron_iceblock'),
(29330,'spell_sapphiron_despawn_buffet');

REPLACE INTO `spell_template` (`Id`, `SchoolMask`, `Category`, `Dispel`, `Mechanic`, `Attributes`, `AttributesEx`, `AttributesEx2`, `AttributesEx3`, `AttributesEx4`, `AttributesEx5`, `Stances`, `StancesNot`, `Targets`, `TargetCreatureType`, `RequiresSpellFocus`, `CasterAuraState`, `TargetAuraState`, `CasterAuraStateNot`, `TargetAuraStateNot`, `CastingTimeIndex`, `RecoveryTime`, `CategoryRecoveryTime`, `InterruptFlags`, `AuraInterruptFlags`, `ChannelInterruptFlags`, `procFlags`, `procChance`, `procCharges`, `maxLevel`, `baseLevel`, `spellLevel`, `DurationIndex`, `powerType`, `manaCost`, `manaCostPerLevel`, `manaPerSecond`, `manaPerSecondPerLevel`, `rangeIndex`, `speed`, `StackAmount`, `Totem1`, `Totem2`, `Reagent1`, `Reagent2`, `Reagent3`, `Reagent4`, `Reagent5`, `Reagent6`, `Reagent7`, `Reagent8`, `ReagentCount1`, `ReagentCount2`, `ReagentCount3`, `ReagentCount4`, `ReagentCount5`, `ReagentCount6`, `ReagentCount7`, `ReagentCount8`, `EquippedItemClass`, `EquippedItemSubClassMask`, `EquippedItemInventoryTypeMask`, `Effect1`, `Effect2`, `Effect3`, `EffectDieSides1`, `EffectDieSides2`, `EffectDieSides3`, `EffectRealPointsPerLevel1`, `EffectRealPointsPerLevel2`, `EffectRealPointsPerLevel3`, `EffectBasePoints1`, `EffectBasePoints2`, `EffectBasePoints3`, `EffectMechanic1`, `EffectMechanic2`, `EffectMechanic3`, `EffectImplicitTargetA1`, `EffectImplicitTargetA2`, `EffectImplicitTargetA3`, `EffectImplicitTargetB1`, `EffectImplicitTargetB2`, `EffectImplicitTargetB3`, `EffectRadiusIndex1`, `EffectRadiusIndex2`, `EffectRadiusIndex3`, `EffectApplyAuraName1`, `EffectApplyAuraName2`, `EffectApplyAuraName3`, `EffectAmplitude1`, `EffectAmplitude2`, `EffectAmplitude3`, `EffectMultipleValue1`, `EffectMultipleValue2`, `EffectMultipleValue3`, `EffectChainTarget1`, `EffectChainTarget2`, `EffectChainTarget3`, `EffectItemType1`, `EffectItemType2`, `EffectItemType3`, `EffectMiscValue1`, `EffectMiscValue2`, `EffectMiscValue3`, `EffectTriggerSpell1`, `EffectTriggerSpell2`, `EffectTriggerSpell3`, `EffectPointsPerComboPoint1`, `EffectPointsPerComboPoint2`, `EffectPointsPerComboPoint3`, `SpellVisual`, `SpellIconID`, `activeIconID`, `spellPriority`, `SpellName`, `SpellName2`, `SpellName3`, `SpellName4`, `SpellName5`, `SpellName6`, `SpellName7`, `SpellName8`, `ManaCostPercentage`, `StartRecoveryCategory`, `StartRecoveryTime`, `MaxTargetLevel`, `SpellFamilyName`, `SpellFamilyFlags`, `MaxAffectedTargets`, `DmgClass`, `PreventionType`, `DmgMultiplier1`, `DmgMultiplier2`, `DmgMultiplier3`, `TotemCategory1`, `TotemCategory2`, `AreaId`) VALUES
('31800','16','0','0','0','536871168','268435592','536870916','268435456','0','0','0','0','0','0','0','0','0','0','0','1','0','0','0','0','0','0','101','0','0','0','0','205','0','0','0','0','0','1','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','-1','0','0','6','0','0','0','0','0','0','0','0','0','0','0','0','0','0','1','0','0','0','0','0','0','0','0','39','0','0','0','0','0','0','0','0','0','0','0','0','0','0','127','0','0','0','0','0','0','0','0','0','35','0','0','Icebolt','','','','','','','','0','0','0','0','0','0','0','0','0','1','1','1','0','0','0');

REPLACE INTO `spell_template` (Id, Attributes, AttributesEx, AttributesEx2, AttributesEx3, Targets, CastingTimeIndex, ProcChance, DurationIndex, RangeIndex, EquippedItemClass, Effect1, EffectImplicitTargetA1, EffectMiscValue1, SpellIconID, SpellName, DmgClass, DmgMultiplier1, DmgMultiplier2, DmgMultiplier3, SchoolMask) VALUES
(28535, 256, 268435592, 4, 268435456, 64, 1, 101, 467, 1, -1, 76, 1, 181247, 35, "Summon Ice Block", 1, 1, 1, 1, 16);

REPLACE INTO `spell_template` (Id, Attributes, AttributesEx2, AttributesEx3, CastingTimeIndex, ProcChance, RangeIndex, EquippedItemClass, Effect1, Effect2, EffectDieSides1, EffectImplicitTargetA1, EffectImplicitTargetA2, EffectImplicitTargetB1, EffectImplicitTargetB2, EffectRadiusIndex1, EffectRadiusIndex2, EffectMiscValue1, SpellIconID, SpellName, DmgMultiplier1, DmgMultiplier2, DmgMultiplier3, SchoolMask) VALUES
(30132, 696254720, 4, 268435456, 1, 101, 13, -1, 86, 77, 1, 22, 22, 51, 15, 22, 22, 15, 35, "Despawn Ice Block", 1, 1, 1, 16);

REPLACE INTO `spell_template` (Id, Attributes, AttributesEx2, AttributesEx3, CastingTimeIndex, ProcChance, RangeIndex, EquippedItemClass, Effect1, EffectDieSides1, EffectImplicitTargetA1, EffectMiscValue1, SpellIconID, SpellName, DmgMultiplier1, DmgMultiplier2, DmgMultiplier3, SchoolMask, AttributesServerside) VALUES
(28523, 159383808, 4, 268435456, 1, 101, 13, -1, 86, 1, 40, 15, 35, "Despawn Ice Block", 1, 1, 1, 4, 1);

REPLACE INTO `spell_script_target` VALUES (28523, 0, 181247, 0);

REPLACE INTO `spell_template` (Id, Attributes, ProcChance, DurationIndex, RangeIndex, EquippedItemClass, Effect1, EffectImplicitTargetA1, EffectMiscValue1, EffectMiscValueB1, SpellIconID, SpellName, DmgMultiplier1) VALUES
(29329, 256, 101, 9, 1, -1, 28, 18, 17025, 64, 1, "Summon Sapphiron's Wing Buffet", 1);

REPLACE INTO `spell_template` (Id, Attributes, AttributesEx, CastingTimeIndex, ProcChance, DurationIndex, RangeIndex, EquippedItemClass, Effect1, EffectImplicitTargetA1, EffectApplyAuraName1, EffectAmplitude1, SpellIconID, SpellName, DmgMultiplier1) VALUES
(29330, 320, 268435456, 1, 101, 63, 1, -1, 6, 1, 23, 20000, 1, "Sapphiron's Wing Buffet Despawn", 1);

REPLACE INTO `spell_template` (Id, Attributes, CastingTimeIndex, ProcChance, DurationIndex, RangeIndex, EquippedItemClass, Effect1, EffectDieSides1, EffectImplicitTargetA1, EffectRadiusIndex1, EffectMiscValue1, EffectMiscValueB1, SpellIconID, SpellName, DmgMultiplier1, Schoolmask) VALUES
(28561, 256, 1, 101, 9, 1, -1, 28, 1, 32, 13, 16474, 64, 1, "Summon Blizzard", 1, 1);

REPLACE INTO `creature_template_addon` (entry, auras) VALUES
(17025, 29327);

UPDATE creature_template SET UnitFlags=33554432 WHERE Entry=17025;
```
