### PR TITLE
Playerbot: linux compile fix for GCC and CLang

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -25,6 +25,9 @@
 #include "Entities/Transports.h"
 #include <Detour/Include/DetourCommon.h>
 #include <Detour/Include/DetourMath.h>
+#ifdef ENABLE_PLAYERBOTS
+#include "Server/DBCStores.h"
+#endif
 
 #ifdef BUILD_METRICS
  #include "Metric/Metric.h"


### PR DESCRIPTION
## 🍰 Pullrequest
This is a small include to fix a linux compile error specifically for GCC 14.2.1 / CLang 18.1.8

### Proof
In the playerbot specific code sMapStore.LookupEntry is used which required this include.