### PR TITLE
Fix CodeBench guard macro

### DIFF
--- a/src/shared/Util/CodeBench.cpp
+++ b/src/shared/Util/CodeBench.cpp
@@ -16,7 +16,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "CodeBench.h"
+#include "Util/CodeBench.h"
 #include "Log/Log.h"
 
 ChronoTimeTracker::~ChronoTimeTracker()

--- a/src/shared/Util/CodeBench.h
+++ b/src/shared/Util/CodeBench.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#ifndef MANGOS_TIMER_H
-#define MANGOS_TIMER_H
+#ifndef MANGOS_CODEBENCH_H
+#define MANGOS_CODEBENCH_H
 
 struct ChronoTimeTracker
 {
@@ -51,3 +51,4 @@ struct ChronoTimeTracker
 };
 
 #endif
+


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Old Guard Macro already exists in timer code, so can't be re-used.

Imo we should just switch to
```cpp
#pragma once
```
it is supported by every compiler and build system that is even remotely relevant.

Also fixes ambiguous include statement.