### PR TITLE
Fix crash in Wyvern Sting

### DIFF
--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Hunter.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Hunter.cpp
@@ -73,7 +73,7 @@ struct WyvernSting : public AuraScript
     int32 OnDurationCalculate(WorldObject const* caster, Unit const* target, int32 duration) const override
     {
         // PVP DR example
-        if (caster->IsControlledByPlayer() && target->IsPlayerControlled())
+        if (target && caster->IsControlledByPlayer() && target->IsPlayerControlled())
             return 6000;
         return duration;
     }


### PR DESCRIPTION
Spell duration can be checked with target as nullptr in some places
For me it happened here https://github.com/cmangos/mangos-wotlk/blob/master/src/game/Spells/Spell.cpp#L3661


