### PR TITLE
Guard ai: Prevent crash when killing a guard with a gameobject

### DIFF
--- a/src/game/AI/ScriptDevAI/base/guard_ai.cpp
+++ b/src/game/AI/ScriptDevAI/base/guard_ai.cpp
@@ -52,6 +52,9 @@ void guardAI::Aggro(Unit* who)
 
 void guardAI::JustDied(Unit* killer)
 {
+    if (!killer)
+        return;
+
     // Send Zone Under Attack message to the LocalDefense and WorldDefense Channels
     if (Player* pPlayer = killer->GetBeneficiaryPlayer())
         m_creature->SendZoneUnderAttackMessage(pPlayer);


### PR DESCRIPTION
## 🍰 Pullrequest
This is a small crash fix which occurs when a guard is killed using a spell cast by a gameobject.

### Proof
The killer in JustDied of the guardai is filled here: https://github.com/cmangos/mangos-wotlk/blob/2f5d3f41379b0e478883b893daf5eb6c7a87788d/src/game/Spells/SpellAuras.cpp#L8038
Which is filled with nullptr if the caster is a gameObject: https://github.com/cmangos/mangos-wotlk/blob/2f5d3f41379b0e478883b893daf5eb6c7a87788d/src/game/Spells/SpellAuras.cpp#L10126

This results in a crash trying to find the Beneficiary Player of nullptr.

### How2Test
-Make an alliance hunter with immolation trap.
-Go to mulgore and place the trap near a Brave Dawneagle (or other guard near bloodhoof village) killing it.
-The server will crash.
