### PR TITLE
Require ToTP Token for Accounts at or above a gmlevel

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,139 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "master" ]
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  REPO_DIR : ${{github.workspace}}
+  BUILD_DIR: ${{github.workspace}}/bin/builddir
+  BOOST_VERSION: "1.83.0"
+  BOOST_PLATFORM_VERSION: "22.04"
+
+  
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: manual
+          COMPILER_CC: clang
+          COMPILER_PP: clang++
+          USE_PCH: ON
+          EXTRA_BUILD: "-DBUILD_EXTRACTORS=ON -DBUILD_AHBOT=ON -DBUILD_SCRIPTDEV=ON -DBUILD_METRICS=ON -DBUILD_DEPRECATED_PLAYERBOT=ON "
+        #- language: go
+        #  build-mode: autobuild
+          
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+   
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Create Build Environment
+      run: |
+        echo "GITHUB_SHORT_REV=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        echo "ARCHIVE_FILENAME=${{ github.event.repository.name }}-$(git rev-parse --short HEAD).zip" >> $GITHUB_ENV
+        echo "CC=${{matrix.COMPILER_CC}}" >> $GITHUB_ENV
+        echo "CXX=${{matrix.COMPILER_PP}}" >> $GITHUB_ENV
+        cmake -E make_directory ${{ env.BUILD_DIR }}
+  
+    
+    - name: Install Boost
+      uses: MarkusJx/install-boost@v2.4.5
+      id: install-boost
+      with:
+        # REQUIRED: Specify the required boost version
+        # A list of supported versions can be found here:
+        # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
+        boost_version: ${{env.BOOST_VERSION}}
+        # OPTIONAL: Specify a platform version
+        platform_version: ${{env.BOOST_PLATFORM_VERSION}}
+        # OPTIONAL: Specify a toolset
+        toolset: ${{env.COMPILER_CC}}
+        # OPTIONAL: Specify an architecture
+        arch: x86
+        # NOTE: If a boost version matching all requirements cannot be found,          
+        # this build step will fail
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+    
+    - name: Configure
+      env:
+        USE_PCH: ${{ matrix.USE_PCH }}
+        EXTRA_BUILD: ${{ matrix.EXTRA_BUILD }}
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+      run: cmake -DBoost_ARCHITECTURE=-x64 -DPCH=${{env.USE_PCH}} -DCMAKE_INSTALL_PREFIX=/home/runner/work ${{env.EXTRA_BUILD}}-B ${{env.BUILD_DIR}} -S ${{env.REPO_DIR}} 
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    
+    
+
+    - name: Build
+      env:
+        MAKEFLAGS: "-j8"
+    
+      run: |
+        cmake --build ${{env.BUILD_DIR}} --config ${{env.BUILD_TYPE}}
+        cmake --install ${{env.BUILD_DIR}}
+
+        
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,67 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow helps you trigger a SonarCloud analysis of your code and populates
+# GitHub Code Scanning alerts with the vulnerabilities found.
+# Free for open source project.
+
+# 1. Login to SonarCloud.io using your GitHub account
+
+# 2. Import your project on SonarCloud
+#     * Add your GitHub organization first, then add your repository as a new project.
+#     * Please note that many languages are eligible for automatic analysis,
+#       which means that the analysis will start automatically without the need to set up GitHub Actions.
+#     * This behavior can be changed in Administration > Analysis Method.
+#
+# 3. Follow the SonarCloud in-product tutorial
+#     * a. Copy/paste the Project Key and the Organization Key into the args parameter below
+#          (You'll find this information in SonarCloud. Click on "Information" at the bottom left)
+#
+#     * b. Generate a new token and add it to your Github repository's secrets using the name SONAR_TOKEN
+#          (On SonarCloud, click on your avatar on top-right > My account > Security
+#           or go directly to https://sonarcloud.io/account/security/)
+
+# Feel free to take a look at our documentation (https://docs.sonarcloud.io/getting-started/github/)
+# or reach out to our community forum if you need some help (https://community.sonarsource.com/c/help/sc/9)
+
+name: SonarCloud analysis
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read # allows SonarCloud to decorate PRs with analysis results
+
+jobs:
+  Analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Analyze with SonarCloud
+
+        # You can pin the exact commit or the version.
+        # uses: SonarSource/sonarcloud-github-action@v2.2.0
+        uses: SonarSource/sonarcloud-github-action@4006f663ecaf1f8093e8e4abb9227f6041f52216
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
+        with:
+          # Additional arguments for the SonarScanner CLI
+          args:
+            # Unique keys of your project and organization. You can find them in SonarCloud > Information (bottom-left menu)
+            # mandatory
+            -Dsonar.projectKey=Awesome-WoW-Empire_mangos-wotlk
+            -Dsonar.organization=awesome-wow-empire
+            # Comma-separated paths to directories containing main source files.
+            #-Dsonar.sources= src # optional, default is project base directory
+            # Comma-separated paths to directories containing test source files.
+            #-Dsonar.tests= # optional. For more info about Code Coverage, please refer to https://docs.sonarcloud.io/enriching/test-coverage/overview/
+            # Adds more detail to both client and server-side analysis logs, activating DEBUG mode for the scanner, and adding client-side environment variables and system properties to the server-side log of analysis report processing.
+            #-Dsonar.verbose= # optional, default is false
+          # When you need the analysis to take place in a directory other than the one from which it was launched, default is .
+          projectBaseDir: .

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+A security issue is ***not***:
+- To report a player for hacking and expect them to be banned
+- To report a game crash
+- To report a custom client is not working as expected
+
+A security issue ***is***:
+- To report knowledge of a working exploit or proof of a user exploiting
+- To report client vulnerability
+    - Must be the supported Awesome-WoW client
+- To report a method of crashing the server
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.3.5.12340   | :white_check_mark: |
+| < 3.3.5.12340   | :x:                |
+
+## Reporting a Vulnerability
+
+- To report an exploit, it must contain the name of the exploit at a minimum
+- To report a user exploiting, it must contain: name of the player, a timestamp, and a screenshot or video of the user exploiting
+- To report a client vulnerability, it must contain as much information to repduce the exploit as possible
+- To report a server crash, it must contain the steps to reproduce
+
+You can expect a response to a security report 7-10 busniess days.  
+
+Reports of a user exploiting may be rejected if there is not enough proof or information to discover the vulnerability or methods; this is the most likely result of reporting a user exploiting. Any other vulnerabilities will be accepted once a developer has proven the issue.  Not providing sufficient information may cause the issue to be rejected.
+
+Once accepted, you may expect updates once a week.

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -491,7 +491,7 @@ bool AuthSocket::_HandleLogonChallenge()
                             // Determine if there is a forced token requirement
                             const uint8 secLevel = fields[3].GetUInt8();
                             const int requireTokensForGMLevel = sConfig.GetIntDefault("RequireTokensFor", -1);
