### PR TITLE
Update GitHub Workflows

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,9 +7,8 @@ env:
   BUILD_TYPE: Release
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
-  BOOST_PLATFORM_VERSION: "11"
   BOOST_VERSION: "1.79.0"
-  BOOST_INSTALL_DIR: "${{github.workspace}}/bin"
+  BOOST_PLATFORM_VERSION: "11"
 
 permissions:
   contents: read
@@ -22,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{env.REPO_DIR}}
 
@@ -31,34 +30,25 @@ jobs:
           brew install mysql-client
           brew install openssl
           echo "OPENSSL_ROOT_DIR=$(brew --prefix --installed openssl)" >> $GITHUB_ENV
-          mkdir -p ${{env.BOOST_INSTALL_DIR}}
 
-      - name: Cache Windows boost
-        uses: actions/cache@v2
-        id: cache-boost
-        with:
-          path: "${{env.BOOST_INSTALL_DIR}}/boost"
-          key: ${{ runner.os }}-${{ hashFiles('.github/workflows/macos.yml') }}
-
-      - if: steps.cache-boost.outputs.cache-hit != 'true'
-        name: Install boost
-        uses: MarkusJx/install-boost@v2.3.0
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version
           # A list of supported versions can be found here:
-          # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
+          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
           boost_version: ${{env.BOOST_VERSION}}
           # OPTIONAL: Specify a platform version
           platform_version: ${{env.BOOST_PLATFORM_VERSION}}
-          # OPTIONAL: Specify a custom install location
-          boost_install_dir: ${{env.BOOST_INSTALL_DIR}}
           # OPTIONAL: Specify a toolset
           toolset: clang
+          # NOTE: If a boost version matching all requirements cannot be found,
+          # this build step will fail
 
       - name: Configure
         env:
-          BOOST_ROOT: "${{env.BOOST_INSTALL_DIR}}/boost/boost"
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         run: cmake -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}} -DBoost_ARCHITECTURE=-x64
 
       - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,9 +7,8 @@ env:
   BUILD_TYPE: Release
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
-  BOOST_PLATFORM_VERSION: "22.04"
   BOOST_VERSION: "1.79.0"
-  BOOST_INSTALL_DIR: "${{github.workspace}}/bin"
+  BOOST_PLATFORM_VERSION: "22.04"
 
 jobs:
   build:
@@ -40,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{env.REPO_DIR}}
 
@@ -52,36 +51,28 @@ jobs:
           echo "CXX=${{matrix.COMPILER_PP}}" >> $GITHUB_ENV
           cmake -E make_directory ${{ env.BUILD_DIR }}
 
-      - name: Cache Windows boost
-        uses: actions/cache@v2
-        id: cache-boost
-        with:
-          path: "${{env.BOOST_INSTALL_DIR}}/boost"
-          key: ${{ runner.os }}-${{ hashFiles('.github/workflows/ubuntu.yml') }}
-
-      - if: steps.cache-boost.outputs.cache-hit != 'true'
-        name: Install boost
-        uses: MarkusJx/install-boost@v2.3.0
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version
           # A list of supported versions can be found here:
-          # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
+          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
           boost_version: ${{env.BOOST_VERSION}}
           # OPTIONAL: Specify a platform version
           platform_version: ${{env.BOOST_PLATFORM_VERSION}}
-          # OPTIONAL: Specify a custom install location
-          boost_install_dir: ${{env.BOOST_INSTALL_DIR}}
           # OPTIONAL: Specify a toolset
           toolset: ${{env.COMPILER_CC}}
           # OPTIONAL: Specify an architecture
           arch: x86
+          # NOTE: If a boost version matching all requirements cannot be found,
+          # this build step will fail
 
       - name: Configure
         env:
           USE_PCH: ${{ matrix.USE_PCH }}
           EXTRA_BUILD: ${{ matrix.EXTRA_BUILD }}
-          BOOST_ROOT: "${{env.BOOST_INSTALL_DIR}}/boost/boost"
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         run: cmake -DBoost_ARCHITECTURE=-x64 -DPCH=${{env.USE_PCH}} ${{env.EXTRA_BUILD}}-B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}}
 
       - name: Build

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -12,8 +12,8 @@ env:
   REPO_DIR : ${{github.workspace}}
   BUILD_DIR: ${{github.workspace}}/bin/builddir
   BOOST_TOOLSET: "msvc"
-  BOOST_VERSION: "1.79.0.beta1"
-  BOOST_INSTALL_DIR: "${{github.workspace}}/bin"
+  BOOST_VERSION: "1.79.0"
+  BOOST_PLATFORM_VERSION: "2022"
 
 jobs:
   build:
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{env.REPO_DIR}}
 
@@ -52,33 +52,24 @@ jobs:
           cmake -E make_directory ${{ env.BUILD_DIR }}
 
       # install dependencies
-      - name: Cache Windows boost
-        uses: actions/cache@v2
-        id: cache-boost
-        with:
-          path: "${{env.BOOST_INSTALL_DIR}}/boost"
-          key: ${{ runner.os }}-${{ hashFiles('.github/workflows/windows-release.yml') }}
-
-      - if: steps.cache-boost.outputs.cache-hit != 'true'
-        name: Install boost
-        uses: MarkusJx/install-boost@v2.3.0
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version
           # A list of supported versions can be found here:
-          # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
+          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
           boost_version: ${{env.BOOST_VERSION}}
