### PR TITLE
Quest: Auto-accept quests in starting zone

### DIFF
--- a/src/game/Entities/GossipDef.cpp
+++ b/src/game/Entities/GossipDef.cpp
@@ -460,10 +460,8 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
 
     Player* player = GetMenuSession()->GetPlayer();
     Unit* giver = player->GetMap()->GetUnit(guid);
-    if (giver &&  pQuest->IsAutoAccept() && player->CanTakeQuest(pQuest, false))
-    {
+    if (giver &&  pQuest->IsAutoAccept() && player->CanTakeQuest(pQuest, false) && player->CanAddQuest(pQuest, false))
         player->AddQuest(pQuest, giver);
-    }
 
     DEBUG_LOG("WORLD: Sent SMSG_QUESTGIVER_QUEST_DETAILS - for %s of %s, questid = %u", GetMenuSession()->GetPlayer()->GetGuidStr().c_str(), guid.GetString().c_str(), pQuest->GetQuestId());
 }

--- a/src/game/Entities/GossipDef.cpp
+++ b/src/game/Entities/GossipDef.cpp
@@ -458,6 +458,13 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
 
     GetMenuSession()->SendPacket(data);
 
+    Player* player = GetMenuSession()->GetPlayer();
+    Unit* giver = player->GetMap()->GetUnit(guid);
+    if (giver &&  pQuest->IsAutoAccept() && player->CanTakeQuest(pQuest, false))
+    {
+        player->AddQuest(pQuest, giver);
+    }
+
     DEBUG_LOG("WORLD: Sent SMSG_QUESTGIVER_QUEST_DETAILS - for %s of %s, questid = %u", GetMenuSession()->GetPlayer()->GetGuidStr().c_str(), guid.GetString().c_str(), pQuest->GetQuestId());
 }
 

--- a/src/game/Quests/QuestDef.cpp
+++ b/src/game/Quests/QuestDef.cpp
@@ -43,7 +43,7 @@ Quest::Quest(Field* questRecord)
     RequiredMaxRepValue = questRecord[15].GetInt32();
     SuggestedPlayers = questRecord[16].GetUInt32();
     LimitTime = questRecord[17].GetUInt32();
-    m_QuestFlags = questRecord[18].GetUInt16();
+    m_QuestFlags = questRecord[18].GetUInt32();
     m_SpecialFlags = questRecord[19].GetUInt16();
     CharTitleId = questRecord[20].GetUInt32();
     PlayersSlain = questRecord[21].GetUInt32();


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR allows Quests in the starting zones (Quests with the flag "QUEST_FLAGS_AUTO_ACCEPT") to be automatically accepted.
This PR is for WotLK *only*.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/2947

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Create new character
- Talk to the very first quest-giver

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Determine if SendQuestGiverQuestDetails() was the correct place to put the accepting code.
