### PR TITLE
Add custom shared_ptr variant that enforces unique ownership but allows giving out weak_ptrs

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -290,7 +290,6 @@ BattleGround::~BattleGround()
 {
     // remove objects and creatures
     // (this is done automatically in mapmanager update, when the instance is reset after the reset time)
-    sBattleGroundMgr.RemoveBattleGround(GetInstanceId(), GetTypeId());
 
     // skip template bgs as they were never added to visible bg list
     BattleGroundBracketId bracketId = GetBracketId();

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -673,6 +673,10 @@ class BattleGround
         void SetPlayerSkinRefLootId(uint32 reflootId) { m_playerSkinReflootId = reflootId; }
 
         virtual void AlterTeleportLocation(Player* player, ObjectGuid& transportGuid, float& x, float& y, float& z, float& ori) {}
+
+        MaNGOS::unique_weak_ptr<BattleGround> GetWeakPtr() const { return m_weakRef; }
+        void SetWeakPtr(MaNGOS::unique_weak_ptr<BattleGround> weakRef) { m_weakRef = std::move(weakRef); }
+
     protected:
         // this method is called, when BG cannot spawn its own spirit guide, or something is wrong, It correctly ends BattleGround
         void EndNow();
@@ -765,6 +769,8 @@ class BattleGround
         float m_startMaxDist;
 
         uint32 m_playerSkinReflootId;
+
+        MaNGOS::unique_weak_ptr<BattleGround> m_weakRef;
 };
 
 // helper functions for world state list fill

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -1285,14 +1285,7 @@ void BattleGroundMgr::DeleteAllBattleGrounds()
 {
     // will also delete template bgs:
     for (uint8 i = BATTLEGROUND_TYPE_NONE; i < MAX_BATTLEGROUND_TYPE_ID; ++i)
-    {
-        for (BattleGroundSet::iterator itr = m_battleGrounds[i].begin(); itr != m_battleGrounds[i].end();)
-        {
-            BattleGround* bg = itr->second;
-            ++itr;                                          // step from invalidate iterator pos in result element remove in ~BattleGround call
-            delete bg;
-        }
-    }
+        m_battleGrounds[i].clear();
 }
 
 /**
@@ -1632,7 +1625,7 @@ BattleGround* BattleGroundMgr::GetBattleGroundThroughClientInstance(uint32 insta
     for (auto& itr : m_battleGrounds[bgTypeId])
     {
         if (itr.second->GetClientInstanceId() == instanceId)
-            return itr.second;
+            return itr.second.get();
     }
 
     return nullptr;
@@ -1654,13 +1647,13 @@ BattleGround* BattleGroundMgr::GetBattleGround(uint32 instanceId, BattleGroundTy
         {
             itr = m_battleGrounds[i].find(instanceId);
             if (itr != m_battleGrounds[i].end())
-                return itr->second;
+                return itr->second.get();
         }
         return nullptr;
     }
 
     itr = m_battleGrounds[bgTypeId].find(instanceId);
-    return ((itr != m_battleGrounds[bgTypeId].end()) ? itr->second : nullptr);
+    return ((itr != m_battleGrounds[bgTypeId].end()) ? itr->second.get() : nullptr);
 }
 
 /**
@@ -1671,7 +1664,7 @@ BattleGround* BattleGroundMgr::GetBattleGround(uint32 instanceId, BattleGroundTy
 BattleGround* BattleGroundMgr::GetBattleGroundTemplate(BattleGroundTypeId bgTypeId)
 {
     // map is sorted and we can be sure that lowest instance id has only BG template
-    return m_battleGrounds[bgTypeId].empty() ? nullptr : m_battleGrounds[bgTypeId].begin()->second;
+    return m_battleGrounds[bgTypeId].empty() ? nullptr : m_battleGrounds[bgTypeId].begin()->second.get();
 }
 
 /**
@@ -1886,6 +1879,13 @@ uint32 BattleGroundMgr::CreateBattleGround(BattleGroundTypeId bgTypeId, bool IsA
 
     // return some not-null value, bgTypeId is good enough for me
     return bgTypeId;
+}
+
+void BattleGroundMgr::AddBattleGround(uint32 instanceId, BattleGroundTypeId bgTypeId, BattleGround* bg)
+{
+    MaNGOS::unique_trackable_ptr<BattleGround>& ptr = m_battleGrounds[bgTypeId][instanceId];
+    ptr.reset(bg);
+    bg->SetWeakPtr(ptr);
 }
 
 /**

--- a/src/game/BattleGround/BattleGroundMgr.h
+++ b/src/game/BattleGround/BattleGroundMgr.h
@@ -23,11 +23,12 @@
 #include "Utilities/EventProcessor.h"
 #include "Globals/SharedDefines.h"
 #include "Server/DBCEnums.h"
+#include "Util/UniqueTrackablePtr.h"
 #include "BattleGround.h"
 
 #include <mutex>
 
-typedef std::map<uint32, BattleGround*> BattleGroundSet;
+typedef std::map<uint32, MaNGOS::unique_trackable_ptr<BattleGround>> BattleGroundSet;
 
 // this container can't be deque, because deque doesn't like removing the last element - if you remove it, it invalidates next iterator and crash appears
 typedef std::list<BattleGround*> BgFreeSlotQueueType;
@@ -215,7 +216,7 @@ class BattleGroundMgr
 
         uint32 CreateBattleGround(BattleGroundTypeId /*bgTypeId*/, bool /*isArena*/, uint32 /*minPlayersPerTeam*/, uint32 /*maxPlayersPerTeam*/, uint32 /*levelMin*/, uint32 /*levelMax*/, char const* /*battleGroundName*/, uint32 /*mapId*/, float /*team1StartLocX*/, float /*team1StartLocY*/, float /*team1StartLocZ*/, float /*team1StartLocO*/, float /*team2StartLocX*/, float /*team2StartLocY*/, float /*team2StartLocZ*/, float /*team2StartLocO*/, float /*startMaxDist*/, uint32 /*playerSkinReflootId*/);
 
-        void AddBattleGround(uint32 instanceId, BattleGroundTypeId bgTypeId, BattleGround* bg) { m_battleGrounds[bgTypeId][instanceId] = bg; };
+        void AddBattleGround(uint32 instanceId, BattleGroundTypeId bgTypeId, BattleGround* bg);;
         void RemoveBattleGround(uint32 instanceId, BattleGroundTypeId bgTypeId) { m_battleGrounds[bgTypeId].erase(instanceId); }
 
         uint32 CreateClientVisibleInstanceId(BattleGroundTypeId /*bgTypeId*/, BattleGroundBracketId /*bracketId*/);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -3259,7 +3259,7 @@ bool ChatHandler::HandleLookupQuestCommand(char* args)
     ObjectMgr::QuestMap const& qTemplates = sObjectMgr.GetQuestTemplates();
     for (const auto& qTemplate : qTemplates)
     {
-        Quest* qinfo = qTemplate.second;
+        Quest* qinfo = qTemplate.second.get();
 
         std::string title;                                  // "" for avoid repeating check default locale
         sObjectMgr.GetQuestLocaleStrings(qinfo->GetQuestId(), loc_idx, &title);
@@ -3531,10 +3531,7 @@ bool ChatHandler::HandleGuildUninviteCommand(char* args)
         return false;
 
     if (targetGuild->DelMember(target_guid))
-    {
         targetGuild->Disband();
-        delete targetGuild;
-    }
 
     return true;
 }
