### PR TITLE
Pet: fix heap-use-after-free due to trying to unsummon an already unsummoned pet

### DIFF
--- a/src/game/Entities/Pet.cpp
+++ b/src/game/Entities/Pet.cpp
@@ -769,6 +769,10 @@ bool Pet::CanTakeMoreActiveSpells(uint32 spellid)
 
 void Pet::Unsummon(PetSaveMode mode, Unit* owner /*= nullptr*/)
 {
+    // do not attempt to unsummon pet if already unsummoned
+    if (m_removed)
+        return;
+
     if (!owner)
         owner = GetOwner();
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Server kept crashing without crashlog, so I hooked it up to ASAN and got this:

<details>
<summary>Crashlog</summary>

```
==2612==ERROR: AddressSanitizer: heap-use-after-free on address 0x1242368d1112 at pc 0x7ff63b3a69e1 bp 0x00c4308ff540 sp 0x00c4308ff548
READ of size 1 at 0x1242368d1112 thread T11
    #0 0x7ff63b3a69e0 in Object::GetTypeId(void) const C:\Server\Source\src\game\Entities\Object.h:415
    #1 0x7ff63c0629ba in Map::RemoveAllObjectsInRemoveList(void) C:\Server\Source\src\game\Maps\Map.cpp:1445
    #2 0x7ff63baa20c2 in MapManager::RemoveAllObjectsInRemoveList(void) C:\Server\Source\src\game\Maps\MapManager.cpp:231
    #3 0x7ff63b26223f in World::Update(unsigned int) C:\Server\Source\src\game\World\World.cpp:1724
    #4 0x7ff63b15a6f9 in WorldRunnable::run(void) C:\Server\Source\src\mangosd\WorldRunnable.cpp:55
    #5 0x7ff63b205818 in MaNGOS::Thread::ThreadTask(void *) C:\Server\Source\src\shared\Multithreading\Threading.cpp:84
    #6 0x7ff63b206416 in std::invoke<void (__cdecl *)(void *), void *>(void (__cdecl *&&)(void *), void *&&) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\type_traits:1762
    #7 0x7ff63b205e55 in std::thread::_Invoke<class std::tuple<void (__cdecl *)(void *), void *>, 0, 1>(void *) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:55
    #8 0x7ffce04c300f  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800b300f)
    #9 0x7ffccb8b37ce in __asan::AsanThread::ThreadStart(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_thread.cpp:277
    #10 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #11 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

0x1242368d1112 is located 18 bytes inside of 10048-byte region [0x1242368d1100,0x1242368d3840)
freed by thread T11 here:
    #0 0x7ff63e7c19c3 in operator delete(void *, unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41
    #1 0x7ff63c424b60 in Pet::`scalar deleting dtor'(unsigned int) (C:\Server\Build\bin\x64_Debug\mangosd.exe+0x141404b60)
    #2 0x7ff63c08ac61 in Map::Remove<class Creature>(class Creature *, bool) C:\Server\Source\src\game\Maps\Map.cpp:1072
    #3 0x7ff63c062ad2 in Map::RemoveAllObjectsInRemoveList(void) C:\Server\Source\src\game\Maps\Map.cpp:1464
    #4 0x7ff63baa20c2 in MapManager::RemoveAllObjectsInRemoveList(void) C:\Server\Source\src\game\Maps\MapManager.cpp:231
    #5 0x7ff63b26223f in World::Update(unsigned int) C:\Server\Source\src\game\World\World.cpp:1724
    #6 0x7ff63b15a6f9 in WorldRunnable::run(void) C:\Server\Source\src\mangosd\WorldRunnable.cpp:55
    #7 0x7ff63b205818 in MaNGOS::Thread::ThreadTask(void *) C:\Server\Source\src\shared\Multithreading\Threading.cpp:84
    #8 0x7ff63b206416 in std::invoke<void (__cdecl *)(void *), void *>(void (__cdecl *&&)(void *), void *&&) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\type_traits:1762
    #9 0x7ff63b205e55 in std::thread::_Invoke<class std::tuple<void (__cdecl *)(void *), void *>, 0, 1>(void *) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:55
    #10 0x7ffce04c300f  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800b300f)
    #11 0x7ffccb8b37ce in __asan::AsanThread::ThreadStart(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_thread.cpp:277
    #12 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #13 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

previously allocated by thread T11 here:
    #0 0x7ff63e7c1935 in operator new(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40
    #1 0x7ff63b3e858d in Player::LoadPet(void) C:\Server\Source\src\game\Entities\Player.cpp:16085
    #2 0x7ff63c97d9ba in WorldSession::HandlePlayerLogin(class LoginQueryHolder *) C:\Server\Source\src\game\Entities\CharacterHandler.cpp:932
    #3 0x7ff63c982e85 in PlayerbotHolder::HandlePlayerBotLoginCallback(class QueryResult *, class SqlQueryHolder *) C:\Server\Source\src\game\Entities\CharacterHandler.cpp:136
    #4 0x7ff63c98afca in MaNGOS::_Callback<class PlayerbotHolder, class QueryResult *, class SqlQueryHolder *, void, void>::_Execute(void) C:\Server\Source\src\framework\Utilities\Callback.h:117
    #5 0x7ff63c989349 in MaNGOS::_IQueryCallback<class MaNGOS::_Callback<class PlayerbotHolder, class QueryResult *, class SqlQueryHolder *, void, void>>::Execute(void) C:\Server\Source\src\framework\Utilities\Callback.h:430
    #6 0x7ff63b23e527 in SqlResultQueue::Update(void) C:\Server\Source\src\shared\Database\SqlOperations.cpp:110
    #7 0x7ff63b1bf0c8 in Database::ProcessResultQueue(void) C:\Server\Source\src\shared\Database\Database.cpp:201
    #8 0x7ff63b264a34 in World::UpdateResultQueue(void) C:\Server\Source\src\game\World\World.cpp:2245
    #9 0x7ff63b262126 in World::Update(unsigned int) C:\Server\Source\src\game\World\World.cpp:1695
    #10 0x7ff63b15a6f9 in WorldRunnable::run(void) C:\Server\Source\src\mangosd\WorldRunnable.cpp:55
    #11 0x7ff63b205818 in MaNGOS::Thread::ThreadTask(void *) C:\Server\Source\src\shared\Multithreading\Threading.cpp:84
    #12 0x7ff63b206416 in std::invoke<void (__cdecl *)(void *), void *>(void (__cdecl *&&)(void *), void *&&) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\type_traits:1762
    #13 0x7ff63b205e55 in std::thread::_Invoke<class std::tuple<void (__cdecl *)(void *), void *>, 0, 1>(void *) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:55
    #14 0x7ffce04c300f  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800b300f)
    #15 0x7ffccb8b37ce in __asan::AsanThread::ThreadStart(unsigned __int64) D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_thread.cpp:277
    #16 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #17 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

Thread T11 created by T0 here:
    #0 0x7ffccb8b59a7 in __asan_wrap_CreateThread D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win.cpp:163
    #1 0x7ffce04c387e  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800b387e)
    #2 0x7ff63b206003 in std::thread::_Start<void (__cdecl *)(void *), void *>(void (__cdecl *&&)(void *), void *&&) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:73
    #3 0x7ff63b205b74 in std::thread::thread<void (__cdecl *)(void *), void *, 0>(void (__cdecl *&&)(void *), void *&&) C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.37.32822\include\thread:88
    #4 0x7ff63b204a22 in MaNGOS::Thread::Thread(class MaNGOS::Runnable *) C:\Server\Source\src\shared\Multithreading\Threading.cpp:31
    #5 0x7ff63b0d9b8f in Master::Run(void) C:\Server\Source\src\mangosd\Master.cpp:141
    #6 0x7ff63b0c6022 in main C:\Server\Source\src\mangosd\Main.cpp:211
    #7 0x7ff63e7c36f8 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #8 0x7ff63e7c364d in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #9 0x7ff63e7c350d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #10 0x7ff63e7c376d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #11 0x7ffd66ad7033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #12 0x7ffd68482650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)

SUMMARY: AddressSanitizer: heap-use-after-free C:\Server\Source\src\game\Entities\Object.h:415 in Object::GetTypeId(void) const
Shadow bytes around the buggy address:
  0x043e7c19a1d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x043e7c19a1e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x043e7c19a1f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x043e7c19a200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x043e7c19a210: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x043e7c19a220: fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x043e7c19a230: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x043e7c19a240: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x043e7c19a250: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x043e7c19a260: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x043e7c19a270: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==2612==ABORTING

```
</details>

From the very little I understand from this, Map is trying to unsummon a pet while it's already being unsummoned, causing memory corruption.

No way to reproduce, but it happened after letting celguar's Playerbots run for ~20 minutes.
This could just be due to some quirk of playerbots and not happen during normal usage, but even so I don't think this safeguard would hurt to have.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
