### PR TITLE
Fix crash due to SpellCastTargets::setItemTarget() not resetting item target properly

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -177,13 +177,20 @@ void SpellCastTargets::setGOTarget(GameObject* target)
 
 void SpellCastTargets::setItemTarget(Item* item)
 {
-    if (!item)
-        return;
-
-    m_itemTarget = item;
-    m_itemTargetGUID = item->GetObjectGuid();
-    m_itemTargetEntry = item->GetEntry();
-    m_targetMask |= TARGET_FLAG_ITEM;
+    if (item)
+    {
+        m_itemTarget = item;
+        m_itemTargetGUID = item->GetObjectGuid();
+        m_itemTargetEntry = item->GetEntry();
+        m_targetMask |= TARGET_FLAG_ITEM;
+    }
+    else
+    {
+        m_itemTarget = nullptr;
+        m_itemTargetGUID = ObjectGuid();
+        m_itemTargetEntry = 0;
+        m_targetMask &= ~TARGET_FLAG_ITEM;
+    }
 }
 
 void SpellCastTargets::setTradeItemTarget(Player* caster)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Valid for Classic, TBC and WotLK.

`setItemTarget()` is called with `nullptr` argument ([here](https://github.com/cmangos/mangos-wotlk/blob/master/src/game/Spells/Spell.cpp#L5308) and [here](https://github.com/cmangos/mangos-wotlk/blob/master/src/game/Spells/Spell.cpp#L8937)) but currently this does nothing, causing a crash eventually.

Don't have a way to reproduce this, sadly.

I got this crashlog from ASAN (using [celguar's PlayerBots](https://github.com/celguar/mangosbot-bots/commits/master) so line numbers might be different):
<details>
<summary>Crashlog</summary>

```
=================================================================
==5792==ERROR: AddressSanitizer: heap-use-after-free on address 0x12244fb1e49c at pc 0x7ff6e9fc1a9c bp 0x0035bd4ff030 sp 0x0035bd4ff038
WRITE of size 1 at 0x12244fb1e49c thread T6
    #0 0x7ff6e9fc1a9b in Spell::~Spell(void) C:\Server\Source\src\game\Spells\Spell.cpp:497
    #1 0x7ff6e9fc2bd3 in Spell::`scalar deleting dtor'(unsigned int) (C:\Server\Build\bin\x64_RelWithDebInfo\mangosd.exe+0x140822bd3)
    #2 0x7ff6e9fc1d3a in SpellEvent::~SpellEvent(void) C:\Server\Source\src\game\Spells\Spell.cpp:7486
    #3 0x7ff6e9fc2c13 in SpellEvent::`scalar deleting dtor'(unsigned int) (C:\Server\Build\bin\x64_RelWithDebInfo\mangosd.exe+0x140822c13)
    #4 0x7ff6eafb1223 in std::_Tree<std::_Tmap_traits<unsigned __int64,BasicEvent *,std::less<unsigned __int64>,std::allocator<std::pair<unsigned __int64 const ,BasicEvent *> >,1> >::begin C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\xtree:1127
    #5 0x7ff6eafb1223 in EventProcessor::Update(unsigned int) C:\Server\Source\src\framework\Utilities\EventProcessor.cpp:39
    #6 0x7ff6e9e2f87c in Unit::Update(unsigned int) C:\Server\Source\src\game\Entities\Unit.cpp:504
    #7 0x7ff6e99a081e in Player::Update(unsigned int) C:\Server\Source\src\game\Entities\Player.cpp:1444
    #8 0x7ff6e9dbae90 in Map::Update(unsigned int const &) C:\Server\Source\src\game\Maps\Map.cpp:825
    #9 0x7ff6e9ba8942 in MapUpdateWorker::execute(void) C:\Server\Source\src\game\Maps\MapWorkers.h:52
    #10 0x7ff6ea072710 in MapUpdater::WorkerThread(void) C:\Server\Source\src\game\Maps\MapUpdater.cpp:96
    #11 0x7ff6ea0717fb in std::invoke C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\type_traits:1768
    #12 0x7ff6ea0717fb in std::thread::_Invoke<class std::tuple<void (__cdecl MapUpdater::*)(void), class MapUpdater *>, 0, 1>(void *) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:55
    #13 0x7ffd663a1bb1  (C:\Windows\System32\ucrtbase.dll+0x180021bb1)
    #14 0x7ffce3a037ce in __asan::AsanThread::ThreadStart(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_thread.cpp:277
    #15 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #16 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

0x12244fb1e49c is located 156 bytes inside of 168-byte region [0x12244fb1e400,0x12244fb1e4a8)
freed by thread T8 here:
    #0 0x7ff6eafe7413 in operator delete(void *, unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41
    #1 0x7ff6e9ecfe65 in Item::`scalar deleting dtor'(unsigned int) (C:\Server\Build\bin\x64_RelWithDebInfo\mangosd.exe+0x14072fe65)
    #2 0x7ff6e9ed6a2c in Item::SetState(enum ItemUpdateState, class Player *) C:\Server\Source\src\game\Entities\Item.cpp:749
    #3 0x7ff6e995a718 in Player::DestroyItem(unsigned char, unsigned char, bool) C:\Server\Source\src\game\Entities\Player.cpp:10877
    #4 0x7ff6e9bdee47 in Loot::Release(class Player *) C:\Server\Source\src\game\Loot\LootMgr.cpp:1427
    #5 0x7ff6ea7e65ce in PlayerbotAI::UpdateAI(unsigned int, bool) C:\Server\Source\src\modules\Bots\playerbot\PlayerbotAI.cpp:278
    #6 0x7ff6e99a134b in Player::UpdateAI(unsigned int, bool) C:\Server\Source\src\game\Entities\Player.cpp:1645
    #7 0x7ff6e9dbaea8 in Map::Update(unsigned int const &) C:\Server\Source\src\game\Maps\Map.cpp:828
    #8 0x7ff6e9ba8942 in MapUpdateWorker::execute(void) C:\Server\Source\src\game\Maps\MapWorkers.h:52
    #9 0x7ff6ea072710 in MapUpdater::WorkerThread(void) C:\Server\Source\src\game\Maps\MapUpdater.cpp:96
    #10 0x7ff6ea0717fb in std::invoke C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\type_traits:1768
    #11 0x7ff6ea0717fb in std::thread::_Invoke<class std::tuple<void (__cdecl MapUpdater::*)(void), class MapUpdater *>, 0, 1>(void *) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:55
    #12 0x7ffd663a1bb1  (C:\Windows\System32\ucrtbase.dll+0x180021bb1)
    #13 0x7ffce3a037ce in __asan::AsanThread::ThreadStart(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_thread.cpp:277
    #14 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #15 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

previously allocated by thread T8 here:
    #0 0x7ff6eafe7385 in operator new(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40
    #1 0x7ff6e9ed3f94 in NewItemOrBag(struct ItemPrototype const *) C:\Server\Source\src\game\Entities\Bag.h:79
    #2 0x7ff6e9ed12c1 in Item::CreateItem(unsigned int, unsigned int, class Player const *, unsigned int) C:\Server\Source\src\game\Entities\Item.cpp:1093
    #3 0x7ff6e999c306 in Player::StoreNewItem(class std::vector<struct ItemPosCount, class std::allocator<struct ItemPosCount>> const &, unsigned int, bool, int) C:\Server\Source\src\game\Entities\Player.cpp:10366
    #4 0x7ff6e9be0ae2 in Loot::SendItem(class Player *, struct LootItem *, bool) C:\Server\Source\src\game\Loot\LootMgr.cpp:2002
    #5 0x7ff6ea1764d1 in WorldSession::HandleAutostoreLootItemOpcode(class WorldPacket &) C:\Server\Source\src\game\Loot\LootHandler.cpp:65
    #6 0x7ff6eabf30b3 in ai::StoreLootAction::Execute(class ai::Event &) C:\Server\Source\src\modules\Bots\playerbot\strategy\actions\LootAction.cpp:326
    #7 0x7ff6eaa91f64 in ai::Engine::ListenAndExecute(class ai::Action *, class ai::Event &) C:\Server\Source\src\modules\Bots\playerbot\strategy\Engine.cpp:683
    #8 0x7ff6eaa8f840 in ai::Engine::DoNextAction(class Unit *, int, bool, bool) C:\Server\Source\src\modules\Bots\playerbot\strategy\Engine.cpp:232
    #9 0x7ff6ea7c6fdf in PlayerbotAI::DoNextAction(bool) C:\Server\Source\src\modules\Bots\playerbot\PlayerbotAI.cpp:1525
    #10 0x7ff6ea7e7ffa in PlayerbotAI::UpdateAIInternal(unsigned int, bool) C:\Server\Source\src\modules\Bots\playerbot\PlayerbotAI.cpp:829
    #11 0x7ff6ea7e76c8 in PlayerbotAI::UpdateAI(unsigned int, bool) C:\Server\Source\src\modules\Bots\playerbot\PlayerbotAI.cpp:428
    #12 0x7ff6e99a134b in Player::UpdateAI(unsigned int, bool) C:\Server\Source\src\game\Entities\Player.cpp:1645
    #13 0x7ff6e9dbaea8 in Map::Update(unsigned int const &) C:\Server\Source\src\game\Maps\Map.cpp:828
    #14 0x7ff6e9ba8942 in MapUpdateWorker::execute(void) C:\Server\Source\src\game\Maps\MapWorkers.h:52
    #15 0x7ff6ea072710 in MapUpdater::WorkerThread(void) C:\Server\Source\src\game\Maps\MapUpdater.cpp:96
    #16 0x7ff6ea0717fb in std::invoke C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\type_traits:1768
    #17 0x7ff6ea0717fb in std::thread::_Invoke<class std::tuple<void (__cdecl MapUpdater::*)(void), class MapUpdater *>, 0, 1>(void *) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:55
    #18 0x7ffd663a1bb1  (C:\Windows\System32\ucrtbase.dll+0x180021bb1)
    #19 0x7ffce3a037ce in __asan::AsanThread::ThreadStart(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_thread.cpp:277
    #20 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #21 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

Thread T6 created by T0 here:
    #0 0x7ffce3a059a7 in __asan_wrap_CreateThread D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:163
    #1 0x7ffd663a1896  (C:\Windows\System32\ucrtbase.dll+0x180021896)
    #2 0x7ff6ea072dcf in std::thread::{ctor} C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:88
    #3 0x7ff6ea072dcf in MapUpdater::activate(unsigned __int64) C:\Server\Source\src\game\Maps\MapUpdater.cpp:34
    #4 0x7ff6e9ba0be4 in MapManager::Initialize(void) C:\Server\Source\src\game\Maps\MapManager.cpp:58
    #5 0x7ff6e98a37c6 in World::SetInitialWorldSettings(void) C:\Server\Source\src\game\World\World.cpp:1392
    #6 0x7ff6e9811739 in Master::Run(void) C:\Server\Source\src\mangosd\Master.cpp:124
    #7 0x7ff6e97f924b in main C:\Server\Source\src\mangosd\Main.cpp:211
    #8 0x7ff6eafe860f in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #9 0x7ff6eafe860f in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #11 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

Thread T8 created by T0 here:
    #0 0x7ffce3a059a7 in __asan_wrap_CreateThread D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:163
    #1 0x7ffd663a1896  (C:\Windows\System32\ucrtbase.dll+0x180021896)
    #2 0x7ff6ea072dcf in std::thread::{ctor} C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:88
    #3 0x7ff6ea072dcf in MapUpdater::activate(unsigned __int64) C:\Server\Source\src\game\Maps\MapUpdater.cpp:34
    #4 0x7ff6e9ba0be4 in MapManager::Initialize(void) C:\Server\Source\src\game\Maps\MapManager.cpp:58
    #5 0x7ff6e98a37c6 in World::SetInitialWorldSettings(void) C:\Server\Source\src\game\World\World.cpp:1392
    #6 0x7ff6e9811739 in Master::Run(void) C:\Server\Source\src\mangosd\Master.cpp:124
    #7 0x7ff6e97f924b in main C:\Server\Source\src\mangosd\Main.cpp:211
    #8 0x7ff6eafe860f in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #9 0x7ff6eafe860f in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #11 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

SUMMARY: AddressSanitizer: heap-use-after-free C:\Server\Source\src\game\Spells\Spell.cpp:497 in Spell::~Spell(void)
Shadow bytes around the buggy address:
  0x044ad90e3c40: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x044ad90e3c50: 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa
  0x044ad90e3c60: fa fa 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x044ad90e3c70: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
  0x044ad90e3c80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x044ad90e3c90: fd fd fd[fd]fd fa fa fa fa fa fa fa fa fa 00 00
  0x044ad90e3ca0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x044ad90e3cb0: 00 00 00 00 fa fa fa fa fa fa fa fa fd fd fd fd
  0x044ad90e3cc0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x044ad90e3cd0: fd fd fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x044ad90e3ce0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==5792==ABORTING
```
</details>

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Could not find a way to reproduce this.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
