### PR TITLE
Timer: Add a timer for code-benchmarking with RAII

### DIFF
--- a/src/shared/Util/CodeBench.cpp
+++ b/src/shared/Util/CodeBench.cpp
@@ -1,0 +1,13 @@
+#include "CodeBench.h"
+#include "Log/Log.h"
+
+ChronoTimeTracker::~ChronoTimeTracker()
+{
+    std::chrono::nanoseconds elapsed = elapsedNanos();
+    sLog.outError("%s: time elapsed: %ldns, %ldµs, %ldms, %lds",
+        m_name.c_str(),
+        nanos(elapsed).count(),
+        micros(elapsed).count(),
+        millis(elapsed).count(),
+        secs(elapsed).count());
+}

--- a/src/shared/Util/CodeBench.h
+++ b/src/shared/Util/CodeBench.h
@@ -1,0 +1,30 @@
+struct ChronoTimeTracker
+{
+    public:
+        ChronoTimeTracker() : m_startTime(std::chrono::steady_clock::now()), m_name("Unnamed Timer") {}
+        ChronoTimeTracker(std::string name) : m_startTime(std::chrono::steady_clock::now()), m_name(name) {}
+        ~ChronoTimeTracker();
+        std::chrono::seconds elapsedSeconds()
+        {
+            return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+        std::chrono::milliseconds elapsedMillis()
+        {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+        std::chrono::microseconds elapsedMicros()
+        {
+            return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+        std::chrono::nanoseconds elapsedNanos()
+        {
+            return std::chrono::steady_clock::now() - m_startTime;
+        }
+    private:
+        std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> m_startTime;
+        std::string m_name;
+        inline constexpr std::chrono::nanoseconds nanos(std::chrono::nanoseconds nanos) { return nanos; }
+        inline constexpr std::chrono::microseconds micros(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::microseconds>(nanos); }
+        inline constexpr std::chrono::milliseconds millis(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::milliseconds>(nanos); }
+        inline constexpr std::chrono::seconds secs(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::seconds>(nanos); }
+};

--- a/src/shared/Util/Timer.h
+++ b/src/shared/Util/Timer.h
@@ -164,14 +164,17 @@ struct ShortTimeTracker
 struct ChronoTimeTracker
 {
     public:
-        ChronoTimeTracker() : m_startTime(std::chrono::steady_clock::now()) {}
+        ChronoTimeTracker() : m_startTime(std::chrono::steady_clock::now()), m_name("Unnamed Timer") {}
+        ChronoTimeTracker(std::string name) : m_startTime(std::chrono::steady_clock::now()), m_name(name) {}
         ~ChronoTimeTracker()
         {
-            sLog.outError("Elapsed: %lds, %ldms, %ldµs, %ldns",
-                elapsedSeconds().count(),
-                elapsedMillis().count(),
-                elapsedMicros().count(),
-                elapsedNanos().count());
+            std::chrono::nanoseconds elapsed = elapsedNanos();
+            sLog.outError("%s: time elapsed: %ldns, %ldµs, %ldms, %lds",
+                m_name.c_str(),
+                nanos(elapsed).count(),
+                micros(elapsed).count(),
+                millis(elapsed).count(),
+                secs(elapsed).count());
         }
         std::chrono::seconds elapsedSeconds()
         {
@@ -187,10 +190,15 @@ struct ChronoTimeTracker
         }
         std::chrono::nanoseconds elapsedNanos()
         {
-            return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - m_startTime);
+            return std::chrono::steady_clock::now() - m_startTime;
         }
     private:
         std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> m_startTime;
+        std::string m_name;
+        inline constexpr std::chrono::nanoseconds nanos(std::chrono::nanoseconds nanos) { return nanos; }
+        inline constexpr std::chrono::microseconds micros(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::microseconds>(nanos); }
+        inline constexpr std::chrono::milliseconds millis(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::milliseconds>(nanos); }
+        inline constexpr std::chrono::seconds secs(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::seconds>(nanos); }
 };
 
 #endif

--- a/src/shared/Util/Timer.h
+++ b/src/shared/Util/Timer.h
@@ -161,44 +161,4 @@ struct ShortTimeTracker
         uint32 i_expiryTime;
 };
 
-struct ChronoTimeTracker
-{
-    public:
-        ChronoTimeTracker() : m_startTime(std::chrono::steady_clock::now()), m_name("Unnamed Timer") {}
-        ChronoTimeTracker(std::string name) : m_startTime(std::chrono::steady_clock::now()), m_name(name) {}
-        ~ChronoTimeTracker()
-        {
-            std::chrono::nanoseconds elapsed = elapsedNanos();
-            sLog.outError("%s: time elapsed: %ldns, %ldµs, %ldms, %lds",
-                m_name.c_str(),
-                nanos(elapsed).count(),
-                micros(elapsed).count(),
-                millis(elapsed).count(),
-                secs(elapsed).count());
-        }
-        std::chrono::seconds elapsedSeconds()
-        {
-            return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - m_startTime);
-        }
-        std::chrono::milliseconds elapsedMillis()
-        {
-            return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_startTime);
-        }
-        std::chrono::microseconds elapsedMicros()
-        {
-            return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_startTime);
-        }
-        std::chrono::nanoseconds elapsedNanos()
-        {
-            return std::chrono::steady_clock::now() - m_startTime;
-        }
-    private:
-        std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> m_startTime;
-        std::string m_name;
-        inline constexpr std::chrono::nanoseconds nanos(std::chrono::nanoseconds nanos) { return nanos; }
-        inline constexpr std::chrono::microseconds micros(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::microseconds>(nanos); }
-        inline constexpr std::chrono::milliseconds millis(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::milliseconds>(nanos); }
-        inline constexpr std::chrono::seconds secs(std::chrono::nanoseconds nanos) { return std::chrono::duration_cast<std::chrono::seconds>(nanos); }
-};
-
 #endif

--- a/src/shared/Util/Timer.h
+++ b/src/shared/Util/Timer.h
@@ -161,4 +161,36 @@ struct ShortTimeTracker
         uint32 i_expiryTime;
 };
 
+struct ChronoTimeTracker
+{
+    public:
+        ChronoTimeTracker() : m_startTime(std::chrono::steady_clock::now()) {}
+        ~ChronoTimeTracker()
+        {
+            sLog.outError("Elapsed: %lds, %ldms, %ldµs, %ldns",
+                elapsedSeconds().count(),
+                elapsedMillis().count(),
+                elapsedMicros().count(),
+                elapsedNanos().count());
+        }
+        std::chrono::seconds elapsedSeconds()
+        {
+            return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+        std::chrono::milliseconds elapsedMillis()
+        {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+        std::chrono::microseconds elapsedMicros()
+        {
+            return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+        std::chrono::nanoseconds elapsedNanos()
+        {
+            return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - m_startTime);
+        }
+    private:
+        std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> m_startTime;
+};
+
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR adds a timer to benchmark code performance.

To use it simply create a new ChronoTimeTracker object and let it go out of scope, or delete it. Example:

```cpp
{
    ChronoTimeTracker bench;
    // some code you want to benchmark
}
```
or
```cpp
ChronoTimeTracker* bench = new ChronoTimeTracker();
// some code you want to benchmark
delete bench;
```

The time can also be polled at runtime with
```cpp
ChronoTimeTracker bench;
while(1)
{
    sLog.outDebug("%ld", bench.elapsedSeconds().count());
}
```

Please note that measurements taken like this come with variance and should only be trusted in aggregate