### PR TITLE
Require ToTP Token for Accounts at or above a gmlevel

### DIFF
--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -111,6 +111,17 @@ ConfVersion=2021031501
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 #
+#    RequireTokensFor
+#        Description: Require ToTP (Authenticators) for accounts this level and higher. 
+#           wotlkrealmd.account.token should be set to at least a 20 character, recommend 40 character, long 
+#           randomly generatedkey string containing only uppercase and numbers. 
+#           QR code string: otpauth://totp/{LABEL}?secret={GENERATEDKEY}
+#        Default:    -1 - (Disabled)
+#                     0 - (Players)
+#                     1 - (Moderators)
+#                     2 - (GameMasters)
+#                     3 - (Administrators)
+#
 #    WrongPass.MaxCount
 #        Number of login attemps with wrong password before the account or IP is banned
 #        Default: 0  (Never ban)
@@ -144,6 +155,7 @@ ProcessPriority = 1
 WaitAtStartupError = 0
 RealmsStateUpdateDelay = 20
 StrictVersionCheck = 0
+RequireTokensFor = -1
 WrongPass.MaxCount = 0
 WrongPass.BanTime = 600
 WrongPass.BanType = 0


### PR DESCRIPTION
Added new feature that allows the option to require a token for accounts of a specific gmlevel and higher, including all accounts.  Enforced by prompting for token, regardless if one is in the DB

## 🍰 Pullrequest
Edits realmd.conf.dist.in and  src/realmd/AuthSocket.cpp; creates a new realmd variable "RequireTokensFor" which takes the gmlevel and will force characters of that level and higher to use a token.  Implemented by simply showing the token regardless if one is set or not.

No obvious error messages existed in the client to help achieve this so simply showing the token box seemed like the right answer.

### Proof
- None

### Issues
- None

### How2Test
* Configure realmd.conf "RequireTokensFor" to 0, attempt to log into any character and a token box will appear.
* Configure realmd.conf "RequireTokensFor" to 1, attempt to log in with a player character and no box will appear.
*  Configure realmd.conf "RequireTokensFor" to 1, attempt to log in with a moderator or above and token box will appear.

### Todo / Checklist
- [X] None
