### PR TITLE
Spell: Add SpellScript for Mind Amplification Dish

### DIFF
--- a/sql/scriptdev2/spell.sql
+++ b/sql/scriptdev2/spell.sql
@@ -975,6 +975,7 @@ INSERT INTO spell_scripts(Id, ScriptName) VALUES
 (67547,'spell_clear_valkyr_essence'),
 (67590,'spell_powering_up'),
 (67630,'spell_leeching_swarm_aura'),
+(67799,'spell_mind_amplification_dish'),
 (68084,'spell_clear_valkyr_touch'),
 (68614,'spell_irresistible_cologne_spill_aura'),
 (68644,'spell_valentine_boss_validate_area'),

--- a/src/game/AI/ScriptDevAI/scripts/world/item_scripts_wotlk.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/item_scripts_wotlk.cpp
@@ -190,6 +190,46 @@ struct BlessingOfAncientKings : public AuraScript
     }
 };
 
+// 67799 - Mind Amplification Dish
+struct MindAmplificationDish : public SpellScript
+{
+    enum
+    {
+        MIND_CONTROL  = 13181,
+        FAIL_CONTROL  = 26740,
+        DULLARD       = 67809,
+        MENTAL_BATTLE = 67810,
+    };
+
+    SpellCastResult OnCheckCast(Spell* spell, bool /*strict*/) const override
+    {
+        if (spell->GetAffectiveCaster()->HasAura(DULLARD))
+            return SPELL_FAILED_CASTER_AURASTATE;
+        return SPELL_CAST_OK;
+    }
+
+    void OnEffectExecute(Spell* spell, SpellEffectIndex effIdx) const override
+    {
+        if (effIdx != EFFECT_INDEX_0)
+            return;
+        Unit* caster = spell->GetAffectiveCaster();
+        Unit* target = spell->GetUnitTarget();
+
+        if (!caster || !target)
+            return;
+
+        uint32 roll = urand(0, 99);
+        if (roll < 75)
+            caster->CastSpell(target, MIND_CONTROL, TRIGGERED_NONE, spell->GetCastItem());
+        else if (roll < 90)
+            caster->CastSpell(target, MENTAL_BATTLE, TRIGGERED_NONE, spell->GetCastItem());
+        else if (roll < 97)
+            target->CastSpell(caster, FAIL_CONTROL, TRIGGERED_NONE, spell->GetCastItem());
+        else
+            caster->CastSpell(nullptr, DULLARD, TRIGGERED_NONE, spell->GetCastItem());
+    }
+};
+
 void AddSC_item_scripts_wotlk()
 {
     RegisterSpellScript<SwiftHandOfJustice>("spell_swift_hand_of_justice");
@@ -198,4 +238,5 @@ void AddSC_item_scripts_wotlk()
     RegisterSpellScript<Icecrown25MeleeTrinket>("spell_icecrown_25_melee_trinket");
     RegisterSpellScript<ValanyrEquipEffect>("spell_valanyr_equip_effect");
     RegisterSpellScript<BlessingOfAncientKings>("spell_blessing_of_ancient_kings");
+    RegisterSpellScript<MindAmplificationDish>("spell_mind_amplification_dish");
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds an implementation for the `Mind Amplification Dish` Engineering thingie.
PR is a draft because I don't have reliable probability numbers, just a very small sample size.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3065

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Learn Spell 67799
- Keep casting spell on enemy humanoids

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] Find reliable probability numbers
- [x] Check if spell really only works against humanoids or if I have to check that manually in OnCheckTarget()