-          # OPTIONAL: Specify a toolset on windows
+          # OPTIONAL: Specify a platform version
+          platform_version: ${{env.BOOST_PLATFORM_VERSION}}
+          # OPTIONAL: Specify a toolset
           toolset: ${{env.BOOST_TOOLSET}}
-          # OPTIONAL: Specify a custon install location
-          boost_install_dir: ${{env.BOOST_INSTALL_DIR}}
-          platform_version: 2022
           # NOTE: If a boost version matching all requirements cannot be found,
           # this build step will fail
 
       - name: Configure
         env:
-          BOOST_ROOT: "${{env.BOOST_INSTALL_DIR}}/boost/boost"
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         run: cmake ${{matrix.OPTIONAL_DEFINES}} -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}}
 
       - name: Build
@@ -91,7 +82,7 @@ jobs:
           cd bin
           7z a -tzip ${{env.ARCHIVE_FILENAME}} "x64_${{env.BUILD_TYPE}}"
       - name: Archive this artefact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: snapshot-${{matrix.TYPE}}
           path: "bin/${{env.ARCHIVE_FILENAME}}"
@@ -104,27 +95,27 @@ jobs:
 
     steps:
       - name: Download artifact snapshot-default
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: snapshot-default
           path: all_snapshots
       - name: Download artifact snapshot-with-all
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: snapshot-with-all
           path: all_snapshots
       - name: Download artifact snapshot-with-playerbot-ahbot
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: snapshot-with-playerbot-ahbot
           path: all_snapshots
       - name: Download artifact snapshot-with-playerbot
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: snapshot-with-playerbot
           path: all_snapshots
       - name: Download artifact snapshot-with-ahbot
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: snapshot-with-ahbot
           path: all_snapshots

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ env:
   BUILD_DIR: ${{github.workspace}}/bin/builddir
   BOOST_TOOLSET: "msvc"
   BOOST_VERSION: "1.79.0"
-  BOOST_INSTALL_DIR: "${{github.workspace}}/bin"
+  BOOST_PLATFORM_VERSION: "2022"
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{env.REPO_DIR}}
 
@@ -31,33 +31,24 @@ jobs:
           cmake -E make_directory ${{ env.BUILD_DIR }}
 
       # install dependencies
-      - name: Cache Windows boost
-        uses: actions/cache@v2
-        id: cache-boost
-        with:
-          path: "${{env.BOOST_INSTALL_DIR}}/boost"
-          key: ${{ runner.os }}-${{ hashFiles('.github/workflows/windows.yml') }}
-
-      - if: steps.cache-boost.outputs.cache-hit != 'true'
-        name: Install boost
-        uses: MarkusJx/install-boost@v2.3.0
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.1
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version
           # A list of supported versions can be found here:
-          # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
+          # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
           boost_version: ${{env.BOOST_VERSION}}
-          # OPTIONAL: Specify a toolset on windows
+          # OPTIONAL: Specify a platform version
+          platform_version: ${{env.BOOST_PLATFORM_VERSION}}
+          # OPTIONAL: Specify a toolset
           toolset: ${{env.BOOST_TOOLSET}}
-          # OPTIONAL: Specify a custon install location
-          boost_install_dir: ${{env.BOOST_INSTALL_DIR}}
-          platform_version: 2022
           # NOTE: If a boost version matching all requirements cannot be found,
           # this build step will fail
-
+          
       - name: Configure
         env:
-          BOOST_ROOT: "${{env.BOOST_INSTALL_DIR}}/boost/boost"
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         run: cmake -B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}}
 
       - name: Build
@@ -71,7 +62,7 @@ jobs:
           7z a -tzip ${{env.ARCHIVE_FILENAME}} x64_Release
 
       - name: Archive this artefact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: snapshot
           path: "bin/${{env.ARCHIVE_FILENAME}}"


### PR DESCRIPTION
## 🍰 Pullrequest
This PR fixes the warning given by the GitHub actions runners regarding soon to be deprecated functions on Node.js 12. Updates checkout, install-boost, and upload-artifact to versions that are compatible with Node.js 14. Removed cache@v2 since install-boost routine has it built in and also removed the setting of the BOOST_INSTALL_DIR env variable as the output from install-boost can set the BOOST_ROOT env variable. Unified all Boost versions to 1.79.0 and unified comments in install-boost function to new pre-built Boost list and minor reordering of options in function.

### Proof
Windows-https://github.com/cmangos/mangos-wotlk/actions/runs/3988653094
Windows Release-https://github.com/cmangos/mangos-wotlk/actions/runs/4003391214
Linux-https://github.com/cmangos/mangos-wotlk/actions/runs/3988653090
Mac-https://github.com/cmangos/mangos-wotlk/actions/runs/3988653089

Warnings galore

### Issues
- Preventing future issue when Node.js 12 is disabled and CI runners stop functioning

### How2Test
Windows-https://github.com/Niam5/Eluna-CMaNGOS-WotLK/actions/runs/4012638748
Windows Release-https://github.com/Niam5/Eluna-CMaNGOS-WotLK/actions/runs/4071809358
Yes there are still warnings but those functions do not have updates available at this time, alternatives may need to be considered if they do not update and stop working.
Linux-https://github.com/Niam5/Eluna-CMaNGOS-WotLK/actions/runs/4012638750
Mac-https://github.com/Niam5/Eluna-CMaNGOS-WotLK/actions/runs/4012638746

Warnings be gone or severely reduced!

### Todo / Checklist
- [X] None