@@ -3599,7 +3596,6 @@ bool ChatHandler::HandleGuildDeleteCommand(char* args)
         return false;
 
     targetGuild->Disband();
-    delete targetGuild;
 
     return true;
 }

--- a/src/game/Entities/Object.cpp
+++ b/src/game/Entities/Object.cpp
@@ -48,7 +48,7 @@
 #include "MotionGenerators/PathFinder.h"
 #include "Movement/MoveSpline.h"
 
-Object::Object(): m_updateFlag(0), m_itsNewObject(false), m_dbGuid(0)
+Object::Object(): m_updateFlag(0), m_itsNewObject(false), m_dbGuid(0), m_scriptRef(this, NoopObjectDeleter())
 {
     m_objectTypeId      = TYPEID_OBJECT;
     m_objectType        = TYPEMASK_OBJECT;
@@ -79,6 +79,30 @@ Object::~Object()
     delete[] m_uint32Values;
 
     delete m_loot;
+}
+
+void Object::AddToWorld()
+{
+    if (m_inWorld)
+        return;
+
+    m_inWorld = true;
+
+    // synchronize values mirror with values array (changes will send in updatecreate opcode any way
+    ClearUpdateMask(false);                         // false - we can't have update data in update queue before adding to world
+
+    // Set new ref when adding to world (except if we already have one - also set in constructor to allow scripts to work in initialization phase)
+    // Changing the ref when adding/removing from world prevents accessing players on different maps (possibly from another thread)
+    if (!m_scriptRef)
+        m_scriptRef.reset(this, NoopObjectDeleter());
+}
+
+void Object::RemoveFromWorld()
+{
+    // if we remove from world then sending changes not required
+    ClearUpdateMask(true);
+    m_inWorld = false;
+    m_scriptRef = nullptr;
 }
 
 void Object::_InitValues()

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -628,6 +628,8 @@ class Object
         inline bool IsGameObject() const { return GetTypeId() == TYPEID_GAMEOBJECT; }
         inline bool IsCorpse() const { return GetTypeId() == TYPEID_CORPSE; }
 
+        MaNGOS::unique_weak_ptr<Object> GetWeakPtr() const { return m_scriptRef; }
+
     protected:
         Object();
 

--- a/src/game/Entities/Object.h
+++ b/src/game/Entities/Object.h
@@ -33,6 +33,7 @@
 #include "PlayerDefines.h"
 #include "Entities/ObjectVisibility.h"
 #include "Grids/Cell.h"
+#include "Util/UniqueTrackablePtr.h"
 #include "Utilities/EventProcessor.h"
 
 #include <set>
@@ -389,22 +390,9 @@ class Object
         virtual ~Object();
 
         const bool& IsInWorld() const { return m_inWorld; }
-        virtual void AddToWorld()
-        {
-            if (m_inWorld)
-                return;
+        virtual void AddToWorld();
 
-            m_inWorld = true;
-
-            // synchronize values mirror with values array (changes will send in updatecreate opcode any way
-            ClearUpdateMask(false);                         // false - we can't have update data in update queue before adding to world
-        }
-        virtual void RemoveFromWorld()
-        {
-            // if we remove from world then sending changes not required
-            ClearUpdateMask(true);
-            m_inWorld = false;
-        }
+        virtual void RemoveFromWorld();
 
         ObjectGuid const& GetObjectGuid() const { return GetGuidValue(OBJECT_FIELD_GUID); }
         uint32 GetGUIDLow() const { return GetObjectGuid().GetCounter(); }
@@ -682,6 +670,9 @@ class Object
         Object& operator=(Object const&);                   // prevent generation assigment operator
 
         uint32 m_dbGuid;
+
+        struct NoopObjectDeleter { void operator()(Object*) const { /*noop - not managed*/ } };
+        MaNGOS::unique_trackable_ptr<Object> m_scriptRef;
 
     public:
         // for output helpfull error messages from ASSERTs

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4513,16 +4513,9 @@ void Player::DeleteFromDB(ObjectGuid playerguid, uint32 accountId, bool updateRe
 
     // remove from guild
     if (uint32 guildId = GetGuildIdFromDB(playerguid))
-    {
         if (Guild* guild = sGuildMgr.GetGuildById(guildId))
-        {
             if (guild->DelMember(playerguid))
-            {
                 guild->Disband();
-                delete guild;
-            }
-        }
-    }
 
     // remove from arena teams
     LeaveAllArenaTeams(playerguid);

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -393,7 +393,6 @@ Unit::~Unit()
 
     delete m_combatData;
     delete m_charmInfo;
-    delete m_vehicleInfo;
     delete movespline;
 
     // those should be already removed at "RemoveFromWorld()" call
@@ -6169,6 +6168,7 @@ void Unit::RemoveAura(Aura* Aur, AuraRemoveMode mode)
 
     // Set remove mode
     Aur->SetRemoveMode(mode);
+    Aur->InvalidateScriptRef();
 
     // some ShapeshiftBoosts at remove trigger removing other auras including parent Shapeshift aura
     // remove aura from list before to prevent deleting it before
@@ -12337,19 +12337,18 @@ void Unit::SetVehicleId(uint32 entry, uint32 overwriteNpcEntry)
     if (m_vehicleInfo && entry == m_vehicleInfo->GetVehicleEntry()->m_ID)
         return;
 
-    delete m_vehicleInfo;
+    m_vehicleInfo = nullptr;
 
     if (entry)
     {
         VehicleEntry const* ventry = sVehicleStore.LookupEntry(entry);
         MANGOS_ASSERT(ventry != nullptr);
 
-        m_vehicleInfo = new VehicleInfo(this, ventry, overwriteNpcEntry);
+        m_vehicleInfo.reset(new VehicleInfo(this, ventry, overwriteNpcEntry));
         m_updateFlag |= UPDATEFLAG_VEHICLE;
     }
     else
     {
-        m_vehicleInfo = nullptr;
         m_updateFlag &= ~UPDATEFLAG_VEHICLE;
     }
 

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1537,7 +1537,8 @@ class Unit : public WorldObject
         virtual bool Mount(uint32 displayid, const Aura* aura = nullptr);
         virtual bool Unmount(const Aura* aura = nullptr);
 
-        VehicleInfo* GetVehicleInfo() const { return m_vehicleInfo; }
+        VehicleInfo* GetVehicleInfo() const { return m_vehicleInfo.get(); }
+        MaNGOS::unique_weak_ptr<VehicleInfo> GetVehicleInfoWeakPtr() const { return m_vehicleInfo; }
         bool IsVehicle() const { return m_vehicleInfo != nullptr; }
         void SetVehicleId(uint32 entry, uint32 overwriteNpcEntry);
         Unit const* FindRootVehicle(const Unit* whichVehicle = nullptr) const;
@@ -2716,7 +2717,7 @@ class Unit : public WorldObject
 
         bool m_canDualWield = false;
 
-        VehicleInfo* m_vehicleInfo;
+        MaNGOS::unique_trackable_ptr<VehicleInfo> m_vehicleInfo;
         void DisableSpline();
         void EndSpline();
         bool m_isCreatureLinkingTrigger;

--- a/src/game/Entities/Vehicle.cpp
+++ b/src/game/Entities/Vehicle.cpp
@@ -969,4 +969,10 @@ void VehicleInfo::RemoveSeatMods(Unit* passenger, uint32 seatFlags)
     }
 }
 
