### PR TITLE
Clean up feign death state

### DIFF
--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -2436,7 +2436,14 @@ class Unit : public WorldObject
         void SetImmobilizedState(bool apply, bool stun = false, bool logout = false);
         ///----------End of crowd control methods----------
 
-        bool IsFeigningDeath() const { return HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH); }
+        bool IsFeigningDeath() const
+        {
+            if (hasUnitState(UNIT_STAT_FEIGN_DEATH))
+            {
+                return true;
+            }
+            return HasFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
+        }
         bool IsFeigningDeathSuccessfully() const { return hasUnitState(UNIT_STAT_FEIGN_DEATH); }
         void SetFeignDeath(bool apply, ObjectGuid casterGuid = ObjectGuid(), uint32 spellID = 0, bool dynamic = true, bool success = true);
         virtual bool IsIgnoringFeignDeath() const { return false; }


### PR DESCRIPTION
## 🍰 Pullrequest
I noticed that the Ingvar encounter is broken at the moment: when he "dies" after phase 1, he stays marked as dead and is unlootable even after you kill him again. After a little digging with the debugger it seems like we are not clearing the feign death state correctly. This is my probably-wrong attempt at fixing it (it does fix the issue with Ingvar, but I don't know what unintended consequences it might have 🙂)

One thing to investigate is that the animation when Ingvar gets resurrected seems broken by this feign death mechanic (he just lies on the floor and then suddenly turns into a standing scourged version of himself, the spinny transformation does not happen).

### Proof
![image](https://github.com/cmangos/mangos-wotlk/assets/601930/ac871524-d442-4e40-864b-b41d2484f1c7)
![image](https://github.com/cmangos/mangos-wotlk/assets/601930/6055c4a8-7361-4255-a15c-d23bc9c63950)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
Fixes #3537

### How2Test
In Utgarde Keep:
`.npc tempspawn 23954 100000`

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
