### PR TITLE
Thorim: Add SpellScript for Circle of Healing by Add

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -767,6 +767,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (61546,'spell_shatter'),
 (61830,'spell_drink'),
 (61916,'spell_lightning_whirl'),
+(61964,'spell_thorim_circle_of_healing'),
 (62108,'spell_tails_up_summon_female_frost_leopard'),
 (62116,'spell_tails_up_summon_female_icepaw_bear'),
 (62138,'spell_teleport_inside_violet_hold'),

--- a/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/boss_thorim.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/boss_thorim.cpp
@@ -1049,6 +1049,28 @@ UnitAI* GetAI_npc_thunder_orb(Creature* pCreature)
     return new npc_thunder_orbAI(pCreature);
 }
 
+struct ThorimCircleOfHealing : SpellScript
+{
+    bool OnCheckTarget(const Spell* /*spell*/, Unit* target, SpellEffectIndex /*eff*/) const override
+    {
+        if (!target || !target->IsCreature())
+            return false;
+        switch (target->GetEntry())
+        {
+            case NPC_JORMUNGAR_BEHEMOTH:
+            case NPC_DARK_RUNE_ACOLYTE:
+            case NPC_SOLDIER_ALLIANCE:
+            case NPC_CAPTAIN_ALLIANCE:
+            case NPC_SOLDIER_HORDE:
+            case NPC_CAPTAIN_HORDE:
+                return true;
+            default:
+                return false;
+        }
+        return false;
+    }
+};
+
 void AddSC_boss_thorim()
 {
     Script* pNewScript = new Script;
@@ -1070,4 +1092,6 @@ void AddSC_boss_thorim()
     pNewScript->Name = "npc_thunder_orb";
     pNewScript->GetAI = GetAI_npc_thunder_orb;
     pNewScript->RegisterSelf();
+
+    RegisterSpellScript<ThorimCircleOfHealing>("spell_thorim_circle_of_healing");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
One of the NPCs in the Pre-Pull event of Thorim does a Circle of Healing.
This PR makes sure this spell only targets the intended creatures and not every single creature, including trigger NPCs in the vicinity.

- Enter Thorim's Arena with GM Off
- When the mercenaries spawn engage them in combat
- Observe the targets healed by CoH

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Testing
