### PR TITLE
SpellScript: Add flags to Submerged and Stand spells

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -224,6 +224,8 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (37430,'spell_lurker_spout_turning'),
 (37851,'spell_tag_for_single_use'),
 (37896,'spell_to_infinity_and_above'),
+(37751,'spell_submerged'),
+(37752,'spell_stand'),
 (38606,'spell_exorcism_feather'),
 (38640,'spell_koi_koi_death'),
 (38915,'spell_mental_interference'),

--- a/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/slave_pens/boss_ahune.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/slave_pens/boss_ahune.cpp
@@ -169,8 +169,6 @@ struct boss_ahuneAI : public CombatAI
             // Note: the following spell breaks the visual. Needs to be fixed!
             // DoCastSpellIfCan(m_creature, SPELL_AHUNE_SELF_STUN, CAST_TRIGGERED);
 
-            m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
-
             if (Creature* pCore = m_creature->GetMap()->GetCreature(m_frozenCoreGuid))
                 pCore->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE | UNIT_FLAG_IMMUNE_TO_PLAYER);
         }
@@ -217,11 +215,10 @@ struct boss_ahuneAI : public CombatAI
 
     void HandleEmerge()
     {
-        m_creature->RemoveAurasDueToSpell(SPELL_SUBMERGE);
         m_creature->RemoveAurasDueToSpell(SPELL_AHUNE_SELF_STUN);
-        m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
 
         DoCastSpellIfCan(m_creature, SPELL_BIRTH);
+        DoCastSpellIfCan(m_creature, SPELL_STAND);
         SpawnBunnies();
 
         if (Creature* pCore = m_creature->GetMap()->GetCreature(m_frozenCoreGuid))

--- a/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/npcs_special.cpp
@@ -1595,7 +1595,6 @@ struct npc_burster_wormAI : public CombatAI
         m_creature->CastSpell(nullptr, SPELL_SUBMERGED, TRIGGERED_NONE);
         if (passive)
             DoCastSpellIfCan(nullptr, m_uiBorePassive, CAST_TRIGGERED | CAST_AURA_NOT_PRESENT);
-        m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
     }
 
     void SpellHitTarget(Unit* target, const SpellEntry* spellInfo) override
@@ -1645,7 +1644,6 @@ struct npc_burster_wormAI : public CombatAI
             case 1: // after teleport
             {
                 // come up
-                m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
                 m_creature->RemoveAurasDueToSpell(SPELL_SANDWORM_SUBMERGE_VISUAL);
                 DoCastSpellIfCan(nullptr, SPELL_STAND);
                 timer = 1000;

--- a/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/spell_scripts.cpp
@@ -1620,6 +1620,32 @@ struct ForgetHammersmith : public SpellScript
     }
 };
 
+struct Submerged : public SpellScript
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const override
+    {
+        Unit* unitTarget = spell->GetUnitTarget();
+        if (!unitTarget)
+            return;
+
+        unitTarget->SetStandState(UNIT_STAND_STATE_CUSTOM);
+        unitTarget->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+    }
+};
+
+struct Stand : public SpellScript
+{
+    void OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const override
+    {
+        Unit* unitTarget = spell->GetUnitTarget();
+        if (!unitTarget)
+            return;
+
+        unitTarget->SetStandState(UNIT_STAND_STATE_STAND);
+        unitTarget->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+    }
+};
+
 void AddSC_spell_scripts()
 {
     Script* pNewScript = new Script;
@@ -1671,4 +1697,6 @@ void AddSC_spell_scripts()
     RegisterSpellScript<ForgetSwordsmith>("spell_forget_36438");
     RegisterSpellScript<ForgetAxesmith>("spell_forget_36439");
     RegisterSpellScript<ForgetHammersmith>("spell_forget_36441");
+    RegisterSpellScript<Submerged>("spell_submerged");
+    RegisterSpellScript<Stand>("spell_stand");
 }

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -8985,15 +8985,6 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                     }
                     return;
                 }
-                case 37751:                                 // Submerged
-                case 37752:                                 // Stand
-                {
-                    if (!unitTarget)
-                        return;
-
-                    unitTarget->SetStandState(m_spellInfo->Id == 37751 ? UNIT_STAND_STATE_CUSTOM : UNIT_STAND_STATE_STAND);
-                    return;
-                }
                 case 37775:                                 // Karazhan - Chess NPC Action - Poison Cloud
                 {
                     if (!unitTarget)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds adding and removing the UNIT_FLAG_UNINTERACTIBLE flag to the `Submerged` and `Stand` spells and updates the scripts using these spells which added and removed this flag manually before.