### PR TITLE
CI/CD: Update MacOS version to 12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     permissions:
       contents: read
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR updates the version of the MacOS CI/CD runner from 11 to 12.

See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
![image](https://github.com/cmangos/mangos-wotlk/assets/3718129/ffd248c4-ba00-44d4-8ddf-98d0a49b8f65)
