### PR TITLE
Store pet correctly when entering vehicle

### DIFF
--- a/src/game/Entities/Vehicle.cpp
+++ b/src/game/Entities/Vehicle.cpp
@@ -279,7 +279,7 @@ void VehicleInfo::Board(Unit* passenger, uint8 seat)
     if (passenger->GetTypeId() == TYPEID_PLAYER)
     {
         Player* pPlayer = (Player*)passenger;
-        pPlayer->RemovePet(PET_SAVE_AS_CURRENT);
+        pPlayer->UnsummonPetTemporaryIfAny();
 
         WorldPacket data(SMSG_ON_CANCEL_EXPECTED_RIDE_VEHICLE_AURA);
         pPlayer->GetSession()->SendPacket(data);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes sure that pets are stored correctly when the player enters a vehicle, so that they are re-summoned once the player exits the vehicle.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Test
