### PR TITLE
Spells: Allow secondary target checking for area auras

### DIFF
--- a/src/game/Spells/Scripts/SpellScript.h
+++ b/src/game/Spells/Scripts/SpellScript.h
@@ -126,6 +126,8 @@ struct AuraScript
     // called on persistent area aura dyngo lifetime end
     virtual void OnPersistentAreaAuraEnd(DynamicObject* /*dynGo*/) const {}
     // called on unit heartbeat
+    virtual bool OnAreaAuraCheckTarget(Aura* aura, Unit* target) const { return true; }
+    // called on AreaAura target checking
     virtual void OnHeartbeat(Aura* /*aura*/) const {}
     // used to override SPELL_AURA_TRANSFORM or SPELL_AURA_MOD_SHAPESHIFT display id - more uses in future
     virtual uint32 GetAuraScriptCustomizationValue(Aura* /*aura*/) const { return 0; }

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -693,6 +693,9 @@ void AreaAura::Update(uint32 diff)
 
             for (auto& target : targets)
             {
+                if (!GetAuraScript()->OnAreaAuraCheckTarget(this, target))
+                    continue;
+
                 // flag for selection is need apply aura to current iteration target
                 bool apply = true;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR allows for checking for secondary targets of AreaAuras (not persistent area auras, that's a different PR) in an AuraScript

Background for this is that some Area Auras of type AREA_AURA_FRIEND are selective about which friends they target. Example: The Ulduar Leviathan hardmode buffs should only apply to the flame leviathan and I believe the adds he spawns when the hardmodes are activated.
