### PR TITLE
Mounts: Fix issues with vehicles and flying mounts

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -2064,7 +2064,8 @@ bool Player::ResolvePendingUnmount()
         ResummonPetTemporaryUnSummonedIfAny();
 
     UpdateSpeed(MOVE_RUN, true); // update speed
-    UpdateSpeed(MOVE_FLIGHT, true);
+    if (m_pendingMountAuraFlying)
+        UpdateSpeed(MOVE_FLIGHT, true);
 
     return true;
 }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -2064,6 +2064,7 @@ bool Player::ResolvePendingUnmount()
         ResummonPetTemporaryUnSummonedIfAny();
 
     UpdateSpeed(MOVE_RUN, true); // update speed
+    UpdateSpeed(MOVE_FLIGHT, true);
 
     return true;
 }

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -2040,6 +2040,8 @@ bool Player::ResolvePendingMount()
     }
 
     UpdateSpeed(MOVE_RUN, true); // update speed
+    if (m_pendingMountAuraFlying)
+        UpdateSpeed(MOVE_FLIGHT, true);
 
     return true;
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes a crash in Vehicle code that is caused by the vehicleInfo being destroyed before UnBoard is called, with UnBoard necessarily referencing vehicleInfo, which is its parent.

This PR also ensures that flying mounts have their speed properly updated. Don't ask my why it wasn't before.