### PR TITLE
Dialogue: Fix dialogue helper not working with BCTs

### DIFF
--- a/src/game/AI/ScriptDevAI/include/sc_instance.cpp
+++ b/src/game/AI/ScriptDevAI/include/sc_instance.cpp
@@ -417,6 +417,18 @@ void DialogueHelper::DoNextDialogueStep()
                 DoScriptText(iTextEntry, pSpeaker);
         }
     }
+    else if (uiSpeakerEntry && iTextEntry > 0)
+    {
+        // Use Speaker if directly provided
+        Creature* pSpeaker = GetSpeakerByEntry(uiSpeakerEntry);
+        if (m_instance && !pSpeaker)                       // Get Speaker from instance
+        {
+            pSpeaker = m_instance->GetSingleCreatureFromStorage(uiSpeakerEntry);
+        }
+
+        if (pSpeaker)
+            DoBroadcastText(iTextEntry, pSpeaker, GetDialogueTarget());
+    }
 
     JustDidDialogueStep(m_dialogueArray ?  m_currentEntry->textEntry : m_currentEntryTwoSide->textEntry);
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR makes the DialogueHelper compatible with BroadcastText IDs
(Different from TBC and Classic)