### PR TITLE
Spells: Ensure that Corruption and Seed of Corruption are interchangeable

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -5622,7 +5622,7 @@ bool Unit::RemoveNoStackAurasDueToAuraHolder(SpellAuraHolder* holder)
             {
                 // holder cannot remove higher/stronger rank if it isn't from the same caster
                 // judgement excluded due to invalid comparison of dummy auras
-                if (specific != SPELL_JUDGEMENT && IsSimilarExistingAuraStronger(holder, existing)) // TROLOLO
+                if (!IsSpellSpecificInterchangeable(specific) && IsSimilarExistingAuraStronger(holder, existing)) // TROLOLO
                     return false;
 
                 if (!diminished && sSpellMgr.IsSpellAnotherRankOfSpell(spellId, existingSpellId) && sSpellMgr.IsSpellHigherRankOfSpell(existingSpellId, spellId))

--- a/src/game/Spells/SpellMgr.h
+++ b/src/game/Spells/SpellMgr.h
@@ -2066,6 +2066,18 @@ inline bool IsSpellSpecificIdentical(SpellSpecific specific, SpellSpecific speci
     return false;
 }
 
+inline bool IsSpellSpecificInterchangeable(SpellSpecific specific)
+{
+    switch (specific)
+    {
+        case SPELL_CORRUPTION_DEBUFF:
+        case SPELL_JUDGEMENT:
+            return true;
+        default: break;
+    }
+    return false;
+}
+
 inline bool IsSimilarAuraEffect(SpellEntry const* entry, uint32 effect, SpellEntry const* entry2, uint32 effect2)
 {
     return (entry2->EffectApplyAuraName[effect2] && entry->EffectApplyAuraName[effect] &&


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3652

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create Warlock
- Level Warlock to 80
- Learn 47836 and 47813
- Cast them on a target such that one spell replaces the other

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Testing
- [ ] Refactoring?
