### PR TITLE
MMapManager::unloadMap(uint32 mapId) crash fix

### DIFF
--- a/src/game/MotionGenerators/MoveMap.cpp
+++ b/src/game/MotionGenerators/MoveMap.cpp
@@ -410,10 +410,13 @@ namespace MMAP
     {
         bool success = false;
         // unload all maps with given mapId
-        for (auto itr = m_loadedMMaps.begin(); itr != m_loadedMMaps.end(); ++itr)
+        for (auto itr = m_loadedMMaps.begin(); itr != m_loadedMMaps.end();)
         {
             if (itr->first != uint64(mapId) << 32)
+            {
+                itr++;
                 continue;
+            }
 
             // unload all tiles from given map
             MMapData* mmap = (*itr).second;
@@ -432,7 +435,7 @@ namespace MMAP
             }
 
             delete mmap;
-            m_loadedMMaps.erase(itr);
+            itr = m_loadedMMaps.erase(itr);
             DEBUG_FILTER_LOG(LOG_FILTER_MAP_LOADING, "MMAP:unloadMap: Unloaded %03i.mmap", mapId);
             success = true;
         }


### PR DESCRIPTION


## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
m_loadedMMaps.erase(itr); invalidates itr. Fix by reassigning itr to one returned by erase.

### Proof
<!-- Link resources as proof -->
https://en.cppreference.com/w/cpp/container/unordered_map/erase

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Compile in debug.
- ser shut 1 and observe for failed assertions related to unloadMap.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
