### PR TITLE
Add Death Knight assignment for Soul Charge color.

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/caverns_of_time/hyjal/hyjal.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/caverns_of_time/hyjal/hyjal.cpp
@@ -877,6 +877,7 @@ void instance_mount_hyjal::OnPlayerDeath(Player* player)
         case CLASS_WARLOCK:
             player->CastSpell(nullptr, SPELL_SOUL_CHARGE_RED_CHARGE, TRIGGERED_OLD_TRIGGERED);
             break;
+        case CLASS_DEATH_KNIGHT:
         case CLASS_MAGE:
         case CLASS_ROGUE:
         case CLASS_WARRIOR:


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Adds Death Knight to the Soul Charge color effects for Archimonde in Hyjal Summit.

### Proof
<!-- Link resources as proof -->
- Tested on Dragonflight, Soul Charge color spell ID observed in sniff.

### Issues
<!-- Which Issues does this fix, which are related?-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.-->
- Engage Archimonde in Hyjal with at least two characters, one of which being a Death Knight.
- Allow Archimonde to kill the Death Knight.
- Observe the Soul Charge effect as a result of the death.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] According to various guides as well as [this TBC Classic video](https://www.youtube.com/watch?v=aNZRorkzZbk), it does seem that Mage/Paladin should have their color assignments swapped. If the source is suitable, I can make the change in this PR as well.