### PR TITLE
Config: Implement config override with env vars

### DIFF
--- a/src/game/Anticheat/module/anticheat.conf.dist.in
+++ b/src/game/Anticheat/module/anticheat.conf.dist.in
@@ -3,6 +3,16 @@
 #   This file is intended to be used in a setting where the anticheat should run
 #   purely in a read-only mode.  It will do all of its tasks, but take no action,
 #   aside from sending out notifications.  It is intended for testing purposes.
+#
+# 	To overwrite configuration fields with environment variables
+# 	use the following pattern to generate environment variable names:
+#
+# 		For Enable:
+# 			export Anticheat_Enable=0
+#
+# 		For IPBanDelay.Max:
+# 			export Anticheat_IPBanDelay_Max=120
+#
 
 [AnticheatConf]
 ConfVersion=2017102301

--- a/src/game/Anticheat/module/libanticheat.cpp
+++ b/src/game/Anticheat/module/libanticheat.cpp
@@ -215,7 +215,7 @@ namespace NamreebAnticheat
 {
 void AnticheatLib::Reload()
 {
-    if (!sAnticheatConfig.SetSource(_LIB_ANTICHEAT_CONFIG, "Mangosd_"))
+    if (!sAnticheatConfig.SetSource(_LIB_ANTICHEAT_CONFIG, "Anticheat_"))
         sLog.outError("[Anticheat] Could not find configuration file %s.", _LIB_ANTICHEAT_CONFIG);
 
     // the configuration setting must be loaded before the database data because the current config settings

--- a/src/game/Anticheat/module/libanticheat.cpp
+++ b/src/game/Anticheat/module/libanticheat.cpp
@@ -215,7 +215,7 @@ namespace NamreebAnticheat
 {
 void AnticheatLib::Reload()
 {
-    if (!sAnticheatConfig.SetSource(_LIB_ANTICHEAT_CONFIG))
+    if (!sAnticheatConfig.SetSource(_LIB_ANTICHEAT_CONFIG, "Mangosd_"))
         sLog.outError("[Anticheat] Could not find configuration file %s.", _LIB_ANTICHEAT_CONFIG);
 
     // the configuration setting must be loaded before the database data because the current config settings

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -40,7 +40,7 @@ AuctionHouseBot::~AuctionHouseBot()
 
 void AuctionHouseBot::Initialize()
 {
-    if (!m_ahBotCfg.SetSource(m_configFileName))
+    if (!m_ahBotCfg.SetSource(m_configFileName, "Mangosd_"))
     {
         // set buy/sell chance to 0, this prevents Update() from accessing uninitialized variables
         m_chanceBuy = 0;

--- a/src/mangosd/Main.cpp
+++ b/src/mangosd/Main.cpp
@@ -148,6 +148,8 @@ int main(int argc, char* argv[])
         return 1;
     }
 
+    std::vector<std::string> overriddenConfKeys = sConfig.OverrideWithEnvVariablesIfAny();
+
 #ifndef _WIN32                                               // posix daemon commands need apply after config read
     if (vm.count("s"))
     {
@@ -178,6 +180,8 @@ int main(int argc, char* argv[])
     sLog.outString("Built for %s", _ENDIAN_PLATFORM);
     sLog.outString("Using commit hash(%s) committed on %s", REVISION_ID, REVISION_DATE);
     sLog.outString("Using configuration file %s.", configFile.c_str());
+    for (std::string const& key : overriddenConfKeys)
+        sLog.outString("Configuration field '%s' was overridden with environment variable.", key.c_str());
 
     DETAIL_LOG("%s (Library: %s)", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)

--- a/src/mangosd/Main.cpp
+++ b/src/mangosd/Main.cpp
@@ -141,14 +141,12 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    if (!sConfig.SetSource(configFile))
+    if (!sConfig.SetSource(configFile, "Mangosd_"))
     {
         sLog.outError("Could not find configuration file %s.", configFile.c_str());
         Log::WaitBeforeContinueIfNeed();
         return 1;
     }
-
-    std::vector<std::string> overriddenConfKeys = sConfig.OverrideWithEnvVariablesIfAny();
 
 #ifndef _WIN32                                               // posix daemon commands need apply after config read
     if (vm.count("s"))
@@ -180,8 +178,6 @@ int main(int argc, char* argv[])
     sLog.outString("Built for %s", _ENDIAN_PLATFORM);
     sLog.outString("Using commit hash(%s) committed on %s", REVISION_ID, REVISION_DATE);
     sLog.outString("Using configuration file %s.", configFile.c_str());
-    for (std::string const& key : overriddenConfKeys)
-        sLog.outString("Configuration field '%s' was overridden with environment variable.", key.c_str());
 
     DETAIL_LOG("%s (Library: %s)", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -1,5 +1,15 @@
 #####################################
-# MaNGOS Configuration file         #
+# MaNGOS Configuration file         
+# 
+# 	To overwrite configuration fields with environment variables
+# 	use the following pattern to generate environment variable names:
+#
+# 		For Rate.Health:
+# 			export Mangosd_Rate_Health=1.2
+#
+# 		For DataDir:
+# 			export Mangosd_DataDir=/tmp
+#
 #####################################
 
 [MangosdConf]

--- a/src/realmd/Main.cpp
+++ b/src/realmd/Main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
         Log::WaitBeforeContinueIfNeed();
         return 1;
     }
-    
+
 #ifndef _WIN32                                               // posix daemon commands need apply after config read
     if (vm.count("s"))
     {

--- a/src/realmd/Main.cpp
+++ b/src/realmd/Main.cpp
@@ -120,15 +120,13 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    if (!sConfig.SetSource(configFile))
+    if (!sConfig.SetSource(configFile, "Realmd_"))
     {
         sLog.outError("Could not find configuration file %s.", configFile.c_str());
         Log::WaitBeforeContinueIfNeed();
         return 1;
     }
     
-    std::vector<std::string> overriddenConfKeys = sConfig.OverrideWithEnvVariablesIfAny();
-
 #ifndef _WIN32                                               // posix daemon commands need apply after config read
     if (vm.count("s"))
     {
@@ -161,8 +159,6 @@ int main(int argc, char* argv[])
     sLog.outString("Built for %s", _ENDIAN_PLATFORM);
     sLog.outString("Using commit hash(%s) committed on %s", REVISION_ID, REVISION_DATE);
     sLog.outString("Using configuration file %s.", configFile.c_str());
-    for (std::string const& key : overriddenConfKeys)
-        sLog.outString("Configuration field '%s' was overridden with environment variable.", key.c_str());
 
     ///- Check the version of the configuration file
     uint32 confVersion = sConfig.GetIntDefault("ConfVersion", 0);

--- a/src/realmd/Main.cpp
+++ b/src/realmd/Main.cpp
@@ -126,6 +126,8 @@ int main(int argc, char* argv[])
         Log::WaitBeforeContinueIfNeed();
         return 1;
     }
+    
+    std::vector<std::string> overriddenConfKeys = sConfig.OverrideWithEnvVariablesIfAny();
 
 #ifndef _WIN32                                               // posix daemon commands need apply after config read
     if (vm.count("s"))
@@ -159,6 +161,8 @@ int main(int argc, char* argv[])
     sLog.outString("Built for %s", _ENDIAN_PLATFORM);
     sLog.outString("Using commit hash(%s) committed on %s", REVISION_ID, REVISION_DATE);
     sLog.outString("Using configuration file %s.", configFile.c_str());
+    for (std::string const& key : overriddenConfKeys)
+        sLog.outString("Configuration field '%s' was overridden with environment variable.", key.c_str());
 
     ///- Check the version of the configuration file
     uint32 confVersion = sConfig.GetIntDefault("ConfVersion", 0);

--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -1,5 +1,15 @@
 ############################################
-# MaNGOS realmd configuration file         #
+# MaNGOS realmd configuration file
+#
+# 	To overwrite configuration fields with environment variables
+# 	use the following pattern to generate environment variable names:
+#
+# 		For WrongPass.MaxCount:
+# 			export Realmd_WrongPass_MaxCount=10
+#
+# 		For RealmServerPort:
+# 			export Realmd_RealmServerPort=3333
+#
 ############################################
 
 [RealmdConf]

--- a/src/shared/Config/Config.cpp
+++ b/src/shared/Config/Config.cpp
@@ -18,6 +18,7 @@
 
 #include "Config.h"
 #include "Policies/Singleton.h"
+#include "Util/Util.h"
 #include <mutex>
 
 #include <boost/algorithm/string.hpp>
@@ -25,17 +26,20 @@
 #include <unordered_map>
 #include <string>
 #include <fstream>
+#include <cstdlib>
 
 INSTANTIATE_SINGLETON_1(Config);
+
+std::optional<std::string> EnvVarForIniKey(std::string const& key);
 
 bool Config::SetSource(const std::string& file)
 {
     m_filename = file;
 
-    return Reload();
+    return Reload(true);
 }
 
-bool Config::Reload()
+bool Config::Reload(bool isNewSource)
 {
     std::ifstream in(m_filename, std::ifstream::in);
 
@@ -43,6 +47,7 @@ bool Config::Reload()
         return false;
 
     std::unordered_map<std::string, std::string> newEntries;
+    std::unordered_map<std::string, std::string> normalizedToOriginalKeysMap;
     std::lock_guard<std::mutex> guard(m_configLock);
 
     do
@@ -62,16 +67,44 @@ bool Config::Reload()
         if (equals == std::string::npos)
             return false;
 
-        auto const entry = boost::algorithm::trim_copy(boost::algorithm::to_lower_copy(line.substr(0, equals)));
+        auto const entryRaw = line.substr(0, equals);
+        auto const entry = boost::algorithm::trim_copy(boost::algorithm::to_lower_copy(entryRaw));
         auto const value = boost::algorithm::trim_copy_if(boost::algorithm::trim_copy(line.substr(equals + 1)), boost::algorithm::is_any_of("\""));
 
+        normalizedToOriginalKeysMap[entry] = boost::algorithm::trim_copy(entryRaw);
         newEntries[entry] = value;
     }
     while (in.good());
 
     m_entries = std::move(newEntries);
+    m_normalizedToOriginalKeysMap = std::move(normalizedToOriginalKeysMap);
 
+    if (!isNewSource)
+        OverrideWithEnvVariablesIfAny();
+    
     return true;
+}
+
+std::vector<std::string> Config::OverrideWithEnvVariablesIfAny()
+{
+    std::vector<std::string> overriddenKeys;
+
+    for (auto itr = m_entries.begin(); itr != m_entries.end(); ++itr)
+    {
+        if (itr->first.empty())
+            continue;
+
+        std::string originalKey = m_normalizedToOriginalKeysMap[itr->first];
+        std::optional<std::string> envVar = EnvVarForIniKey(originalKey);
+        if (!envVar)
+            continue;
+
+        itr->second = *envVar;
+
+        overriddenKeys.push_back(originalKey);
+    }
+
+    return overriddenKeys;
 }
 
 bool Config::IsSet(const std::string& name) const
@@ -85,8 +118,21 @@ const std::string Config::GetStringDefault(const std::string& name, const std::s
     auto const nameLower = boost::algorithm::to_lower_copy(name);
 
     auto const entry = m_entries.find(nameLower);
+    
+    if (entry == m_entries.cend())
+    {
+        std::optional<std::string> envVar = EnvVarForIniKey(name);
+        if (envVar)
+        {
+            sLog.outString("Missing key '%s' in config file '%s', recovered with environment '%s' value.", name.c_str(), m_filename.c_str(), envVar->c_str());
 
-    return entry == m_entries.cend() ? def : entry->second;
+            return *envVar;
+        }
+
+        return def;
+    }
+
+    return entry->second;
 }
 
 bool Config::GetBoolDefault(const std::string& name, bool def) const
@@ -113,3 +159,77 @@ float Config::GetFloatDefault(const std::string& name, float def) const
     return std::stof(value);
 }
 
+// Converts ini keys to the environment variable key (upper snake case).
+// Example of conversions:
+//   SomeConfig => SOME_CONFIG
+//   myNestedConfig.opt1 => MY_NESTED_CONFIG_OPT_1
+//   LogDB.Opt.ClearTime => LOG_DB_OPT_CLEAR_TIME
+std::string IniKeyToEnvVarKey(std::string const& key)
+{
+    std::string result;
+
+    const char* str = key.c_str();
+    size_t n = key.length();
+
+    char curr;
+    bool isEnd;
+    bool nextIsUpper;
+    bool currIsNumeric;
+    bool nextIsNumeric;
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        curr = str[i];
+        if (curr == ' ' || curr == '.' || curr == '-')
+        {
+            result += '_';
+            continue;
+        }
+
+        isEnd = i == n - 1;
+        if (!isEnd)
+        {
+            nextIsUpper = isupper(str[i + 1]);
+
+            // handle "aB" to "A_B"
+            if (!isupper(curr) && nextIsUpper)
+            {
+                result += static_cast<char>(std::toupper(curr));
+                result += '_';
+                continue;
+            }
+
+            currIsNumeric = isNumeric(curr);
+            nextIsNumeric = isNumeric(str[i + 1]);
+
+            // handle "a1" to "a_1"
+            if (!currIsNumeric && nextIsNumeric)
+            {
+                result += static_cast<char>(std::toupper(curr));
+                result += '_';
+                continue;
+            }
+
+            // handle "1a" to "1_a"
+            if (currIsNumeric && !nextIsNumeric)
+            {
+                result += static_cast<char>(std::toupper(curr));
+                result += '_';
+                continue;
+            }
+        }
+
+        result += static_cast<char>(std::toupper(curr));
+    }
+    return result;
+}
+
+std::optional<std::string> EnvVarForIniKey(std::string const& key)
+{
+    std::string envKey = "CM_" + IniKeyToEnvVarKey(key);
+    char* val = std::getenv(envKey.c_str());
+    if (!val)
+        return std::nullopt;
+
+    return std::string(val);
+}

--- a/src/shared/Config/Config.cpp
+++ b/src/shared/Config/Config.cpp
@@ -30,16 +30,17 @@
 
 INSTANTIATE_SINGLETON_1(Config);
 
-std::optional<std::string> EnvVarForIniKey(std::string const& key);
+std::optional<std::string> EnvVarForIniKey(std::string const&, std::string const&);
 
-bool Config::SetSource(const std::string& file)
+bool Config::SetSource(const std::string& file, const std::string& envVarPrefix)
 {
     m_filename = file;
+    m_envVarPrefix = envVarPrefix;
 
-    return Reload(true);
+    return Reload();
 }
 
-bool Config::Reload(bool isNewSource)
+bool Config::Reload()
 {
     std::ifstream in(m_filename, std::ifstream::in);
 
@@ -47,7 +48,6 @@ bool Config::Reload(bool isNewSource)
         return false;
 
     std::unordered_map<std::string, std::string> newEntries;
-    std::unordered_map<std::string, std::string> normalizedToOriginalKeysMap;
     std::lock_guard<std::mutex> guard(m_configLock);
 
     do
@@ -67,44 +67,21 @@ bool Config::Reload(bool isNewSource)
         if (equals == std::string::npos)
             return false;
 
-        auto const entryRaw = line.substr(0, equals);
-        auto const entry = boost::algorithm::trim_copy(boost::algorithm::to_lower_copy(entryRaw));
-        auto const value = boost::algorithm::trim_copy_if(boost::algorithm::trim_copy(line.substr(equals + 1)), boost::algorithm::is_any_of("\""));
+        auto const trimmedEntry = boost::algorithm::trim_copy(line.substr(0, equals));
+        auto const entry = boost::algorithm::to_lower_copy(trimmedEntry);
+        auto value = boost::algorithm::trim_copy_if(boost::algorithm::trim_copy(line.substr(equals + 1)), boost::algorithm::is_any_of("\""));
 
-        normalizedToOriginalKeysMap[entry] = boost::algorithm::trim_copy(entryRaw);
+        std::optional<std::string> envValue = EnvVarForIniKey(m_envVarPrefix, trimmedEntry);
+        if (envValue)
+            value = *envValue;
+        
         newEntries[entry] = value;
     }
     while (in.good());
 
     m_entries = std::move(newEntries);
-    m_normalizedToOriginalKeysMap = std::move(normalizedToOriginalKeysMap);
-
-    if (!isNewSource)
-        OverrideWithEnvVariablesIfAny();
     
     return true;
-}
-
-std::vector<std::string> Config::OverrideWithEnvVariablesIfAny()
-{
-    std::vector<std::string> overriddenKeys;
-
-    for (auto itr = m_entries.begin(); itr != m_entries.end(); ++itr)
-    {
-        if (itr->first.empty())
-            continue;
-
-        std::string originalKey = m_normalizedToOriginalKeysMap[itr->first];
-        std::optional<std::string> envVar = EnvVarForIniKey(originalKey);
-        if (!envVar)
-            continue;
-
-        itr->second = *envVar;
-
-        overriddenKeys.push_back(originalKey);
-    }
-
-    return overriddenKeys;
 }
 
 bool Config::IsSet(const std::string& name) const
@@ -121,7 +98,7 @@ const std::string Config::GetStringDefault(const std::string& name, const std::s
     
     if (entry == m_entries.cend())
     {
-        std::optional<std::string> envVar = EnvVarForIniKey(name);
+        std::optional<std::string> envVar = EnvVarForIniKey(m_envVarPrefix, name);
         if (envVar)
         {
             sLog.outString("Missing key '%s' in config file '%s', recovered with environment '%s' value.", name.c_str(), m_filename.c_str(), envVar->c_str());
@@ -159,74 +136,11 @@ float Config::GetFloatDefault(const std::string& name, float def) const
     return std::stof(value);
 }
 
-// Converts ini keys to the environment variable key (upper snake case).
-// Example of conversions:
-//   SomeConfig => SOME_CONFIG
-//   myNestedConfig.opt1 => MY_NESTED_CONFIG_OPT_1
-//   LogDB.Opt.ClearTime => LOG_DB_OPT_CLEAR_TIME
-std::string IniKeyToEnvVarKey(std::string const& key)
+std::optional<std::string> EnvVarForIniKey(std::string const& prefix, std::string const& key)
 {
-    std::string result;
-
-    const char* str = key.c_str();
-    size_t n = key.length();
-
-    char curr;
-    bool isEnd;
-    bool nextIsUpper;
-    bool currIsNumeric;
-    bool nextIsNumeric;
-
-    for (size_t i = 0; i < n; ++i)
-    {
-        curr = str[i];
-        if (curr == ' ' || curr == '.' || curr == '-')
-        {
-            result += '_';
-            continue;
-        }
-
-        isEnd = i == n - 1;
-        if (!isEnd)
-        {
-            nextIsUpper = isupper(str[i + 1]);
-
-            // handle "aB" to "A_B"
-            if (!isupper(curr) && nextIsUpper)
-            {
-                result += static_cast<char>(std::toupper(curr));
-                result += '_';
-                continue;
-            }
-
-            currIsNumeric = isNumeric(curr);
-            nextIsNumeric = isNumeric(str[i + 1]);
-
-            // handle "a1" to "a_1"
-            if (!currIsNumeric && nextIsNumeric)
-            {
-                result += static_cast<char>(std::toupper(curr));
-                result += '_';
-                continue;
-            }
-
-            // handle "1a" to "1_a"
-            if (currIsNumeric && !nextIsNumeric)
-            {
-                result += static_cast<char>(std::toupper(curr));
-                result += '_';
-                continue;
-            }
-        }
-
-        result += static_cast<char>(std::toupper(curr));
-    }
-    return result;
-}
-
-std::optional<std::string> EnvVarForIniKey(std::string const& key)
-{
-    std::string envKey = "CM_" + IniKeyToEnvVarKey(key);
+    std::string escapedKey = key;
+    std::replace(escapedKey.begin(), escapedKey.end(), '.', '_');
+    std::string envKey = prefix + escapedKey;
     char* val = std::getenv(envKey.c_str());
     if (!val)
         return std::nullopt;

--- a/src/shared/Config/Config.cpp
+++ b/src/shared/Config/Config.cpp
@@ -80,7 +80,7 @@ bool Config::Reload()
     while (in.good());
 
     m_entries = std::move(newEntries);
-    
+
     return true;
 }
 

--- a/src/shared/Config/Config.cpp
+++ b/src/shared/Config/Config.cpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <fstream>
 #include <cstdlib>
+#include <optional>
+#include <algorithm>
 
 INSTANTIATE_SINGLETON_1(Config);
 
@@ -143,7 +145,7 @@ std::optional<std::string> EnvVarForIniKey(std::string const& prefix, std::strin
     std::string envKey = prefix + escapedKey;
     char* val = std::getenv(envKey.c_str());
     if (!val)
-        return std::nullopt;
+        return {};
 
     return std::string(val);
 }

--- a/src/shared/Config/Config.h
+++ b/src/shared/Config/Config.h
@@ -32,10 +32,14 @@ class Config
     private:
         std::string m_filename;
         std::unordered_map<std::string, std::string> m_entries; // keys are converted to lower case.  values cannot be.
+        std::unordered_map<std::string, std::string> m_normalizedToOriginalKeysMap;
 
     public:
         bool SetSource(const std::string& file);
-        bool Reload();
+        bool Reload(bool isNewSource = false);
+
+        /// Overrides configuration with environment variables and returns overridden keys
+        std::vector<std::string> OverrideWithEnvVariablesIfAny();
 
         bool IsSet(const std::string& name) const;
 

--- a/src/shared/Config/Config.h
+++ b/src/shared/Config/Config.h
@@ -31,15 +31,12 @@ class Config
 {
     private:
         std::string m_filename;
+        std::string m_envVarPrefix;
         std::unordered_map<std::string, std::string> m_entries; // keys are converted to lower case.  values cannot be.
-        std::unordered_map<std::string, std::string> m_normalizedToOriginalKeysMap;
 
     public:
-        bool SetSource(const std::string& file);
-        bool Reload(bool isNewSource = false);
-
-        /// Overrides configuration with environment variables and returns overridden keys
-        std::vector<std::string> OverrideWithEnvVariablesIfAny();
+        bool SetSource(const std::string& file, const std::string& envVarPrefix);
+        bool Reload();
 
         bool IsSet(const std::string& name) const;
 


### PR DESCRIPTION
## 🍰 Pullrequest
Implement overriding of configuration from the .conf file with environment variables. Environment variables keys are autogenerated based on the keys defined in .conf file. 

Usage example:
```
$ export CM_DATA_DIR=/usr
$ CM_WORLD_SERVER_PORT=8080 ./mangosd
```
### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