-                            const bool tokenOverride = secLevel >= requireTokensForGMLevel;
+                            const bool tokenOverride = requireTokensForGMLevel >= 0 && secLevel >= requireTokensForGMLevel;
                             if ( tokenOverride )
                                 DEBUG_LOG("[Auth] Overriding token requirements for %s with gmlevel %u",self->_login.c_str(),secLevel);
 

--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -111,6 +111,17 @@ ConfVersion=2021031501
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 #
+#    RequireTokensFor
+#        Description: Require ToTP (Authenticators) for accounts this level and higher. 
+#           wotlkrealmd.account.token should be set to at least a 20 character, recommend 40 character, long 
+#           randomly generatedkey string containing only uppercase and numbers. 
+#           QR code string: otpauth://totp/{LABEL}?secret={GENERATEDKEY}
+#        Default:    -1 - (Disabled)
+#                     0 - (Players)
+#                     1 - (Moderators)
+#                     2 - (GameMasters)
+#                     3 - (Administrators)
+#
 #    WrongPass.MaxCount
 #        Number of login attemps with wrong password before the account or IP is banned
 #        Default: 0  (Never ban)
@@ -144,6 +155,7 @@ ProcessPriority = 1
 WaitAtStartupError = 0
 RealmsStateUpdateDelay = 20
 StrictVersionCheck = 0
+RequireTokensFor = -1
 WrongPass.MaxCount = 0
 WrongPass.BanTime = 600
 WrongPass.BanType = 0


### PR DESCRIPTION
* Added new feature that allows the option to require a token for accounts of a specific gmlevel and higher, including all accounts. Enforced by prompting for token, regardless if one is in the DB

## 🍰 Pullrequest
Edits realmd.conf.dist.in and src/realmd/AuthSocket.cpp; creates a new realmd variable "RequireTokensFor" which takes the gmlevel and will force characters of that level and higher to use a token. Implemented by simply showing the token regardless if one is set or not.

No obvious error messages existed in the client to help achieve this so simply showing the token box seemed like the right answer.

### Proof
- None

### Issues
- None

### How2Test
* Configure realmd.conf "RequireTokensFor" to -1, attempt to log into a player and an admin, no token box will appear.
* Configure realmd.conf "RequireTokensFor" to 0, attempt to log into a player account and a token box will appear.
* Configure realmd.conf "RequireTokensFor" to 1, attempt to log in with a player character and no token box will appear.
* Configure realmd.conf "RequireTokensFor" to 1, attempt to log in with a game master or above and token box will appear.

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
