### PR TITLE
Spell: Fix Kael'Thas Flamestrike exploding immediately

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/tempest_keep/the_eye/boss_kaelthas.cpp
@@ -1397,6 +1397,8 @@ struct FlameStrikeKael : public AuraScript
 {
     void OnApply(Aura* aura, bool apply) const override
     {
+        if (apply)
+            return;
         aura->GetTarget()->CastSpell(nullptr, 36731, TRIGGERED_OLD_TRIGGERED, nullptr, aura);
         if (aura->GetTarget()->IsCreature())
             static_cast<Creature*>(aura->GetTarget())->ForcedDespawn(10000);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR ensures that Kael'Thas' Flamestrike does not explode immediately so that players have time to run out of the pre-flamestrike visual.

### Proof
<!-- Link resources as proof -->
- https://youtu.be/50rC95LSCZE?t=1942

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3762

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Do the Kael'Thas encounter and pay attention to flamestrike

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Check if NPC should despawn 10s after spawn or 10s after the flamestrike damage effect is triggered
