### PR TITLE
Fix crash in BattleGroundWS.cpp due to wrong argument passed to IsFlagPickedUp()

### DIFF
--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -95,8 +95,7 @@ void BattleGroundWS::Update(uint32 diff)
             {
                 for (uint8 i = 0; i < PVP_TEAM_COUNT; ++i)
                 {
-                    Team playerTeam = GetTeamIdByTeamIndex((PvpTeamIndex)i);
-                    if (IsFlagPickedUp(playerTeam))
+                    if (IsFlagPickedUp((PvpTeamIndex)i))
                         if (Player* player = GetBgMap()->GetPlayer(GetFlagCarrierGuid((PvpTeamIndex)i)))
                             player->CastSpell(player, BG_WS_SPELL_FOCUSED_ASSAULT, TRIGGERED_OLD_TRIGGERED);
                 }
@@ -106,8 +105,7 @@ void BattleGroundWS::Update(uint32 diff)
             {
                 for (uint8 i = 0; i < PVP_TEAM_COUNT; ++i)
                 {
-                    Team playerTeam = GetTeamIdByTeamIndex((PvpTeamIndex)i);
-                    if (IsFlagPickedUp(playerTeam))
+                    if (IsFlagPickedUp((PvpTeamIndex)i))
                     {
                         if (Player* player = GetBgMap()->GetPlayer(GetFlagCarrierGuid((PvpTeamIndex)i)))
                         {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Valid for TBC and WotLK. Classic does not have this mechanic.

`bool IsFlagPickedUp(uint8 teamIdx))` expects to receive an index for `m_flagCarrier`, but a `Team` value was passed instead, causing a crash.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
