### PR TITLE
Spell: Fix Dream Vision allowing autohit

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -43,6 +43,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (12948,'spell_hakkar_summoned'),
 (13278,'spell_gdr_channel'),
 (13493,'spell_gdr_periodic'),
+(11403,'spell_dream_vision'),
 (11886,'spell_capture_beast'),
 (11887,'spell_capture_hippogryph'),
 (11888,'spell_capture_faerie_dragon'),

--- a/src/game/AI/ScriptDevAI/scripts/world/item_scripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/item_scripts.cpp
@@ -400,6 +400,27 @@ struct GoblinBomb : public SpellScript
     }
 };
 
+// 11403 - Dream Vision
+struct DreamVision : public SpellScript
+{
+    void OnSummon(Spell* /*spell*/, Creature* summon) const override
+    {
+        if (summon->GetEntry() != 7863)
+            return;
+
+        summon->SetHover(true);
+        summon->SetWaterWalk(true);
+        summon->SetFeatherFall(true);
+    }
+
+    void OnRadiusCalculate(Spell* /*spell*/, SpellEffectIndex effIdx, bool /*targetB*/, float& radius) const override
+    {
+        if (effIdx != EFFECT_INDEX_0)
+            return;
+        radius = 2.f;
+    }
+};
+
 void AddSC_item_scripts()
 {
     Script* pNewScript = new Script;
@@ -440,4 +461,5 @@ void AddSC_item_scripts()
     RegisterSpellScript<ArgussianCompass>("spell_argussian_compass");
     RegisterSpellScript<SummonGoblinBomb>("spell_summon_goblin_bomb");
     RegisterSpellScript<GoblinBomb>("spell_goblin_bomb");
+    RegisterSpellScript<DreamVision>("spell_dream_vision");
 }

--- a/src/game/Entities/CreatureSettings.cpp
+++ b/src/game/Entities/CreatureSettings.cpp
@@ -40,6 +40,19 @@ void CreatureSettings::ResetStaticFlags(CreatureStaticFlags staticFlags, Creatur
         m_owner->GetVisibilityData().SetVisibilityDistanceOverride(VisibilityDistanceType::Gigantic);
     if (HasFlag(CreatureStaticFlags3::INFINITE_AOI))
         m_owner->GetVisibilityData().SetVisibilityDistanceOverride(VisibilityDistanceType::Infinite);
+
+    if (HasFlag(CreatureStaticFlags::UNINTERACTIBLE))
+        m_owner->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE);
+    if (HasFlag(CreatureStaticFlags::IMMUNE_TO_PC))
+        m_owner->SetImmuneToPlayer(true);
+    if (HasFlag(CreatureStaticFlags::IMMUNE_TO_NPC))
+        m_owner->SetImmuneToNPC(true);
+
+    if (HasFlag(CreatureStaticFlags2::NO_OWNER_THREAT))
+        m_owner->DisableThreatPropagationToOwner();
+    if (HasFlag(CreatureStaticFlags2::HIDE_BODY))
+        m_owner->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_HIDE_BODY);
+
 }
 
 void CreatureSettings::SetFlag(CreatureStaticFlags flag)

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -2382,16 +2382,6 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
             {
                 switch (GetId())
                 {
-                    case 11403:                             // Dream Vision
-                    {
-                        if (target->IsPlayer())
-                        {
-                            Unit* pet = static_cast<Player*>(target)->GetCharm();
-                            if (pet && pet->GetEntry() == 7863)
-                                pet->SetVisibility(VISIBILITY_OFF);
-                        }
-                        break;
-                    }
                     case 1515:                              // Tame beast
                         if (Unit* caster = GetCaster()) // Wotlk - sniff - adds 1000 threat
                             target->AddThreat(caster, 1000.0f, false, GetSpellSchoolMask(GetSpellProto()), GetSpellProto());


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures the creature summoned by Dream Vision cannot enter combat in any way

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3634

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Go into a zone with enemies
- `.additem 9197`
- Use the item
- try to attack enemies while channeling

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
