### PR TITLE
Add SQLite support for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,9 +231,13 @@ endif()
 
 # Win32 delivered packages
 if(WIN32 AND (BUILD_GAME_SERVER OR BUILD_LOGIN_SERVER OR BUILD_EXTRACTORS))
-  set(MYSQL_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/dep/lib/include/mysql")
-  set(MYSQL_LIBRARY "${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_release/libmysql.lib")
-  set(MYSQL_DEBUG_LIBRARY "${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_debug/libmysql.lib")
+  if(SQLITE)
+    find_package(SQLite3 REQUIRED)
+  else()
+    set(MYSQL_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/dep/lib/include/mysql")
+    set(MYSQL_LIBRARY "${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_release/libmysql.lib")
+    set(MYSQL_DEBUG_LIBRARY "${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_debug/libmysql.lib")
+  endif()
   set(OPENSSL_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/dep/lib/include")
   set(OPENSSL_LIBRARIES
      "${CMAKE_SOURCE_DIR}/dep/lib/${DEP_ARCH}_release/libcrypto.lib"

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,7 @@
 option(DEBUG                                "Include additional debug-code in core"     OFF)
 option(WARNINGS                             "Show all warnings during compile"          OFF)
 option(POSTGRESQL                           "Use PostgreSQL"                            OFF)
+option(SQLITE                               "Use SQLite"                                OFF)
 option(PCH                                  "Use precompiled headers"                   ON)
 option(BUILD_GAME_SERVER                    "Build game server"                         ON)
 option(BUILD_LOGIN_SERVER                   "Build login server"                        ON)
@@ -31,6 +32,7 @@ message(STATUS
     DEBUG                   Include additional debug-code in core
     WARNINGS                Show all warnings during compile
     POSTGRESQL              Use PostgreSQL instead of mysql
+    SQLITE                  Use SQLite instead of mysql
     BUILD_GAME_SERVER       Build game server (core server)
     BUILD_LOGIN_SERVER      Build login server (auth server)
     BUILD_EXTRACTORS        Build map/dbc/vmap/mmap extractor

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -47,6 +47,8 @@ ConfVersion=2024020101
 #                ---PGSQL---
 #                    hostname;port;username;password;database
 #                    .;/path/to/unix_socket/DIRECTORY or . for default path;username;password;database - use Unix sockets at Unix/Linux
+#                ---SQLITE---
+#                    /path/to/sqlite.db
 #
 #    LoginDatabaseConnections
 #    WorldDatabaseConnections


### PR DESCRIPTION
## 🍰 Pullrequest
Adds necessary cmake support to use SQLite on Windows

### How2Test
Requires external SQLite library to be built or otherwise accessible through system path. See steps below for building the library manually.

Download source and binary packages from https://www.sqlite.org/download.html
- source example: `sqlite-amalgamation-3470000.zip`
- binary example: `sqlite-dll-win-x64-3470000.zip`

Extract content of both archives to `C:\Program Files\sqlite` (make sure the files are not in any subdirectories)

Open `Developer Command Prompt for VS` as administrator and navigate to `C:\Program Files\sqlite`

Run  `lib /DEF:sqlite3.def /OUT:sqlite3.lib /MACHINE:x64`

Open System Properties, Environment Variables, System Variables and add C:\Program Files\sqlite to PATH

Reboot to make environment variables take effect

cmake and build
![image](https://github.com/user-attachments/assets/b5bd4658-14f3-4b17-a1c3-458c0d4cbbf8)

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
