### PR TITLE
CombatAI: Allow manipulating timers with Chrono literals

### DIFF
--- a/src/game/AI/ScriptDevAI/base/TimerAI.h
+++ b/src/game/AI/ScriptDevAI/base/TimerAI.h
@@ -20,9 +20,12 @@
 #include "Util.h"
 #include "Platform/Define.h"
 
+#include <chrono>
 #include <functional>
 #include <map>
 #include <vector>
+
+using namespace std::chrono_literals;
 
 class ChatHandler;
 
@@ -66,13 +69,37 @@ class TimerManager
         // TODO: remove first function
         void AddCustomAction(uint32 id, bool disabled, std::function<void()> functor);
         void AddCustomAction(uint32 id, uint32 timer, std::function<void()> functor);
+        void AddCustomAction(uint32 id, std::chrono::milliseconds timer, std::function<void()> functor)
+        {
+            AddCustomAction(id, uint32(timer.count()), functor);
+        }
         void AddCustomAction(uint32 id, uint32 timerMin, uint32 timerMax, std::function<void()> functor);
+        void AddCustomAction(uint32 id, std::chrono::milliseconds timerMin, std::chrono::milliseconds timerMax, std::function<void()> functor)
+        {
+            AddCustomAction(id, timerMin.count(), timerMax.count(), functor);
+        }
 
         virtual void ResetTimer(uint32 index, uint32 timer);
+        virtual void ResetTimer(uint32 index, std::chrono::milliseconds timer)
+        {
+            ResetTimer(index, timer.count());
+        }
         virtual void DisableTimer(uint32 index);
         virtual void ReduceTimer(uint32 index, uint32 timer);
+        virtual void ReduceTimer(uint32 index, std::chrono::milliseconds timer)
+        {
+            ReduceTimer(index, timer.count());
+        }
         virtual void DelayTimer(uint32 index, uint32 timer);
+        virtual void DelayTimer(uint32 index, std::chrono::milliseconds timer)
+        {
+            DelayTimer(index, timer.count());
+        }
         virtual void ResetIfNotStarted(uint32 index, uint32 timer);
+        virtual void ResetIfNotStarted(uint32 index, std::chrono::milliseconds timer)
+        {
+            ResetIfNotStarted(index, timer.count());
+        }
 
         virtual void UpdateTimers(const uint32 diff);
         virtual void ResetAllTimers();
@@ -95,16 +122,40 @@ class CombatActions : public TimerManager
         void AddCombatAction(uint32 id, bool disabled);
         // Adds a combat action which is always reset to static timer value
         void AddCombatAction(uint32 id, uint32 timer);
+        void AddCombatAction(uint32 id, std::chrono::milliseconds timer)
+        {
+            AddCombatAction(id, uint32(timer.count()));
+        }
         // Adds a combat action which is reset to a random number between min and max (inclusive)
         void AddCombatAction(uint32 id, uint32 timerMin, uint32 timerMax);
+        void AddCombatAction(uint32 id, std::chrono::milliseconds timerMin, std::chrono::milliseconds timerMax)
+        {
+            AddCombatAction(id, timerMin.count(), timerMax.count());
+        }
         // Adds a combat action which has no timer. It is reset to default value at start. Useful for one-off actions like phase transition at HP level.
         void AddTimerlessCombatAction(uint32 id, bool byDefault);
 
         virtual void ResetTimer(uint32 index, uint32 timer) override;
+        virtual void ResetTimer(uint32 index, std::chrono::milliseconds timer)
+        {
+            ResetTimer(index, timer.count());
+        }
         virtual void DisableTimer(uint32 index) override;
         virtual void ReduceTimer(uint32 index, uint32 timer) override;
+        virtual void ReduceTimer(uint32 index, std::chrono::milliseconds timer)
+        {
+            ReduceTimer(index, timer.count());
+        }
         virtual void DelayTimer(uint32 index, uint32 timer) override;
+        virtual void DelayTimer(uint32 index, std::chrono::milliseconds timer)
+        {
+            DelayTimer(index, timer.count());
+        }
         virtual void ResetIfNotStarted(uint32 index, uint32 timer) override;
+        virtual void ResetIfNotStarted(uint32 index, std::chrono::milliseconds timer)
+        {
+            ResetIfNotStarted(index, timer.count());
+        }
 
         void DisableCombatAction(uint32 index);
 
@@ -112,6 +163,10 @@ class CombatActions : public TimerManager
         {
             ResetTimer(index, timer);
             SetActionReadyStatus(index, false);
+        }
+        void ResetCombatAction(uint32 index, std::chrono::milliseconds timer)
+        {
+            ResetCombatAction(index, timer.count());
         }
 
         void DelayCombatAction(uint32 index, uint32 timer)
@@ -123,6 +178,10 @@ class CombatActions : public TimerManager
             }
             else
                 DelayTimer(index, timer);
+        }
+        void DelayCombatAction(uint32 index, std::chrono::milliseconds timer)
+        {
+            DelayCombatAction(index, timer.count());
         }
 
         inline void SetActionReadyStatus(uint32 index, bool state) { m_actionReadyStatus[index] = state; }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR allows for std::chrono_literals to be used when manipulating CombatAI timers

(instead of `8 * MINUTE * IN_MILLISECONDS` you can now just write `8min`)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Check for unforeseen consequences
