### PR TITLE
Shaman: Don't add heroism/bloodlust on sated targets

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -1274,7 +1274,9 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (58589,'spell_stoneclaw_totem_absorb'),
 (58590,'spell_stoneclaw_totem_absorb'),
 (58591,'spell_stoneclaw_totem_absorb'),
-(70811,'spell_item_shaman_t10_elemental_2p_bonus');
+(70811,'spell_item_shaman_t10_elemental_2p_bonus')
+(2825,'spell_heroism_bloodlust'),
+(32182,'spell_heroism_bloodlust');
 
 -- Food and Drink
 INSERT INTO spell_scripts(Id, ScriptName) VALUES

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Shaman.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Shaman.cpp
@@ -228,6 +228,16 @@ struct StoneclawTotemAbsorb : public SpellScript
     }
 };
 
+struct HeroismBloodlust : public SpellScript
+{
+    bool OnCheckTarget(const Spell* /*spell*/, Unit* target, SpellEffectIndex /*eff*/) const
+    {
+        if (!target || !target->IsAlive() || target->HasAura(57724) || target->HasAura(57723))
+            return false;
+        return true;
+    }
+};
+
 void LoadShamanScripts()
 {
     Script* pNewScript = new Script;
@@ -244,4 +254,5 @@ void LoadShamanScripts()
     RegisterSpellScript<AncestralAwakeningSearch>("spell_ancestral_awakening_search");
     RegisterSpellScript<StoneclawTotem>("spell_stoneclaw_totem");
     RegisterSpellScript<StoneclawTotemAbsorb>("spell_stoneclaw_totem_absorb");
+    RegisterSpellScript<HeroismBloodlust>("spell_heroism_bloodlust");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes it so Heroism/Bloodlust isn't cast on characters with the Sated/Exhausted debuff.
There is a minor issue with how it currently works, and that is that when everybody in the group/raid has the sated/exhausted debuff and the shaman uses bloodlust/heroism no sound is being played. I'm not sure if that's how it's supposed to be.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3083

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create Shaman
- Use `.level 79`
- Use `.learn all_myclass`
- Cast Bloodlust/Heroism from the Enhancement Spellbook
- Use `.cooldown clear`
- Cast Bloodlust/Heroism again

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] Research the sound issue
