### PR TITLE
Ulduar: Add Hodir's Protective Gaze Spellscript

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/ulduar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/ulduar.cpp
@@ -304,6 +304,22 @@ void instance_ulduar::OnCreatureCreate(Creature* pCreature)
     m_npcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
 }
 
+void instance_ulduar::OnCreatureRespawn(Creature* creature)
+{
+    if (creature->GetEntry() == NPC_HODIR_HELPER)
+    {
+        creature->AI()->AddCustomAction(TIMER_HODIRS_PROTECTIVE_GAZE, true, [&]()
+        {
+            Creature* hodirHelper = GetSingleCreatureFromStorage(NPC_HODIR_HELPER);
+            if (!hodirHelper || hodirHelper->HasAura(64174))
+                return;
+            if (GetData(TYPE_YOGGSARON) != IN_PROGRESS)
+                return;
+            hodirHelper->CastSpell(hodirHelper, 64174, TRIGGERED_NONE);
+        });
+    }
+}
+
 void instance_ulduar::OnObjectCreate(GameObject* pGo)
 {
     switch (pGo->GetEntry())

--- a/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/ulduar.h
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/ulduar.h
@@ -501,6 +501,8 @@ enum
     ACHIEV_CRIT_CONQ_FREYA      = 10583,
     ACHIEV_CRIT_CONQ_COUNCIL    = 10599,
     ACHIEV_CRIT_CONQ_HODIR      = 10719,
+
+    TIMER_HODIRS_PROTECTIVE_GAZE = 0,
 };
 
 struct UlduarSpawn
@@ -588,6 +590,7 @@ class instance_ulduar : public ScriptedInstance, private DialogueHelper
         void OnPlayerDeath(Player* pPlayer) override;
 
         void OnCreatureCreate(Creature* pCreature) override;
+        void OnCreatureRespawn(Creature* creature) override;
         void OnCreatureEnterCombat(Creature* pCreature) override;
         void OnCreatureDeath(Creature* pCreature) override;
         void OnObjectCreate(GameObject* pGo) override;

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Paladin.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Paladin.cpp
@@ -262,6 +262,7 @@ struct ArdentDefender : public AuraScript
         healMod *= defenseFactor;
         healMod = player->GetMaxHealth() * (healMod / 100.f);
         remainingDamage = 0;
+        preventedDeath = true;
         player->CastCustomSpell(nullptr, 66235, &healMod, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED);
         player->CastSpell(nullptr, 66233, TRIGGERED_OLD_TRIGGERED);
     }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds a Spell-Script for "Hodir's Protective Gaze"

### Proof
<!-- Link resources as proof -->
- [Ensidia World First Yogg-Saron](https://www.youtube.com/watch?v=iatGk4TOlEA)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/760

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Begin the Yogg-Saron fight with Hodir's assistance
- Hodir will cast his protective gaze
- take enough damage to die
- protective gaze will activate and prevent death
- the aura will vanish for all players and only reappear 25 seconds later

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] Due to some slightly deeper systemic changes some other problems might've been caused. Please test them.
