### PR TITLE
Fix Manashield and deprecate ApplyPowerMod

### DIFF
--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -2650,7 +2650,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit* caster, SpellSchoolMask schoolMa
                 currentAbsorb = maxAbsorb;
 
             int32 manaReduction = int32(currentAbsorb * manaMultiplier);
-            ApplyPowerMod(POWER_MANA, manaReduction, false);
+            ModifyPower(POWER_MANA, -manaReduction);
         }
 
         // Mana Shield (or Fire Ward or Frost Ward or Ice Barrier)
@@ -10475,6 +10475,7 @@ void Unit::SetMaxPower(Powers power, uint32 val)
 
 void Unit::ApplyPowerMod(Powers power, uint32 val, bool apply)
 {
+    m_unitPower[power] = m_unitPower[power] + (apply ? val : -val);
     ApplyModUInt32Value(UNIT_FIELD_POWER1 + power, val, apply);
 
     // group update

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1431,6 +1431,7 @@ class Unit : public WorldObject
         void SetPower(Powers power, float val, bool withPowerUpdate = true);
         void SetMaxPower(Powers power, uint32 val);
         int32 ModifyPower(Powers power, int32 dVal);
+        [[deprecated("Use ModifyPower()")]]
         void ApplyPowerMod(Powers power, uint32 val, bool apply);
         void ApplyMaxPowerMod(Powers power, uint32 val, bool apply);
         bool HasMana() { return GetPowerType() == POWER_MANA; }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes Manashield not properly absorbing mana and not updating the mana update field for the client.
This PR also deprecates the `ApplyPowerMod` function which is not used anywhere else and should not be used in my opinion

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3114

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- level mage to level 20
- learn mana shield (1463)
- get into combat with an enemy
- cast mana shield
- watch mana bar

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Discuss deprecation
