### PR TITLE
AuctionHouseBot: Fix invalid gameobject loot query by removing state condition

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -80,7 +80,7 @@ void AuctionHouseBot::Initialize()
 
         // gameobject loot
         ParseLootConfig("AuctionHouseBot.Loot.Gameobject", m_gameobjectLootConfig);
-        FillUintVectorFromQuery("SELECT DISTINCT entry FROM gameobject_loot_template WHERE entry IN (SELECT data1 FROM gameobject_template WHERE entry IN (SELECT id FROM gameobject WHERE state = 1 AND spawntimesecsmax > 0))", m_gameobjectLootTemplates);
+        FillUintVectorFromQuery("SELECT DISTINCT entry FROM gameobject_loot_template WHERE entry IN (SELECT data1 FROM gameobject_template WHERE entry IN (SELECT id FROM gameobject WHERE spawntimesecsmax > 0))", m_gameobjectLootTemplates);
 
         // skinning loot
         ParseLootConfig("AuctionHouseBot.Loot.Skinning", m_skinningLootConfig);


### PR DESCRIPTION
## 🍰 Pullrequest
This PR fixes the gameobject loot loading query for the AH bot. The `state` column was moved to `gameobject_addon`, which currently leads to an SQL error on startup if the AH bot is enabled. I removed the state condition entirely, since the query results (before state migration including the state condition and after the state migration without the state condition) are the same (tested on wotlk-db only).

### Proof
[- State column was moved to gameobject_addon](https://github.com/cmangos/mangos-wotlk/commit/fb6f93170aaf4219ecc1935f39715ec4e7973994)

### Issues
- None

### How2Test
1. Enable AH bot
2. When starting the application, the SQL error should not appear anymore

### Todo / Checklist
- [X] None
