### PR TITLE
Map: Fixed a crash loading an instanceId 1 which is reserved for ebonhold

### DIFF
--- a/src/game/Maps/MapPersistentStateMgr.cpp
+++ b/src/game/Maps/MapPersistentStateMgr.cpp
@@ -854,7 +854,7 @@ void MapPersistentStateManager::PackInstances() const
     BarGoLink bar(InstanceSet.size() + 1);
     bar.step();
 
-    uint32 InstanceNumber = 1;
+    uint32 InstanceNumber = 2; //Reserve instance id 1 for ebonhold GetTeam() == ALLIANCE.
     // we do assume std::set is sorted properly on integer value
     for (uint32 i : InstanceSet)
     {


### PR DESCRIPTION
## 🍰 Pullrequest
This PR fixes an issue where instanceId's are reshuffled on server boot. The shuffling may move a dungeon instance at instance ID 1 which is reserved for ebon hold (alliance version)

### Proof
When creating new maps the deathknight start map for alliance is always given instanceId= 1 here: https://github.com/cmangos/mangos-wotlk/blob/6a6de7bc8cf4d96684f200d2d67e645a42fea8ee/src/game/Maps/MapManager.cpp#L131

During shuffling of saved instanceids to pack them in the changed code any saved dungeon can be assigned instanceID 1 which results the maps sharing the same ID causing a crash when loading players for the saved dungeon and finding the deathknight start map in saved instances.

### How2Test
Have a character saved to an instance.
Reboot the server and note that the instanceID is repacked to 1.
Activate the ebonhold for alliance.
Log in the character saved to the instance.
