### PR TITLE
Warlock: Fix Seed of Corruption not exploding when stunned or dead

### DIFF
--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
@@ -228,7 +228,7 @@ struct SeedOfCorruption : public AuraScript
             return;
         if (aura->GetRemoveMode() == AURA_REMOVE_BY_DEATH)
             if (Unit* caster = aura->GetCaster())
-                caster->CastSpell(aura->GetTarget(), GetSeedDamageSpell(aura->GetId()), TRIGGERED_OLD_TRIGGERED);
+                caster->CastSpell(aura->GetTarget(), GetSeedDamageSpell(aura->GetId()), TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CURRENT_CASTED_SPELL | TRIGGERED_IGNORE_CASTER_AURA_STATE | TRIGGERED_HIDE_CAST_IN_COMBAT_LOG);
     }
 
     SpellAuraProcResult OnProc(Aura* aura, ProcExecutionData& procData) const override
@@ -247,7 +247,7 @@ struct SeedOfCorruption : public AuraScript
 
             // Cast finish spell (triggeredByAura already not exist!)
             if (Unit* caster = procData.triggeredByAura->GetCaster())
-                caster->CastSpell(procData.victim, GetSeedDamageSpell(aura->GetId()), TRIGGERED_OLD_TRIGGERED);
+                caster->CastSpell(procData.victim, GetSeedDamageSpell(aura->GetId()), TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CURRENT_CASTED_SPELL | TRIGGERED_IGNORE_CASTER_AURA_STATE | TRIGGERED_HIDE_CAST_IN_COMBAT_LOG);
             return SPELL_AURA_PROC_OK;              // no hidden cooldown
         }
 

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Warlock.cpp
@@ -228,7 +228,7 @@ struct SeedOfCorruption : public AuraScript
             return;
         if (aura->GetRemoveMode() == AURA_REMOVE_BY_DEATH)
             if (Unit* caster = aura->GetCaster())
-                caster->CastSpell(aura->GetTarget(), GetSeedDamageSpell(aura->GetId()), TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CURRENT_CASTED_SPELL | TRIGGERED_HIDE_CAST_IN_COMBAT_LOG);
+                caster->CastSpell(aura->GetTarget(), GetSeedDamageSpell(aura->GetId()), TRIGGERED_OLD_TRIGGERED);
     }
 
     SpellAuraProcResult OnProc(Aura* aura, ProcExecutionData& procData) const override
@@ -247,7 +247,7 @@ struct SeedOfCorruption : public AuraScript
 
             // Cast finish spell (triggeredByAura already not exist!)
             if (Unit* caster = procData.triggeredByAura->GetCaster())
-                caster->CastSpell(procData.victim, GetSeedDamageSpell(aura->GetId()), TRIGGERED_IGNORE_GCD | TRIGGERED_IGNORE_CURRENT_CASTED_SPELL | TRIGGERED_HIDE_CAST_IN_COMBAT_LOG);
+                caster->CastSpell(procData.victim, GetSeedDamageSpell(aura->GetId()), TRIGGERED_OLD_TRIGGERED);
             return SPELL_AURA_PROC_OK;              // no hidden cooldown
         }
 
@@ -262,7 +262,7 @@ struct SeedOfCorruptionDamage : public SpellScript
     bool OnCheckTarget(const Spell* spell, Unit* target, SpellEffectIndex /*eff*/) const override
     {
         if (target->GetObjectGuid() == spell->m_targets.getUnitTargetGuid()) // in TBC skip target of initial aura
-            return false;
+            return true; // in WotLK Seed of Corruption also damages the initial target
         return true;
     }
 };

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -511,6 +511,7 @@ Spell::Spell(WorldObject * caster, SpellEntry const* info, uint32 triggeredFlags
     m_ignoreCosts = m_IsTriggeredSpell || ((triggeredFlags & TRIGGERED_IGNORE_COSTS) != 0);
     m_ignoreCooldowns = m_IsTriggeredSpell || ((triggeredFlags & TRIGGERED_IGNORE_COOLDOWNS) != 0);
     m_ignoreConcurrentCasts = m_IsTriggeredSpell || ((triggeredFlags & TRIGGERED_IGNORE_CURRENT_CASTED_SPELL) != 0) || m_spellInfo->HasAttribute(SPELL_ATTR_EX4_ALLOW_CAST_WHILE_CASTING);
+    m_ignoreCasterAuraState = m_IsTriggeredSpell || ((triggeredFlags & TRIGGERED_IGNORE_CASTER_AURA_STATE) != 0 || m_spellInfo->HasAttribute(SPELL_ATTR_EX5_IGNORE_CASTER_REQUIREMENTS));
     m_hideInCombatLog = (m_IsTriggeredSpell && !IsAutoRepeatRangedSpell(m_spellInfo)) || ((triggeredFlags & TRIGGERED_HIDE_CAST_IN_COMBAT_LOG) != 0);
     m_resetLeash = (triggeredFlags & TRIGGERED_DO_NOT_RESET_LEASH) == 0;
     m_channelOnly = (triggeredFlags & TRIGGERED_CHANNEL_ONLY) != 0;
@@ -7115,6 +7116,9 @@ SpellCastResult Spell::CheckPetCast(Unit* target)
 
 SpellCastResult Spell::CheckCasterAuras(uint32& param1) const
 {
+    if (m_ignoreCasterAuraState)
+        return SPELL_CAST_OK;
+
     if (!m_trueCaster->IsUnit())
         return SPELL_CAST_OK;
 

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -652,6 +652,7 @@ class Spell
         bool m_ignoreCosts;
         bool m_ignoreCooldowns;
         bool m_ignoreConcurrentCasts;
+        bool m_ignoreCasterAuraState;
         bool m_hideInCombatLog;
         bool m_resetLeash;
         bool m_channelOnly;

--- a/src/game/Spells/SpellDefines.h
+++ b/src/game/Spells/SpellDefines.h
@@ -737,6 +737,7 @@ enum TriggerCastFlags : uint32
     TRIGGERED_HIDE_CAST_IN_COMBAT_LOG           = 0x00002000,   // Sends cast flag for ignoring combat log display - used for many procs - default behaviour for triggered by aura
     TRIGGERED_DO_NOT_RESET_LEASH                = 0x00004000,   // Does not reset leash on cast
     TRIGGERED_CHANNEL_ONLY                      = 0x00008000,   // Only starts channel and no effects - used for summoning portal GO anims
+    TRIGGERED_IGNORE_CASTER_AURA_STATE          = 0x00010000,   // Ignores the Aurastate of the caster
     TRIGGERED_FULL_MASK                         = 0xFFFFFFFF
 };
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR allows Seed of Corruption to explode even when the Warlock is stunned or dead or LOS, etc.
Additionally this PR allows the explosion from Seed of Corruption to hit the original target in WotLK, as that is intended behaviour.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create Warlock
- Learn Seed of Corruption
- Cast Seed of Corruption on enemy
- Cast any Stun spell on self
- Watch what happens with the seed