+MaNGOS::unique_weak_ptr<VehicleInfo> VehicleInfo::GetWeakPtr() const
+{
+    Unit* pVehicle = (Unit*)m_owner;
+    return pVehicle->GetVehicleInfoWeakPtr();
+}
+
 /*! @} */

--- a/src/game/Entities/Vehicle.h
+++ b/src/game/Entities/Vehicle.h
@@ -107,6 +107,8 @@ class VehicleInfo : public TransportBase
         void RespawnAccessories(int32 seatIndex = -1);
         void RecallAccessories(float distance = 0.f, int32 seatIndex = -1);
 
+        MaNGOS::unique_weak_ptr<VehicleInfo> GetWeakPtr() const;
+
     private:
         // Internal use to calculate the boarding position
         void CalculateBoardingPositionOf(float gx, float gy, float gz, float go, float& lx, float& ly, float& lz, float& lo) const;

--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -172,9 +172,6 @@ ObjectMgr::ObjectMgr() :
 
 ObjectMgr::~ObjectMgr()
 {
-    for (auto& mQuestTemplate : mQuestTemplates)
-        delete mQuestTemplate.second;
-
     for (auto& i : petInfo)
         delete[] i.second;
 
@@ -4870,9 +4867,6 @@ void ObjectMgr::LoadGroups()
 void ObjectMgr::LoadQuests()
 {
     // For reload case
-    for (QuestMap::const_iterator itr = mQuestTemplates.begin(); itr != mQuestTemplates.end(); ++itr)
-        delete itr->second;
-
     mQuestTemplates.clear();
 
     m_ExclusiveQuestGroups.clear();
@@ -4942,7 +4936,8 @@ void ObjectMgr::LoadQuests()
         Field* fields = queryResult->Fetch();
 
         Quest* newQuest = new Quest(fields);
-        mQuestTemplates[newQuest->GetQuestId()] = newQuest;
+        auto itr = mQuestTemplates.try_emplace(newQuest->GetQuestId(), newQuest).first;
+        newQuest->m_weakRef = itr->second;
     }
     while (queryResult->NextRow());
 
@@ -4952,7 +4947,7 @@ void ObjectMgr::LoadQuests()
 
     for (auto& mQuestTemplate : mQuestTemplates)
     {
-        Quest* qinfo = mQuestTemplate.second;
+        Quest* qinfo = mQuestTemplate.second.get();
 
         // additional quest integrity checks (GO, creature_template and item_template must be loaded already)
 
@@ -5532,7 +5527,7 @@ void ObjectMgr::LoadQuests()
     // Prevent any breadcrumb loops, and inform target quests of their breadcrumbs
     for (auto& mQuestTemplate : mQuestTemplates)
     {
-        Quest* qinfo = mQuestTemplate.second;
+        Quest* qinfo = mQuestTemplate.second.get();
         uint32   qid = qinfo->GetQuestId();
         uint32 breadcrumbForQuestId = qinfo->BreadcrumbForQuestId;
         std::set<uint32> questSet;
@@ -6035,7 +6030,7 @@ void ObjectMgr::LoadConditions()
 
     for (auto& mQuestTemplate : mQuestTemplates) // needs to be checked after loading conditions
     {
-        Quest* qinfo = mQuestTemplate.second;
+        Quest* qinfo = mQuestTemplate.second.get();
 
         if (qinfo->RequiredCondition)
         {

--- a/src/game/Globals/ObjectMgr.h
+++ b/src/game/Globals/ObjectMgr.h
@@ -36,6 +36,7 @@
 #include "Globals/Conditions.h"
 #include "Maps/SpawnGroupDefines.h"
 #include "Entities/Vehicle.h"
+#include "Util/UniqueTrackablePtr.h"
 
 #include <map>
 #include <climits>
@@ -516,7 +517,7 @@ class ObjectMgr
 
         typedef std::unordered_map<uint32, ArenaTeam*> ArenaTeamMap;
 
-        typedef std::unordered_map<uint32, Quest*> QuestMap;
+        typedef std::unordered_map<uint32, MaNGOS::unique_trackable_ptr<Quest>> QuestMap;
 
         typedef std::unordered_map<uint32, AreaTrigger> AreaTriggerMap;
 
@@ -584,7 +585,7 @@ class ObjectMgr
         Quest const* GetQuestTemplate(uint32 quest_id) const
         {
             QuestMap::const_iterator itr = mQuestTemplates.find(quest_id);
-            return itr != mQuestTemplates.end() ? itr->second : nullptr;
+            return itr != mQuestTemplates.end() ? itr->second.get() : nullptr;
         }
         QuestMap const& GetQuestTemplates() const { return mQuestTemplates; }
 

--- a/src/game/Groups/Group.cpp
+++ b/src/game/Groups/Group.cpp
@@ -70,7 +70,7 @@ GroupMemberStatus GetGroupMemberStatus(const Player* member = nullptr)
 Group::Group() : m_Id(0), m_leaderLastOnline(0), m_groupFlags(GROUP_FLAG_NORMAL),
     m_dungeonDifficulty(REGULAR_DIFFICULTY), m_raidDifficulty(REGULAR_DIFFICULTY),
     m_bgGroup(nullptr), m_bfGroup(nullptr), m_lootMethod(FREE_FOR_ALL), m_lootThreshold(ITEM_QUALITY_UNCOMMON),
-    m_subGroupsCounts(nullptr)
+    m_subGroupsCounts(nullptr), m_scriptRef(this, NoopGroupDeleter())
 {
 }
 

--- a/src/game/Groups/Group.h
+++ b/src/game/Groups/Group.h
@@ -28,6 +28,7 @@
 #include "Server/DBCEnums.h"
 #include "Globals/SharedDefines.h"
 #include "LFG/LFG.h"
+#include "Util/UniqueTrackablePtr.h"
 
 struct ItemPrototype;
 
@@ -298,6 +299,8 @@ class Group
 
         LFGData& GetLfgData() { return m_lfgData; }
 
+        MaNGOS::unique_weak_ptr<Group> GetWeakPtr() const { return m_scriptRef; }
+
     protected:
         bool _addMember(ObjectGuid guid, const char* name, bool isAssistant = false);
         bool _addMember(ObjectGuid guid, const char* name, bool isAssistant, uint8 group);
@@ -392,5 +395,8 @@ class Group
         uint8*              m_subGroupsCounts;
 
         LFGData             m_lfgData;
+
+        struct NoopGroupDeleter { void operator()(Group*) const { /*noop - not managed*/ } };
+        MaNGOS::unique_trackable_ptr<Group> m_scriptRef;
 };
 #endif

--- a/src/game/Guilds/Guild.h
+++ b/src/game/Guilds/Guild.h
@@ -26,6 +26,7 @@
 #include "Entities/Item.h"
 #include "Globals/ObjectAccessor.h"
 #include "Globals/SharedDefines.h"
+#include "Util/UniqueTrackablePtr.h"
 
 class Item;
 
@@ -446,6 +447,9 @@ class Guild
         void   LogBankEvent(uint8 EventType, uint8 TabId, uint32 PlayerGuidLow, uint32 ItemOrMoney, uint8 ItemStackCount = 0, uint8 DestTabId = 0);
         bool   AddGBankItemToDB(uint32 GuildId, uint32 BankTab, uint32 BankTabSlot, uint32 GUIDLow, uint32 Entry) const;
 
+        MaNGOS::unique_weak_ptr<Guild> GetWeakPtr() const { return m_weakRef; }
+        void SetWeakPtr(MaNGOS::unique_weak_ptr<Guild> weakRef) { m_weakRef = std::move(weakRef); }
+
     protected:
         void AddRank(const std::string& name_, uint32 rights, uint32 money);
 
@@ -481,6 +485,8 @@ class Guild
         uint32 m_GuildBankEventLogNextGuid_Item[GUILD_BANK_MAX_TABS];
 
         uint64 m_GuildBankMoney;
+
+        MaNGOS::unique_weak_ptr<Guild> m_weakRef;
 
     private:
         void UpdateAccountsNumber() { m_accountsNumber = 0;}// mark for lazy calculation at request in GetAccountsNumber

--- a/src/game/Guilds/GuildHandler.cpp
+++ b/src/game/Guilds/GuildHandler.cpp
@@ -184,7 +184,6 @@ void WorldSession::HandleGuildRemoveOpcode(WorldPacket& recvPacket)
     if (guild->DelMember(slot->guid))
     {
         guild->Disband();
-        delete guild;
         return;
     }
 
@@ -402,7 +401,6 @@ void WorldSession::HandleGuildLeaveOpcode(WorldPacket& /*recvPacket*/)
     if (_player->GetObjectGuid() == guild->GetLeaderGuid())
     {
         guild->Disband();
-        delete guild;
         return;
     }
 
@@ -411,7 +409,6 @@ void WorldSession::HandleGuildLeaveOpcode(WorldPacket& /*recvPacket*/)
     if (guild->DelMember(_player->GetObjectGuid()))
     {
         guild->Disband();
-        delete guild;
         return;
     }
 
@@ -439,7 +436,6 @@ void WorldSession::HandleGuildDisbandOpcode(WorldPacket& /*recvPacket*/)
     }
 
     guild->Disband();
-    delete guild;
 
     DEBUG_LOG("WORLD: Guild Successfully Disbanded");
 }

--- a/src/game/Guilds/GuildMgr.cpp
+++ b/src/game/Guilds/GuildMgr.cpp
@@ -33,13 +33,13 @@ GuildMgr::GuildMgr()
 
 GuildMgr::~GuildMgr()
 {
-    for (auto& itr : m_GuildMap)
-        delete itr.second;
 }
 
 void GuildMgr::AddGuild(Guild* guild)
 {
-    m_GuildMap[guild->GetId()] = guild;
+    MaNGOS::unique_trackable_ptr<Guild>& ptr = m_GuildMap[guild->GetId()];
+    ptr.reset(guild);
+    guild->SetWeakPtr(ptr);
 }
 
 void GuildMgr::RemoveGuild(uint32 guildId)
@@ -51,7 +51,7 @@ Guild* GuildMgr::GetGuildById(uint32 guildId) const
 {
     GuildMap::const_iterator itr = m_GuildMap.find(guildId);
     if (itr != m_GuildMap.end())
-        return itr->second;
+        return itr->second.get();
 
     return nullptr;
 }
@@ -60,7 +60,7 @@ Guild* GuildMgr::GetGuildByName(std::string const& name) const
 {
     for (const auto& itr : m_GuildMap)
         if (itr.second->GetName() == name)
-            return itr.second;
+            return itr.second.get();
 
     return nullptr;
 }
@@ -69,7 +69,7 @@ Guild* GuildMgr::GetGuildByLeader(ObjectGuid const& guid) const
 {
     for (const auto& itr : m_GuildMap)
         if (itr.second->GetLeaderGuid() == guid)
-            return itr.second;
+            return itr.second.get();
 
     return nullptr;
 }

--- a/src/game/Guilds/GuildMgr.h
+++ b/src/game/Guilds/GuildMgr.h
@@ -20,13 +20,14 @@
 #define _GUILDMGR_H
 
 #include "Common.h"
+#include "Util/UniqueTrackablePtr.h"
 
 class Guild;
 class ObjectGuid;
 
 class GuildMgr
 {
-        typedef std::unordered_map<uint32, Guild*> GuildMap;
+        typedef std::unordered_map<uint32, MaNGOS::unique_trackable_ptr<Guild>> GuildMap;
 
         GuildMap m_GuildMap;
     public:

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -43,6 +43,7 @@
 #include "Grids/ObjectGridLoader.h"
 #include "Vmap/GameObjectModel.h"
 #include "LFG/LFGMgr.h"
+#include "BattleGround/BattleGroundMgr.h"
 
 #ifdef BUILD_METRICS
  #include "Metric/Metric.h"
@@ -2124,7 +2125,10 @@ void BattleGroundMap::Update(const uint32& diff)
         // ]]
         // BattleGround Template instance cannot be updated, because it would be deleted
         if (!m_bg->GetInvitedCount(HORDE) && !m_bg->GetInvitedCount(ALLIANCE))
-            delete m_bg;
+        {
+            sBattleGroundMgr.RemoveBattleGround(GetInstanceId(), m_bg->GetTypeId());
+            m_bg = nullptr;
+        }
     }
     else
         m_bg->Update(diff);

--- a/src/game/Maps/Map.h
+++ b/src/game/Maps/Map.h
@@ -38,6 +38,7 @@
 #include "Globals/GraveyardManager.h"
 #include "Maps/SpawnManager.h"
 #include "Maps/MapDataContainer.h"
+#include "Util/UniqueTrackablePtr.h"
 #include "World/WorldStateVariableManager.h"
 
 #include <bitset>
@@ -214,6 +215,10 @@ class Map : public GridRefManager<NGridType>
         bool CreatureRespawnRelocation(Creature* c);        // used only in CreatureRelocation and ObjectGridUnloader
 
         uint32 GetInstanceId() const { return i_InstanceId; }
+
+        MaNGOS::unique_weak_ptr<Map> GetWeakPtr() const { return m_weakRef; }
+        void SetWeakPtr(MaNGOS::unique_weak_ptr<Map> weakRef) { m_weakRef = std::move(weakRef); }
+
         virtual bool CanEnter(Player* player);
         const char* GetMapName() const;
 
@@ -479,6 +484,7 @@ class Map : public GridRefManager<NGridType>
         uint8 i_spawnMode;
         uint32 i_id;
         uint32 i_InstanceId;
+        MaNGOS::unique_weak_ptr<Map> m_weakRef;
         uint32 m_unloadTimer;
         uint32 m_clientUpdateTimer;
         float m_VisibleDistance;

--- a/src/game/Maps/MapManager.h
+++ b/src/game/Maps/MapManager.h
@@ -26,6 +26,7 @@
 #include "Maps/Map.h"
 #include "Grids/GridStates.h"
 #include "Maps/MapUpdater.h"
+#include "Util/UniqueTrackablePtr.h"
 
 #include <functional>
 
@@ -61,7 +62,7 @@ class MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::ClassLevelLockab
         typedef MaNGOS::ClassLevelLockable<MapManager, std::recursive_mutex>::Lock Guard;
 
     public:
-        typedef std::map<MapID, Map* > MapMapType;
+        typedef std::map<MapID, MaNGOS::unique_trackable_ptr<Map> > MapMapType;
 
         void CreateContinents();
         Map* CreateMap(uint32, const WorldObject* obj);
@@ -153,7 +154,7 @@ class MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::ClassLevelLockab
         {
             for (auto& mapData : i_maps)
             {
-                _do(mapData.second);
+                _do(mapData.second.get());
             }
         }
         template<typename Do> void DoForAllMapsWithMapId(uint32 mapId, Do& _do);
@@ -196,7 +197,7 @@ inline void MapManager::DoForAllMapsWithMapId(uint32 mapId, Do& _do)
     MapMapType::const_iterator start = i_maps.lower_bound(MapID(mapId, 0));
     MapMapType::const_iterator end   = i_maps.lower_bound(MapID(mapId + 1, 0));
     for (MapMapType::const_iterator itr = start; itr != end; ++itr)
-        _do(itr->second);
+        _do(itr->second.get());
 }
 
 template<typename Check>
@@ -204,7 +205,7 @@ inline WorldObject* MapManager::SearchOnAllLoadedMap(Check& check)
 {
     for (auto& mapItr : i_maps)
     {
-        WorldObject* result = check(mapItr.second);
+        WorldObject* result = check(mapItr.second.get());
         if (result)
             return result;
     }

--- a/src/game/Quests/QuestDef.h
+++ b/src/game/Quests/QuestDef.h
@@ -22,6 +22,7 @@
 #include "Platform/Define.h"
 #include "Database/DatabaseEnv.h"
 #include "Server/DBCEnums.h"
+#include "Util/UniqueTrackablePtr.h"
 
 #include <vector>
 
@@ -319,6 +320,8 @@ class Quest
         uint32 GetRewChoiceItemsCount() const { return m_rewchoiceitemscount; }
         uint32 GetRewItemsCount() const { return m_rewitemscount; }
 
+        MaNGOS::unique_weak_ptr<Quest> GetWeakPtr() const { return m_weakRef; }
+
         typedef std::vector<int32> PrevQuests;
         PrevQuests prevQuests;
         typedef std::vector<uint32> PrevChainQuests;
@@ -396,6 +399,8 @@ class Quest
         uint32 CompleteEmoteDelay;
         uint32 QuestStartScript;
         uint32 QuestCompleteScript;
+
+        MaNGOS::unique_weak_ptr<Quest> m_weakRef;
 };
 
 enum QuestUpdateState

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -8486,23 +8486,24 @@ bool Spell::HaveTargetsForEffect(SpellEffectIndex effect) const
 
 SpellEvent::SpellEvent(Spell* spell) : BasicEvent()
 {
-    m_Spell = spell;
+    m_Spell.reset(spell, [](Spell* toDelete)
+    {
+        if (toDelete->IsDeletable() || World::IsStopped())
+        {
+            delete toDelete;
+        }
+        else
+        {
+            sLog.outError("~SpellEvent: %s %u tried to delete non-deletable spell %u. Was not deleted, causes memory leak.",
+                          (toDelete->GetCaster()->GetTypeId() == TYPEID_PLAYER ? "Player" : "Creature"), toDelete->GetCaster()->GetGUIDLow(), toDelete->m_spellInfo->Id);
+        }
+    });
 }
 
 SpellEvent::~SpellEvent()
 {
     if (m_Spell->getState() != SPELL_STATE_FINISHED)
         m_Spell->cancel();
-
-    if (m_Spell->IsDeletable() || World::IsStopped())
-    {
-        delete m_Spell;
-    }
-    else
-    {
-        sLog.outError("~SpellEvent: %s %u tried to delete non-deletable spell %u. Was not deleted, causes memory leak.",
-                      (m_Spell->GetCaster()->GetTypeId() == TYPEID_PLAYER ? "Player" : "Creature"), m_Spell->GetCaster()->GetGUIDLow(), m_Spell->m_spellInfo->Id);
-    }
 }
 
 bool SpellEvent::Execute(uint64 e_time, uint32 p_time)

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -9980,3 +9980,7 @@ SpellCastResult Spell::CheckVehicle(Unit const* caster, SpellEntry const& spellI
     return SPELL_CAST_OK;
 }
 
+MaNGOS::unique_weak_ptr<Spell> Spell::GetWeakPtr() const
+{
+    return m_spellEvent->GetSpellWeakPtr();
+}

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -329,7 +329,9 @@ class SpellEvent : public BasicEvent
         virtual bool IsDeletable() const override;
 
         Spell* GetSpell() const { return m_Spell.get(); }
-        protected:
+        MaNGOS::unique_weak_ptr<Spell> GetSpellWeakPtr() const { return m_Spell; }
+
+    protected:
         MaNGOS::unique_trackable_ptr<Spell> m_Spell;
 };
 
