### PR TITLE
Fix mistake when updating score in Alterac Valley

### DIFF
--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -273,7 +273,7 @@ void BattleGroundAV::UpdateScore(PvpTeamIndex teamIdx, int32 points)
 
     // note: to remove reinforcements points must be negative, for adding reinforcements points must be positive
     int32 newVal = std::max(GetBgMap()->GetVariableManager().GetVariable(worldStateId) + points, 0);
-    GetBgMap()->GetVariableManager().SetVariable(BG_AV_STATE_SCORE_A, newVal);
+    GetBgMap()->GetVariableManager().SetVariable(worldStateId, newVal);
 
     if (points < 0)
     {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

This error messed up Alterac Valley reinforcements because it would update only Alliance ones regardless.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
