### PR TITLE
Player: Fix Power Sync between Client & Server

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1610,7 +1610,7 @@ void Player::Update(const uint32 diff)
     {
         m_regenTimer += diff;
         m_powerUpdateTimer += diff;
-        if (m_powerUpdateTimer >= REGEN_TIME_PRECISE)
+        if (m_regenTimer >= REGEN_TIME_PRECISE)
         {
             RegenerateAll(m_regenTimer);
             if (m_powerUpdateTimer >= REGEN_TIME_FULL)

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1609,7 +1609,8 @@ void Player::Update(const uint32 diff)
     if (IsAlive())
     {
         m_regenTimer += diff;
-        m_healthRegenTimer += diff;
+        if (!IsInCombat())
+            m_healthRegenTimer += diff;
         if (m_regenTimer >= REGEN_TIME_PRECISE)
             RegenerateAll(m_regenTimer);
     }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1619,7 +1619,7 @@ void Player::Update(const uint32 diff)
                 data << GetPackGUID();
                 data << uint8(GetPowerType());
                 data << uint32(GetPower(GetPowerType()));
-                SendMessageToSet(data, GetTypeId() == TYPEID_PLAYER);
+                SendDirectMessage(data);
                 m_powerUpdateTimer -= REGEN_TIME_FULL;
             }
         }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -2415,15 +2415,11 @@ void Player::RewardRage(uint32 damage, uint32 weaponSpeedHitFactor, bool attacke
 
 void Player::RegenerateAll(uint32 diff)
 {
-    if (m_healthRegenTimer >= REGEN_TIME_FULL && (!IsInCombat() || HasAuraType(SPELL_AURA_MOD_REGEN_DURING_COMBAT) ||
-        HasAuraType(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT)))
+    if (m_healthRegenTimer >= REGEN_TIME_FULL)
     {
-        RegenerateHealth(m_healthRegenTimer);
+        if (!IsInCombat() || HasAuraType(SPELL_AURA_MOD_REGEN_DURING_COMBAT) || HasAuraType(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT))
+            RegenerateHealth(m_healthRegenTimer);
         m_healthRegenTimer -= REGEN_TIME_FULL;
-    }
-    else if (IsInCombat())
-    {
-        m_healthRegenTimer -= diff;
     }
 
     switch (getClass())

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1609,8 +1609,7 @@ void Player::Update(const uint32 diff)
     if (IsAlive())
     {
         m_regenTimer += diff;
-        if (!IsInCombat())
-            m_healthRegenTimer += diff;
+        m_healthRegenTimer += diff;
         if (m_regenTimer >= REGEN_TIME_PRECISE)
             RegenerateAll(m_regenTimer);
     }
@@ -2422,6 +2421,11 @@ void Player::RegenerateAll(uint32 diff)
         RegenerateHealth(m_healthRegenTimer);
         m_healthRegenTimer -= REGEN_TIME_FULL;
     }
+    else if (IsInCombat())
+    {
+        m_healthRegenTimer -= diff;
+    }
+
     switch (getClass())
     {
         case CLASS_DRUID:

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -2536,7 +2536,7 @@ void Player::Regenerate(Powers power, uint32 diff)
 
 void Player::RegenerateHealth(uint32 diff)
 {
-    uint32 curValue = GetHealth();
+    float curValue = GetRealHealth();
     uint32 maxValue = GetMaxHealth();
 
     if (curValue >= maxValue) return;
@@ -2568,7 +2568,7 @@ void Player::RegenerateHealth(uint32 diff)
     if (addvalue < 0)
         addvalue = 0;
 
-    ModifyHealth(int32(addvalue * float(diff) / 1000));
+    ModifyHealth(addvalue * float(diff) / 1000);
 }
 
 Creature* Player::GetNPCIfCanInteractWith(ObjectGuid guid, uint32 npcflagmask)

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -2418,7 +2418,7 @@ void Player::RegenerateAll(uint32 diff)
     if (m_healthRegenTimer >= REGEN_TIME_FULL)
     {
         if (!IsInCombat() || HasAuraType(SPELL_AURA_MOD_REGEN_DURING_COMBAT) || HasAuraType(SPELL_AURA_MOD_HEALTH_REGEN_IN_COMBAT))
-            RegenerateHealth(m_healthRegenTimer);
+            RegenerateHealth(REGEN_TIME_FULL);
         m_healthRegenTimer -= REGEN_TIME_FULL;
     }
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1609,8 +1609,17 @@ void Player::Update(const uint32 diff)
     if (IsAlive())
     {
         m_regenTimer += diff;
-        if (m_regenTimer >= REGEN_TIME_FULL)
-            RegenerateAll(m_regenTimer / 100 * 100);
+        m_powerUpdateTimer += diff;
+        RegenerateAll(m_regenTimer);
+        if (m_powerUpdateTimer >= REGEN_TIME_FULL)
+        {
+            WorldPacket data(SMSG_POWER_UPDATE, 8 + 1 + 4);
+            data << GetPackGUID();
+            data << uint8(GetPowerType());
+            data << uint32(GetPower(GetPowerType()));
+            SendMessageToSet(data, GetTypeId() == TYPEID_PLAYER);
+            m_powerUpdateTimer = m_powerUpdateTimer - REGEN_TIME_FULL;
+        }
     }
 
     if (m_deathState == JUST_DIED)

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -1609,20 +1609,8 @@ void Player::Update(const uint32 diff)
     if (IsAlive())
     {
         m_regenTimer += diff;
-        m_powerUpdateTimer += diff;
         if (m_regenTimer >= REGEN_TIME_PRECISE)
-        {
             RegenerateAll(m_regenTimer);
-            if (m_powerUpdateTimer >= REGEN_TIME_FULL)
-            {
-                WorldPacket data(SMSG_POWER_UPDATE, 8 + 1 + 4);
-                data << GetPackGUID();
-                data << uint8(GetPowerType());
-                data << uint32(GetPower(GetPowerType()));
-                SendDirectMessage(data);
-                m_powerUpdateTimer -= REGEN_TIME_FULL;
-            }
-        }
     }
 
     if (m_deathState == JUST_DIED)

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -320,6 +320,10 @@ Unit::Unit() :
         m_createResistance = 0;
 
     m_attacking = nullptr;
+
+    for (float& i : m_unitPower)
+        i = 0.0f;
+
     m_modMeleeHitChance = 0.0f;
     m_modRangedHitChance = 0.0f;
     m_modSpellHitChance = 0.0f;
@@ -10415,16 +10419,17 @@ void Unit::SetHealthPercent(float percent)
     SetHealth(newHealth);
 }
 
-void Unit::SetPower(Powers power, uint32 val, bool withPowerUpdate /*= true*/)
+void Unit::SetPower(Powers power, float val, bool withPowerUpdate /*= true*/)
 {
-    if (GetPower(power) == val)
+    if (GetRealPower(power) == val)
         return;
 
     uint32 maxPower = GetMaxPower(power);
     if (maxPower < val)
         val = maxPower;
 
-    SetStatInt32Value(UNIT_FIELD_POWER1 + power, val);
+    SetStatInt32Value(UNIT_FIELD_POWER1 + power, int32(val));
+    m_unitPower[power] = val;
 
     if (withPowerUpdate)
     {

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -10420,7 +10420,7 @@ void Unit::SetHealthPercent(float percent)
 
 void Unit::SetPower(Powers power, float val, bool withPowerUpdate /*= true*/)
 {
-    if (GetPower(power) == uint32(val))
+    if (GetRealPower(power) == val)
         return;
 
     uint32 maxPower = GetMaxPower(power);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -256,6 +256,7 @@ Unit::Unit() :
     m_charmInfo(nullptr),
     i_motionMaster(this),
     m_regenTimer(0),
+    m_healthRegenTimer(0),
     m_vehicleInfo(nullptr),
     m_combatData(new CombatData(this)),
     m_guardianPetsIterator(m_guardianPets.end()),

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -10421,7 +10421,7 @@ void Unit::SetHealthPercent(float percent)
 
 void Unit::SetPower(Powers power, float val, bool withPowerUpdate /*= true*/)
 {
-    if (GetRealPower(power) == val)
+    if (GetPower(power) == uint32(val))
         return;
 
     uint32 maxPower = GetMaxPower(power);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -256,7 +256,6 @@ Unit::Unit() :
     m_charmInfo(nullptr),
     i_motionMaster(this),
     m_regenTimer(0),
-    m_powerUpdateTimer(0),
     m_vehicleInfo(nullptr),
     m_combatData(new CombatData(this)),
     m_guardianPetsIterator(m_guardianPets.end()),

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -257,6 +257,7 @@ Unit::Unit() :
     i_motionMaster(this),
     m_regenTimer(0),
     m_healthRegenTimer(0),
+    m_unitHealth(0),
     m_vehicleInfo(nullptr),
     m_combatData(new CombatData(this)),
     m_guardianPetsIterator(m_guardianPets.end()),

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -256,6 +256,7 @@ Unit::Unit() :
     m_charmInfo(nullptr),
     i_motionMaster(this),
     m_regenTimer(0),
+    m_powerUpdateTimer(0),
     m_vehicleInfo(nullptr),
     m_combatData(new CombatData(this)),
     m_guardianPetsIterator(m_guardianPets.end()),

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -10376,7 +10376,7 @@ void Unit::SetHealth(float val)
     if (maxHealth < val)
         val = maxHealth;
 
-    SetUInt32Value(UNIT_FIELD_HEALTH, val);
+    SetUInt32Value(UNIT_FIELD_HEALTH, uint32(val));
     m_unitHealth = val;
 
     // group update

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -9070,14 +9070,14 @@ void Unit::HandleExitCombat(bool pvpCombat)
     CallForAllControlledUnits([](Unit* unit) { unit->HandleExitCombat(); }, CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_CHARM | CONTROLLED_TOTEMS);
 }
 
-int32 Unit::ModifyHealth(int32 dVal)
+float Unit::ModifyHealth(float dVal)
 {
     if (dVal == 0)
         return 0;
 
-    int32 curHealth = (int32)GetHealth();
+    float curHealth = GetRealHealth();
 
-    int32 val = dVal + curHealth;
+    float val = dVal + curHealth;
     if (val <= 0)
     {
         SetHealth(0);
@@ -9086,7 +9086,7 @@ int32 Unit::ModifyHealth(int32 dVal)
 
     int32 maxHealth = (int32)GetMaxHealth();
 
-    int32 gain;
+    float gain;
     if (val < maxHealth)
     {
         SetHealth(val);
@@ -10369,13 +10369,14 @@ void Unit::SetLevel(uint32 lvl)
         ((Player*)this)->SetGroupUpdateFlag(GROUP_UPDATE_FLAG_LEVEL);
 }
 
-void Unit::SetHealth(uint32 val)
+void Unit::SetHealth(float val)
 {
     uint32 maxHealth = GetMaxHealth();
     if (maxHealth < val)
         val = maxHealth;
 
     SetUInt32Value(UNIT_FIELD_HEALTH, val);
+    m_unitHealth = val;
 
     // group update
     if (GetTypeId() == TYPEID_PLAYER)

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1406,12 +1406,13 @@ class Unit : public WorldObject
         inline void SetResistance(SpellSchools school, int32 val) { SetInt32Value(UNIT_FIELD_RESISTANCES + school, val); }
 
         uint32 GetHealth()    const { return GetUInt32Value(UNIT_FIELD_HEALTH); }
+        float GetRealHealth() const { return m_unitHealth; }
         uint32 GetMaxHealth() const { return GetUInt32Value(UNIT_FIELD_MAXHEALTH); }
         float GetHealthPercent() const { return (GetHealth() * 100.0f) / GetMaxHealth(); }
-        void SetHealth(uint32 val);
+        void SetHealth(float val);
         void SetMaxHealth(uint32 val);
         void SetHealthPercent(float percent);
-        int32 ModifyHealth(int32 dVal);
+        float ModifyHealth(float dVal);
         float OCTRegenHPPerSpirit() const;
         float OCTRegenMPPerSpirit() const;
 
@@ -2093,6 +2094,7 @@ class Unit : public WorldObject
                    form != FORM_SHADOW && form != FORM_STEALTH;
         }
 
+        float m_unitHealth;
         float m_unitPower[POWER_RUNIC_POWER + 1];
 
         float m_modMeleeHitChance;

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -2670,6 +2670,7 @@ class Unit : public WorldObject
 
         uint32 m_reactiveTimer[MAX_REACTIVE];
         uint32 m_regenTimer;
+        uint32 m_powerUpdateTimer;
         uint32 m_lastManaUseTimer;
 
         bool m_canDodge;

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -2673,6 +2673,7 @@ class Unit : public WorldObject
 
         uint32 m_reactiveTimer[MAX_REACTIVE];
         uint32 m_regenTimer;
+        uint32 m_healthRegenTimer;
         uint32 m_lastManaUseTimer;
 
         bool m_canDodge;

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -2673,7 +2673,6 @@ class Unit : public WorldObject
 
         uint32 m_reactiveTimer[MAX_REACTIVE];
         uint32 m_regenTimer;
-        uint32 m_powerUpdateTimer;
         uint32 m_lastManaUseTimer;
 
         bool m_canDodge;

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1418,10 +1418,11 @@ class Unit : public WorldObject
         Powers GetPowerType() const { return Powers(GetByteValue(UNIT_FIELD_BYTES_0, UNIT_BYTES_0_OFFSET_POWER_TYPE)); }
         void SetPowerType(Powers new_powertype, bool sendUpdate = true);
         uint32 GetPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_POWER1 + power); }
+        float GetRealPower(Powers power) const { return m_unitPower[power]; }
         uint32 GetMaxPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_MAXPOWER1 + power); }
         float GetPowerPercent() const { return (GetMaxPower(GetPowerType()) == 0) ? 0.0f : (GetPower(GetPowerType()) * 100.0f) / GetMaxPower(GetPowerType()); }
         float GetPowerPercent(Powers power) const { return (GetMaxPower(power) == 0) ? 0.0f : (GetPower(power) * 100.0f) / GetMaxPower(power); }
-        void SetPower(Powers power, uint32 val, bool withPowerUpdate = true);
+        void SetPower(Powers power, float val, bool withPowerUpdate = true);
         void SetMaxPower(Powers power, uint32 val);
         int32 ModifyPower(Powers power, int32 dVal);
         void ApplyPowerMod(Powers power, uint32 val, bool apply);
@@ -2091,6 +2092,8 @@ class Unit : public WorldObject
             return form != FORM_NONE && form != FORM_BATTLESTANCE && form != FORM_BERSERKERSTANCE && form != FORM_DEFENSIVESTANCE &&
                    form != FORM_SHADOW && form != FORM_STEALTH;
         }
+
+        float m_unitPower[POWER_RUNIC_POWER + 1];
 
         float m_modMeleeHitChance;
         float m_modRangedHitChance;

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -215,7 +215,7 @@ void Map::LoadMapAndVMap(int gx, int gy)
 
 Map::Map(uint32 id, time_t expiry, uint32 InstanceId, uint8 SpawnMode)
     : i_mapEntry(sMapStore.LookupEntry(id)), i_spawnMode(SpawnMode),
-      i_id(id), i_InstanceId(InstanceId), m_unloadTimer(0),
+      i_id(id), i_InstanceId(InstanceId), m_unloadTimer(0), m_clientUpdateTimer(0),
       m_VisibleDistance(DEFAULT_VISIBILITY_DISTANCE), m_persistentState(nullptr),
       m_activeNonPlayersIter(m_activeNonPlayers.end()), m_onEventNotifiedIter(m_onEventNotifiedObjects.end()),
       i_gridExpiry(expiry), m_TerrainData(sTerrainMgr.LoadTerrain(id)),
@@ -874,7 +874,12 @@ void Map::Update(const uint32& t_diff)
 #endif
 
     // Send world objects and item update field changes
-    SendObjectUpdates();
+    m_clientUpdateTimer += t_diff;
+    if (m_clientUpdateTimer >= 333)
+    {
+        m_clientUpdateTimer -= 333;
+        SendObjectUpdates();
+    }
 
     // Don't unload grids if it's battleground, since we may have manually added GOs,creatures, those doesn't load from DB at grid re-load !
     // This isn't really bother us, since as soon as we have instanced BG-s, the whole map unloads as the BG gets ended

--- a/src/game/Maps/Map.h
+++ b/src/game/Maps/Map.h
@@ -468,6 +468,7 @@ class Map : public GridRefManager<NGridType>
         uint32 i_id;
         uint32 i_InstanceId;
         uint32 m_unloadTimer;
+        uint32 m_clientUpdateTimer;
         float m_VisibleDistance;
         MapPersistentState* m_persistentState;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes the player power not being synced between client and server. As soon as the player sees the required amount of power to cast a spell on the client, the player should also be able to cast this spell. This PR enables that functionality.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3084

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create Rogue
- Go to any attackable mob
- Spam Sinister Strike while keeping an eye on your energy bar

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Confirm this is the correct:tm: way to do things
- [ ] Measure performance impact for multiple players (for 1 player the short loop requires between 0µs and 1µs, the long loop between 8µs and 11µs)
