### PR TITLE
Spell: Ensure Ardent Defender never heals more than max and never less than 0

### DIFF
--- a/src/game/Spells/Scripts/Scripting/ClassScripts/Paladin.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/Paladin.cpp
@@ -258,7 +258,8 @@ struct ArdentDefender : public AuraScript
         remainingDamage *= (100 - reduction) / 100.f;
         if (int32(player->GetHealth()) - remainingDamage > 0 || player->HasAura(66233))
             return;
-        float defenseFactor = (player->GetDefenseSkillValue() - player->GetLevel() * 5) / 140.f;
+        float defenseFactor = std::min(140u, (player->GetDefenseSkillValue() - player->GetLevel() * 5)) / 140.f;
+        defenseFactor = std::max(0.f, defenseFactor);
         healMod *= defenseFactor;
         healMod = player->GetMaxHealth() * (healMod / 100.f);
         remainingDamage = 0;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that Ardent Defender can never heal more than the maximum allowed by the talent rank, and never heal less than 0 (do damage?)