### PR TITLE
GM: Add invincibility command

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -322,6 +322,7 @@ ChatCommand* ChatHandler::getCommandTable()
     {
         { "chat",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMChatCommand,              "", nullptr },
         { "fly",            SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMFlyCommand,               "", nullptr },
+        { "invincible",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMInvincibleCommand,        "", nullptr },
         { "ingame",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleGMListIngameCommand,        "", nullptr },
         { "list",           SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleGMListFullCommand,          "", nullptr },
         { "mountup",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMMountUpCommand,           "", nullptr },

--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -322,7 +322,7 @@ ChatCommand* ChatHandler::getCommandTable()
     {
         { "chat",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMChatCommand,              "", nullptr },
         { "fly",            SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMFlyCommand,               "", nullptr },
-        { "invincible",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMInvincibleCommand,        "", nullptr },
+        { "unkillable",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMUnkillableCommand,        "", nullptr },
         { "ingame",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleGMListIngameCommand,        "", nullptr },
         { "list",           SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleGMListFullCommand,          "", nullptr },
         { "mountup",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleGMMountUpCommand,           "", nullptr },

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -364,6 +364,7 @@ class ChatHandler
         bool HandleGMCommand(char* args);
         bool HandleGMChatCommand(char* args);
         bool HandleGMFlyCommand(char* args);
+        bool HandleGMInvincibleCommand(char* args);
         bool HandleGMListFullCommand(char* args);
         bool HandleGMListIngameCommand(char* args);
         bool HandleGMMountUpCommand(char* args);

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -364,7 +364,7 @@ class ChatHandler
         bool HandleGMCommand(char* args);
         bool HandleGMChatCommand(char* args);
         bool HandleGMFlyCommand(char* args);
-        bool HandleGMInvincibleCommand(char* args);
+        bool HandleGMUnkillableCommand(char* args);
         bool HandleGMListFullCommand(char* args);
         bool HandleGMListIngameCommand(char* args);
         bool HandleGMMountUpCommand(char* args);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -6101,7 +6101,7 @@ bool ChatHandler::HandleGMFlyCommand(char* args)
     return true;
 }
 
-bool ChatHandler::HandleGMInvincibleCommand(char* args)
+bool ChatHandler::HandleGMUnkillableCommand(char* args)
 {
     bool value;
     if (!ExtractOnOff(&args, value))
@@ -6112,7 +6112,7 @@ bool ChatHandler::HandleGMInvincibleCommand(char* args)
     }
     Player* target = m_session->GetPlayer();
     target->SetPreventDeath(value);
-    PSendSysMessage("GM Invincibility %s.", value ? "enabled" : "disabled");
+    PSendSysMessage("GM Unkillability %s.", value ? "enabled" : "disabled");
     return true;
 }
 

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -6101,6 +6101,21 @@ bool ChatHandler::HandleGMFlyCommand(char* args)
     return true;
 }
 
+bool ChatHandler::HandleGMInvincibleCommand(char* args)
+{
+    bool value;
+    if (!ExtractOnOff(&args, value))
+    {
+        SendSysMessage(LANG_USE_BOL);
+        SetSentErrorMessage(true);
+        return false;
+    }
+    Player* target = m_session->GetPlayer();
+    target->SetPreventDeath(value);
+    PSendSysMessage("GM Invincibility %s.", value ? "enabled" : "disabled");
+    return true;
+}
+
 bool ChatHandler::HandlePDumpLoadCommand(char* args)
 {
     char* file = ExtractQuotedOrLiteralArg(&args);

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -24809,6 +24809,19 @@ void Player::SendLootError(ObjectGuid guid, LootError error) const
     SendDirectMessage(data);
 }
 
+void Player::SetPreventDeath(bool enable)
+{
+    if (enable)
+        m_ExtraFlags |= PLAYER_EXTRA_INVINCIBLE;
+    else
+        m_ExtraFlags &= ~PLAYER_EXTRA_INVINCIBLE;
+}
+
+bool Player::IsPreventingDeath() const
+{
+    return m_ExtraFlags & PLAYER_EXTRA_INVINCIBLE;
+}
+
 void Player::ResetDeathTimer()
 {
     // 6 minutes until repop at graveyard

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -24812,14 +24812,14 @@ void Player::SendLootError(ObjectGuid guid, LootError error) const
 void Player::SetPreventDeath(bool enable)
 {
     if (enable)
-        m_ExtraFlags |= PLAYER_EXTRA_INVINCIBLE;
+        m_ExtraFlags |= PLAYER_EXTRA_GM_UNKILLABLE;
     else
-        m_ExtraFlags &= ~PLAYER_EXTRA_INVINCIBLE;
+        m_ExtraFlags &= ~PLAYER_EXTRA_GM_UNKILLABLE;
 }
 
 bool Player::IsPreventingDeath() const
 {
-    return m_ExtraFlags & PLAYER_EXTRA_INVINCIBLE;
+    return m_ExtraFlags & PLAYER_EXTRA_GM_UNKILLABLE;
 }
 
 void Player::ResetDeathTimer()

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -558,7 +558,7 @@ enum PlayerExtraFlags
     PLAYER_EXTRA_WHISP_RESTRICTION  = 0x0200,
 
     // death prevention
-    PLAYER_EXTRA_INVINCIBLE         = 0x0400,
+    PLAYER_EXTRA_GM_UNKILLABLE         = 0x0400,
 };
 
 // 2^n values

--- a/src/game/Entities/Player.h
+++ b/src/game/Entities/Player.h
@@ -556,6 +556,9 @@ enum PlayerExtraFlags
     // other states
     PLAYER_EXTRA_PVP_DEATH          = 0x0100,                // store PvP death status until corpse creating.
     PLAYER_EXTRA_WHISP_RESTRICTION  = 0x0200,
+
+    // death prevention
+    PLAYER_EXTRA_INVINCIBLE         = 0x0400,
 };
 
 // 2^n values
@@ -2522,6 +2525,9 @@ class Player : public Unit
         void SetGhouled(bool enable) { m_isGhouled = enable; }
 
         void SendLootError(ObjectGuid guid, LootError error) const;
+
+        void SetPreventDeath(bool enable);
+        bool IsPreventingDeath() const override;
 
         // cooldown system
         virtual void AddGCD(SpellEntry const& spellEntry, uint32 forcedDuration = 0, bool updateClient = false) override;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds a rudimentary invincibility command to the GM command table:
`.gm invincible on/off`

Using this command allows the GM to test boss mechanics that can interfere with stamina/hp modifications while still being able to experience mechanics that would be suppressed if a spell like the permanent "Divine Shield" would be used to mitigate damage.

### Proof
<!-- Link resources as proof -->

https://github.com/cmangos/mangos-wotlk/assets/3718129/8dfadfd8-e4fc-4bec-8a3d-05ac9f7a4328


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Use `.gm invincible on` to turn on invincibility
- Attack any NPC that attacks back
- Rejoice in invincibility
- Use `.gm invincible off` to turn off invincibility
- once again take damage past death

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Test edge cases
