### PR TITLE
Fix channeled spells using the incorrect target for triggered spells

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -1091,7 +1091,8 @@ void Aura::PickTargetsForSpellTrigger(Unit*& triggerCaster, Unit*& triggerTarget
             triggerCaster = GetCaster();
             if (!triggerCaster)
                 triggerCaster = triggerTarget;
-            triggerTarget = triggerCaster->GetTarget(); // This will default to channel target for channels
+            if (!(triggerTarget = GetTarget()))
+                triggerTarget = triggerCaster->GetTarget(); // This will default to channel target for channels
             break;
         case TARGET_UNIT_FRIEND: // Abolish Disease / Poison confirms this
         case TARGET_UNIT_CASTER:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR changes triggered spells to prefer using the target of the original aura over whatever the unit currently has selected / in focus. For example when starting to channel arcane missiles as a player, selecting another unit mid-channel will continue casting at the original target, instead of at the newly selected target.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3461

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create Char
- Level char to 54
- .tele andorhal
- Walk directly backwards and let the Scarlet Invoker attack you

Edit: ok that test example is a bad example as that particular example has been fixed independently already, tho I'm not sure where.

Edit2: ok so it's fixed on WotLK, but not on Vanilla, but vanilla also has the caster as the target for arcane missiles and then deselects all targets entirely... There's more going on then.