### PR TITLE
WorldSession: Remove unused sync timer

### DIFF
--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -100,7 +100,7 @@ WorldSession::WorldSession(uint32 id, WorldSocket* sock, AccountTypes sec, uint8
     m_inQueue(false), m_playerLoading(false), m_kickSession(false), m_playerLogout(false), m_playerRecentlyLogout(false), m_playerSave(true),
     m_sessionDbcLocale(sWorld.GetAvailableDbcLocale(locale)), m_sessionDbLocaleIndex(sObjectMgr.GetStorageLocaleIndexFor(locale)),
     m_latency(0), m_clientTimeDelay(0), m_tutorialState(TUTORIALDATA_UNCHANGED), m_sessionState(WORLD_SESSION_STATE_CREATED),
-    m_timeSyncClockDeltaQueue(6), m_timeSyncClockDelta(0), m_pendingTimeSyncRequests(), m_timeSyncNextCounter(0), m_timeSyncTimer(0),
+    m_timeSyncClockDeltaQueue(6), m_timeSyncClockDelta(0), m_pendingTimeSyncRequests(), m_timeSyncNextCounter(0),
     m_requestSocket(nullptr), m_recruitingFriendId(recruitingFriend), m_isRecruiter(isARecruiter) {}
 
 /// WorldSession destructor
@@ -1275,8 +1275,6 @@ void WorldSession::SendTimeSync()
 
     m_pendingTimeSyncRequests[m_timeSyncNextCounter] = WorldTimer::getMSTime();
 
-    // Schedule next sync in 10 sec (except for the 2 first packets, which are spaced by only 5s)
-    m_timeSyncTimer = m_timeSyncNextCounter == 0 ? 5000 : 10000;
     m_timeSyncNextCounter++;
 }
 

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1088,7 +1088,6 @@ class WorldSession
 
         std::map<uint32, uint32> m_pendingTimeSyncRequests; // key: counter. value: server time when packet with that counter was sent.
         uint32 m_timeSyncNextCounter;
-        uint32 m_timeSyncTimer;
 
         // Recruit-A-Friend
         uint32 m_recruitingFriendId;


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR removes an unused sync timer from WotLK

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Make sure that the timer functionality shouldn't actually be ported from TBC to WotLK