@@ -903,6 +905,9 @@ class Spell
         void SetDamageDoneModifier(float mod, SpellEffectIndex effIdx);
         void SetIgnoreOwnerLevel(bool state) { m_ignoreOwnerLevel = state; }
         void SetUsableWhileStunned(bool state) { m_usableWhileStunned = state; }
+
+        MaNGOS::unique_weak_ptr<Spell> GetWeakPtr() const;
+
     protected:
         void SendLoot(ObjectGuid guid, LootType loottype, LockType lockType);
         bool IgnoreItemRequirements() const;                // some item use spells have unexpected reagent data

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -28,6 +28,7 @@
 #include "Entities/Player.h"
 #include "Server/SQLStorages.h"
 #include "Spells/SpellEffectDefines.h"
+#include "Util/UniqueTrackablePtr.h"
 
 class WorldSession;
 class WorldPacket;
@@ -327,9 +328,9 @@ class SpellEvent : public BasicEvent
         virtual void Abort(uint64 e_time) override;
         virtual bool IsDeletable() const override;
 
-        Spell* GetSpell() const { return m_Spell; }
+        Spell* GetSpell() const { return m_Spell.get(); }
         protected:
-        Spell* m_Spell;
+        MaNGOS::unique_trackable_ptr<Spell> m_Spell;
 };
 
 class SpellModRAII

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -385,7 +385,7 @@ Aura::Aura(SpellEntry const* spellproto, SpellEffectIndex eff, int32 const* curr
     m_spellmod(nullptr), m_periodicTimer(0), m_periodicTick(0), m_removeMode(AURA_REMOVE_BY_DEFAULT),
     m_effIndex(eff), m_positive(false), m_isPeriodic(false), m_isAreaAura(false),
     m_isPersistent(false), m_magnetUsed(false), m_spellAuraHolder(holder),
-    m_scriptValue(0), m_storage(nullptr), m_affectOverriden(false)
+    m_scriptValue(0), m_storage(nullptr), m_scriptRef(this, NoopAuraDeleter()), m_affectOverriden(false)
 {
     MANGOS_ASSERT(target);
     MANGOS_ASSERT(spellproto && spellproto == sSpellTemplate.LookupEntry<SpellEntry>(spellproto->Id) && "`info` must be pointer to sSpellTemplate element");

--- a/src/game/Spells/SpellAuras.h
+++ b/src/game/Spells/SpellAuras.h
@@ -22,6 +22,7 @@
 #include "Server/DBCEnums.h"
 #include "Entities/ObjectGuid.h"
 #include "Spells/Scripts/SpellScript.h"
+#include "Util/UniqueTrackablePtr.h"
 
 /**
  * Used to modify what an Aura does to a player/npc.
@@ -569,6 +570,9 @@ class Aura
         void ForcePeriodicity(uint32 periodicTime);
         void SetAffectOverriden() { m_affectOverriden = true; } // spell script must implement condition
 
+        MaNGOS::unique_weak_ptr<Aura> GetWeakPtr() const { return m_scriptRef; }
+        void InvalidateScriptRef() { m_scriptRef = nullptr; }
+
     protected:
         Aura(SpellEntry const* spellproto, SpellEffectIndex eff, int32 const* currentDamage, int32 const* currentBasePoints, SpellAuraHolder* holder, Unit* target, Unit* caster = nullptr, Item* castItem = nullptr);
 
@@ -610,6 +614,9 @@ class Aura
         uint64 m_scriptValue; // persistent value for spell script state
         ScriptStorage* m_storage;
         bool m_affectOverriden;
+
+        struct NoopAuraDeleter { void operator()(Aura*) const { /*noop - not managed*/ } };
+        MaNGOS::unique_trackable_ptr<Aura> m_scriptRef;
     private:
         void ReapplyAffectedPassiveAuras(Unit* target, bool owner_mode);
 };

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -134,6 +134,7 @@ set(SRC_GRP_UTIL
     Util/Util.h
     Util/ProducerConsumerQueue.h
     Util/CommonDefines.h
+    Util/UniqueTrackablePtr.h
 )
 
 set(LIBRARY_SRCS

--- a/src/shared/Util/UniqueTrackablePtr.h
+++ b/src/shared/Util/UniqueTrackablePtr.h
@@ -1,0 +1,478 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MANGOS_UNIQUE_TRACKABLE_PTR_H
+#define MANGOS_UNIQUE_TRACKABLE_PTR_H
+
+#include <memory>
+
+namespace MaNGOS
+{
+// C++20 utilities
+template <typename T>
+inline constexpr bool is_bounded_array_v = std::is_array_v<T> && std::extent_v<T> != 0;
+
+template <typename T>
+inline constexpr bool is_unbounded_array_v = std::is_array_v<T> && std::extent_v<T> == 0;
+
+template <typename T>
+class unique_trackable_ptr;
+
+template <typename T>
+class unique_weak_ptr;
+
+template <typename T>
+class unique_strong_ref_ptr;
+
+/**
+ * \brief Specialized variant of std::shared_ptr that enforces unique ownership and/or std::unique_ptr with std::weak_ptr capabilities
+ * Implementation has the same overhead as a std::shared_ptr, that is, a separate allocation for control block that holds use counters
+ * \tparam T Type of held object
+ */
+template <typename T>
+class unique_trackable_ptr
+{
+public:
+    using element_type = T;
+    using pointer = T*;
+
+    unique_trackable_ptr() : _ptr() { }
+
+    explicit unique_trackable_ptr(pointer ptr)
+        : _ptr(ptr) { }
+
+    template <typename Deleter, std::enable_if_t<std::conjunction_v<std::is_move_constructible<Deleter>, std::is_invocable<Deleter&, T*&>>, int> = 0>
+    explicit unique_trackable_ptr(pointer ptr, Deleter deleter)
+        : _ptr(ptr, std::move(deleter)) { }
+
+    unique_trackable_ptr(unique_trackable_ptr const&) = delete;
+
+    unique_trackable_ptr(unique_trackable_ptr&& other) noexcept
+        : _ptr(std::move(other._ptr)) { }
+
+    template <typename T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+    unique_trackable_ptr(unique_trackable_ptr<T2>&& other) noexcept
+        : _ptr(std::move(other)._ptr) { }
+
+    unique_trackable_ptr& operator=(unique_trackable_ptr const&) = delete;
+
+    unique_trackable_ptr& operator=(unique_trackable_ptr&& other) noexcept
+    {
+        _ptr = std::move(other._ptr);
+        return *this;
+    }
+
+    template <typename T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+    unique_trackable_ptr& operator=(unique_trackable_ptr<T2>&& other) noexcept
+    {
+        _ptr = std::move(other)._ptr;
+        return *this;
+    }
+
+    ~unique_trackable_ptr() = default;
+
+    unique_trackable_ptr& operator=(std::nullptr_t)
+    {
+        reset();
+        return *this;
+    }
+
+    void swap(unique_trackable_ptr& other) noexcept
+    {
+        using std::swap;
+        swap(_ptr, other._ptr);
+    }
+
+    element_type& operator*() const
+    {
+        return *_ptr;
+    }
+
+    pointer operator->() const
+    {
+        return _ptr.operator->();
+    }
+
+    pointer get() const
+    {
+        return _ptr.get();
+    }
+
+    explicit operator bool() const
+    {
+        return static_cast<bool>(_ptr);
+    }
+
+    void reset()
+    {
+        _ptr.reset();
+    }
+
+    void reset(pointer ptr)
+    {
+        _ptr.reset(ptr);
+    }
+
+    template <class Deleter, std::enable_if_t<std::conjunction_v<std::is_move_constructible<Deleter>, std::is_invocable<Deleter&, T*&>>, int> = 0>
+    void reset(pointer ptr, Deleter deleter)
+    {
+        _ptr.reset(ptr, std::move(deleter));
+    }
+
+private:
+    template <typename T0>
+    friend class unique_trackable_ptr;
+
+    template <typename T0>
+    friend class unique_weak_ptr;
+
+    template <typename T0, typename... Args>
+    friend std::enable_if_t<!std::is_array_v<T0>, unique_trackable_ptr<T0>> make_unique_trackable(Args&&... args);
+
+    template <typename T0>
+    friend std::enable_if_t<is_unbounded_array_v<T0>, unique_trackable_ptr<T0>> make_unique_trackable(std::size_t N);
+
+    template <typename T0>
+    friend std::enable_if_t<is_unbounded_array_v<T0>, unique_trackable_ptr<T0>> make_unique_trackable(std::size_t N, std::remove_extent_t<T0> const& val);
+
+    template <typename T0>
+    friend std::enable_if_t<is_bounded_array_v<T0>, unique_trackable_ptr<T0>> make_unique_trackable();
+
+    template <typename T0>
+    friend std::enable_if_t<is_bounded_array_v<T0>, unique_trackable_ptr<T0>> make_unique_trackable(std::remove_extent_t<T0> const& val);
+
+    std::shared_ptr<element_type> _ptr;
+};
+
+/**
+ * \brief Trinity::unique_trackable_ptr companion class, replicating what std::weak_ptr is to std::shared_ptr
+ * \tparam T Type of held object
+ */
+template <typename T>
+class unique_weak_ptr
+{
+public:
+    using element_type = T;
+    using pointer = T*;
+
+    unique_weak_ptr() = default;
+
+    unique_weak_ptr(unique_trackable_ptr<T> const& trackable)
+        : _ptr(trackable._ptr) { }
+
+    unique_weak_ptr(unique_weak_ptr const& other) = default;
+
+    template <typename T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+    unique_weak_ptr(unique_weak_ptr<T2> const& other) noexcept
+        : _ptr(other._ptr) { }
+
+    unique_weak_ptr(unique_weak_ptr&& other) noexcept = default;
+
+    template <typename T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+    unique_weak_ptr(unique_weak_ptr<T2>&& other) noexcept
+        : _ptr(std::move(other)._ptr) { }
+
+    unique_weak_ptr& operator=(unique_trackable_ptr<T> const& trackable)
+    {
+        _ptr = trackable._ptr;
+        return *this;
+    }
+
+    unique_weak_ptr& operator=(unique_weak_ptr const& other) = default;
+
+    template <typename T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, int> = 0>
+    unique_weak_ptr& operator=(unique_weak_ptr<T2>&& other)
+    {
+        _ptr = std::move(other)._ptr;
+        return *this;
+    }
+
+    unique_weak_ptr& operator=(unique_weak_ptr&& other) noexcept = default;
+
+    ~unique_weak_ptr() = default;
+
+    void swap(unique_weak_ptr& other) noexcept
+    {
+        using std::swap;
+        swap(_ptr, other._ptr);
+    }
+
+    bool expired() const
+    {
+        return _ptr.expired();
+    }
+
+    unique_strong_ref_ptr<element_type> lock() const
+    {
+        return unique_strong_ref_ptr<element_type>(_ptr.lock());
+    }
+
+private:
+    template <typename T0>
+    friend class unique_weak_ptr;
+
+    template <typename T0>
+    friend class unique_strong_ref_ptr;
+
+    template <class To, class From>
+    friend unique_weak_ptr<To> static_pointer_cast(unique_weak_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_weak_ptr<To> const_pointer_cast(unique_weak_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_weak_ptr<To> reinterpret_pointer_cast(unique_weak_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_weak_ptr<To> dynamic_pointer_cast(unique_weak_ptr<From> const& other);
+
+    std::weak_ptr<element_type> _ptr;
+};
+
+/**
+ * \brief Result of unique_weak_ptr::lock() function, this class holds a temporary strong reference to held object
+ * to prevent it from being deallocated by another thread while it is being actively accessed.
+ * This class is non-movable and non-copypable and is intended only for short lived local variables
+ * \tparam T Type of held object
+ */
+template <typename T>
+class unique_strong_ref_ptr
+{
+public:
+    using element_type = T;
+    using pointer = T*;
+
+    unique_strong_ref_ptr(unique_strong_ref_ptr const&) = delete;
+    unique_strong_ref_ptr(unique_strong_ref_ptr&&) = delete;
+    unique_strong_ref_ptr& operator=(unique_strong_ref_ptr const&) = delete;
+    unique_strong_ref_ptr& operator=(unique_strong_ref_ptr&&) = delete;
+
+    ~unique_strong_ref_ptr() = default;
+
+    element_type& operator*() const
+    {
+        return *_ptr;
+    }
+
+    pointer operator->() const
+    {
+        return _ptr.operator->();
+    }
+
+    pointer get() const
+    {
+        return _ptr.get();
+    }
+
+    explicit operator bool() const
+    {
+        return static_cast<bool>(_ptr);
+    }
+
+    operator unique_weak_ptr<T>() const
+    {
+        unique_weak_ptr<T> weak;
+        weak._ptr = _ptr;
+        return weak;
+    }
+
+private:
+    template <typename T0>
+    friend class unique_weak_ptr;
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> static_pointer_cast(unique_strong_ref_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> static_pointer_cast(unique_strong_ref_ptr<From>&& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> const_pointer_cast(unique_strong_ref_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> const_pointer_cast(unique_strong_ref_ptr<From>&& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> reinterpret_pointer_cast(unique_strong_ref_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> reinterpret_pointer_cast(unique_strong_ref_ptr<From>&& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> dynamic_pointer_cast(unique_strong_ref_ptr<From> const& other);
+
+    template <class To, class From>
+    friend unique_strong_ref_ptr<To> dynamic_pointer_cast(unique_strong_ref_ptr<From>&& other);
+
+    unique_strong_ref_ptr(std::shared_ptr<element_type> ptr) : _ptr(std::move(ptr)) { }
+
+    std::shared_ptr<element_type> _ptr;
+};
+
+// Ugly macros that will become unneccessary with C++20 operator<=>
+#define UNIQUE_TRACKABLE_COMPARISON_OPERATOR(cls, op) \
+template <typename T1, typename T2> \
+bool operator op (cls <T1> const& left, cls <T2> const& right) { return left.get() op right.get(); }
+
+#define UNIQUE_TRACKABLE_COMPARISON_OPERATOR_NULLPTR(cls, op) \
+template <typename T1> \
+bool operator op (cls <T1> const& left, std::nullptr_t) { return left.get() op static_cast<typename cls <T1>::element_type*>(nullptr); }\
+template <typename T1> \
+bool operator op (std::nullptr_t, cls <T1> const& right) { return static_cast<typename cls <T1>::element_type*>(nullptr) op right.get(); }
+
+#define UNIQUE_TRACKABLE_COMPARISON_OPERATORS(STAMPER, cls) \
+    STAMPER(cls, ==) \
+    STAMPER(cls, !=) \
+    STAMPER(cls, <)  \
+    STAMPER(cls, >=) \
+    STAMPER(cls, >)  \
+    STAMPER(cls, <=)
+
+#define UNIQUE_TRACKABLE_COMPARISON_OPERATORS_FOR_CLASS(cls) \
+    UNIQUE_TRACKABLE_COMPARISON_OPERATORS(UNIQUE_TRACKABLE_COMPARISON_OPERATOR, cls) \
+    UNIQUE_TRACKABLE_COMPARISON_OPERATORS(UNIQUE_TRACKABLE_COMPARISON_OPERATOR_NULLPTR, cls)
+
+// unique_trackable_ptr funcions
+UNIQUE_TRACKABLE_COMPARISON_OPERATORS_FOR_CLASS(unique_trackable_ptr)
+
+template <typename T, typename... Args>
+std::enable_if_t<!std::is_array_v<T>, unique_trackable_ptr<T>> make_unique_trackable(Args&&... args)
+{
+    unique_trackable_ptr<T> ptr;
+    ptr._ptr = std::make_shared<T>(std::forward<Args>(args)...);
+    return ptr;
+}
+
+template <typename T>
+std::enable_if_t<is_unbounded_array_v<T>, unique_trackable_ptr<T>> make_unique_trackable(std::size_t N)
+{
+    unique_trackable_ptr<T> ptr;
+    ptr._ptr = std::make_shared<T>(N);
+    return ptr;
+}
+
+template <typename T>
+std::enable_if_t<is_unbounded_array_v<T>, unique_trackable_ptr<T>> make_unique_trackable(std::size_t N, std::remove_extent_t<T> const& val)
+{
+    unique_trackable_ptr<T> ptr;
+    ptr._ptr = std::make_shared<T>(N, val);
+    return ptr;
+}
+
+template <typename T>
+std::enable_if_t<is_bounded_array_v<T>, unique_trackable_ptr<T>> make_unique_trackable()
+{
+    unique_trackable_ptr<T> ptr;
+    ptr._ptr = std::make_shared<T>();
+    return ptr;
+}
+
+template <typename T>
+std::enable_if_t<is_bounded_array_v<T>, unique_trackable_ptr<T>> make_unique_trackable(std::remove_extent_t<T> const& val)
+{
+    unique_trackable_ptr<T> ptr;
+    ptr._ptr = std::make_shared<T>(val);
+    return ptr;
+}
+
+// unique_weak_ptr funcions
+
+template <class To, class From>
+unique_weak_ptr<To> static_pointer_cast(unique_weak_ptr<From> const& other)
+{
+    unique_weak_ptr<To> to;
+    to._ptr = std::static_pointer_cast<To>(other._ptr.lock());
+    return to;
+}
+
+template <class To, class From>
+unique_weak_ptr<To> const_pointer_cast(unique_weak_ptr<From> const& other)
+{
+    unique_weak_ptr<To> to;
+    to._ptr = std::const_pointer_cast<To>(other._ptr.lock());
+    return to;
+}
+
+template <class To, class From>
+unique_weak_ptr<To> reinterpret_pointer_cast(unique_weak_ptr<From> const& other)
+{
+    unique_weak_ptr<To> to;
+    to._ptr = std::reinterpret_pointer_cast<To>(other._ptr.lock());
+    return to;
+}
+
+template <class To, class From>
+unique_weak_ptr<To> dynamic_pointer_cast(unique_weak_ptr<From> const& other)
+{
+    unique_weak_ptr<To> to;
+    to._ptr = std::dynamic_pointer_cast<To>(other._ptr.lock());
+    return to;
+}
+
+// unique_strong_ref_ptr funcions
+UNIQUE_TRACKABLE_COMPARISON_OPERATORS_FOR_CLASS(unique_strong_ref_ptr)
+
+template <class To, class From>
+unique_strong_ref_ptr<To> static_pointer_cast(unique_strong_ref_ptr<From> const& other)
+{
+    return unique_strong_ref_ptr<To>(std::static_pointer_cast<To>(other._ptr));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> static_pointer_cast(unique_strong_ref_ptr<From>&& other)
+{
+    return unique_strong_ref_ptr<To>(std::static_pointer_cast<To>(std::move(other._ptr)));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> const_pointer_cast(unique_strong_ref_ptr<From> const& other)
+{
+    return unique_strong_ref_ptr<To>(std::const_pointer_cast<To>(other._ptr));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> const_pointer_cast(unique_strong_ref_ptr<From>&& other)
+{
+    return unique_strong_ref_ptr<To>(std::const_pointer_cast<To>(std::move(other._ptr)));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> reinterpret_pointer_cast(unique_strong_ref_ptr<From> const& other)
+{
+    return unique_strong_ref_ptr<To>(std::reinterpret_pointer_cast<To>(other._ptr));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> reinterpret_pointer_cast(unique_strong_ref_ptr<From>&& other)
+{
+    return unique_strong_ref_ptr<To>(std::reinterpret_pointer_cast<To>(std::move(other._ptr)));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> dynamic_pointer_cast(unique_strong_ref_ptr<From> const& other)
+{
+    return unique_strong_ref_ptr<To>(std::dynamic_pointer_cast<To>(other._ptr));
+}
+
+template <class To, class From>
+unique_strong_ref_ptr<To> dynamic_pointer_cast(unique_strong_ref_ptr<From>&& other)
+{
+    return unique_strong_ref_ptr<To>(std::dynamic_pointer_cast<To>(std::move(other._ptr)));
+}
+}
+
+#endif // MANGOS_UNIQUE_TRACKABLE_PTR_H


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
As promised some time ago I am now submitting the same change as I made a while ago
TrinityCore/TrinityCore@32e54b6bd168c196adb45360b18721851162d731
TrinityCore/TrinityCore@4779fa5048642b57a0f69de7ab56b9d563c1cbc4

This is a specialized variant of std::shared_ptr that enforces unique ownership

intended to be used by external code unable to track object lifetime such as custom scripting engines such as Eluna
ElunaLuaEngine/Eluna@f4a1203dfec74ea90402f32793642b63e01e463a

### Proof
<!-- Link resources as proof -->
Not a content/game mechanic change

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Run under debugger and verify that all affected objects are still deallocated properly

