### PR TITLE
Battleground: Fix EOTS bases being capturable multiple times

### DIFF
--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -2464,7 +2464,7 @@ void GameObject::TickCapturePoint()
 
     /* PROGRESS EVENTS */
     // alliance takes the tower from neutral, contested or horde (if there is no neutral area) to alliance
-    else if (m_captureState != CAPTURE_STATE_PROGRESS_ALLIANCE && m_captureSlider > CAPTURE_SLIDER_MIDDLE + neutralPercent * 0.5f && progressFaction == ALLIANCE)
+    else if ((m_captureState != CAPTURE_STATE_PROGRESS_ALLIANCE && m_captureState != CAPTURE_STATE_CONTEST_ALLIANCE) && m_captureSlider > CAPTURE_SLIDER_MIDDLE + neutralPercent * 0.5f && progressFaction == ALLIANCE)
     {
         eventId = info->capturePoint.progressEventID1;
 
@@ -2477,7 +2477,7 @@ void GameObject::TickCapturePoint()
         m_captureState = CAPTURE_STATE_PROGRESS_ALLIANCE;
     }
     // horde takes the tower from neutral, contested or alliance (if there is no neutral area) to horde
-    else if (m_captureState != CAPTURE_STATE_PROGRESS_HORDE && m_captureSlider < CAPTURE_SLIDER_MIDDLE - neutralPercent * 0.5f && progressFaction == HORDE)
+    else if ((m_captureState != CAPTURE_STATE_PROGRESS_HORDE && m_captureState != CAPTURE_STATE_CONTEST_HORDE) && m_captureSlider < CAPTURE_SLIDER_MIDDLE - neutralPercent * 0.5f && progressFaction == HORDE)
     {
         eventId = info->capturePoint.progressEventID2;
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that defending a contested but not neutralized/taken base does not count as another base capture.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3726

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create 2 Characters, 1 Alliance, 1 Horde
- set your characters to level 70
- enable .debug bg
- use the BG auto-join to join an EOTS bg
- use .bg start to start the bg prematurely
- take your alliance character and capture the draenei ruins base (works with any base and any faction, just using this as an example for simplification)
- once the base is fully captured with the bar all the way to the edge walk out of the capture range of the base with your alliance character
- move your horde character to the draenei ruins base and let it capture one or two ticks then move the character out of the capture range of the base again
- move your alliance character back into the capture range of the base
- in the bugged version the base will now be captured again, despite never having been lost
- ![image](https://github.com/cmangos/mangos-wotlk/assets/3718129/9567441b-83e7-4958-bd51-2f9600b44017)
- in the fixed version you will just start capturing the base again

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] check tbc backport
- [ ] check for side-effects in other wotlk bgs
