### PR TITLE
Fix NPC name in new mail notification when receiving mails from NPCs

### DIFF
--- a/src/game/Mails/MailHandler.cpp
+++ b/src/game/Mails/MailHandler.cpp
@@ -836,21 +836,9 @@ void WorldSession::HandleQueryNextMailTime(WorldPacket& /**recv_data*/)
                     break;
             }
 
-            data << ObjectGuid(guidType, m->sender); // sender guid
-
-            switch (m->messageType)
-            {
-                case MAIL_AUCTION:
-                case MAIL_CREATURE:
-                case MAIL_GAMEOBJECT:
-                    data << uint32(m->sender);              // sender's id
-                    data << uint32(m->messageType);         // message type
-                    break;
-                default:
-                    data << uint32(0);
-                    data << uint32(0);
-                    break;
-            }
+            data << ObjectGuid(guidType, m->sender);     // sender guid
+            data << static_cast<uint32>(m->sender);      // sender id
+            data << static_cast<uint32>(m->messageType); // message type
 
             data << uint32(m->stationery);
             data << uint32(0xC6000000);                     // float unk, time or something

--- a/src/game/Mails/MailHandler.cpp
+++ b/src/game/Mails/MailHandler.cpp
@@ -824,13 +824,27 @@ void WorldSession::HandleQueryNextMailTime(WorldPacket& /**recv_data*/)
             if (now < m->deliver_time)
                 continue;
 
-            data << ObjectGuid(HIGHGUID_PLAYER, m->sender); // sender guid
+            HighGuid guidType = HIGHGUID_PLAYER;
+
+            switch (m->messageType)
+            {
+                case MAIL_CREATURE:
+                    guidType = HIGHGUID_UNIT;
+                    break;
+                case MAIL_GAMEOBJECT:
+                    guidType = HIGHGUID_GAMEOBJECT;
+                    break;
+            }
+
+            data << ObjectGuid(guidType, m->sender); // sender guid
 
             switch (m->messageType)
             {
                 case MAIL_AUCTION:
-                    data << uint32(m->sender);              // auction house id
-                    data << uint32(MAIL_AUCTION);           // message type
+                case MAIL_CREATURE:
+                case MAIL_GAMEOBJECT:
+                    data << uint32(m->sender);              // sender's id
+                    data << uint32(m->messageType);         // message type
                     break;
                 default:
                     data << uint32(0);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This was fun to track down, even had to parse packets to see where the new mail notification comes from...

If a player receives a mail from a NPC, and that NPC happens to have the same entry as an existing player's guid, then the mail notification would show the player's name instead of the NPC's name.

The packet needs both the highguid and the entry in two separate fields. I tried using either one or the other and it didn't work.

Added it for gameobjects too, since I noticed that type in the mail enum, but did not test it (can gameobjects even send mails?).

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create a new character, edit the guid in the database to 16128.
- Level up a character to 80. This causes the NPC Rhonin (NPC entry: 16128) to send the player a mail.
- Hover the mouse on the new mail notification - it won't show Rhonin, it will show the previously created character's name.
This fixes that.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
