### PR TITLE
Battleground: Fix crash when no players are left in a battleground.

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2112,6 +2112,9 @@ void BattleGroundMap::Update(const uint32& diff)
 {
     Map::Update(diff);
 
+    if (!m_bg)
+        return;
+
     if (!m_bg->GetPlayersSize())
     {
         // BG is empty


### PR DESCRIPTION
## 🍰 Pullrequest
This is a small crashfix which occurs when a battleground ends up empty.

### Proof
The code looks pretty clear m_bg is set to nullptr and the next BattleGroundMap::Update does m_bg->
While I'm unsure if there should have been some mechanic to prevent the update after the m_bg is cleared it clearly does not work.
It's very trivial to reproduce and test though.

### How2Test
-Join a battleground (".debug bg" to join alone).
-Hearthstone out and the server crashes.
