### PR TITLE
Map: Fix crash on bind to instance with incorrect persistentstate

### DIFF
--- a/src/game/Globals/ObjectMgr.cpp
+++ b/src/game/Globals/ObjectMgr.cpp
@@ -7449,11 +7449,17 @@ void ObjectMgr::SetHighestGuids()
         m_ItemGuids.Set((*result)[0].GetUInt32() + 1);
     }
 
+    uint32 newInstanceId = 0;
     result = CharacterDatabase.Query("SELECT MAX(id) FROM instance");
     if (result)
     {
-        m_InstanceGuids.Set((*result)[0].GetUInt32() + 1);
+        newInstanceId = (*result)[0].GetUInt32() + 1;
     }
+
+    if (newInstanceId < 2) //Instance id 0 and 1 are taken by ebon hold.
+        newInstanceId = 2;
+
+    m_InstanceGuids.Set(newInstanceId);
 
     // Cleanup other tables from nonexistent guids (>=m_hiItemGuid)
     CharacterDatabase.BeginTransaction();


### PR DESCRIPTION
## 🍰 Pullrequest
This PR fixes a crash when players enter an instance while the instance has an incorrect persistentstate. Because ebonhold reserves instance ids 0 and 1 issues can arise when new instance ids start at 1. This PR tries to resolve that.

### Proof
The initial crash occurs while adding a player to a DungeonPersistentState here: https://github.com/cmangos/mangos-wotlk/blob/f286d747906d01fee9ea110cdb43c2a406d2cabb/src/game/Entities/Player.cpp#L18004
This is called when creating a solo bind here: https://github.com/cmangos/mangos-wotlk/blob/f286d747906d01fee9ea110cdb43c2a406d2cabb/src/game/Maps/Map.cpp#L2291

Checking more closely showed that the m_mapid of the persistentstate did not match that of the map the player was trying to bind to but rather ebon hold. 

The issue is that the persistentstate is retrieved based on instanceId initially here: https://github.com/cmangos/mangos-wotlk/blob/f286d747906d01fee9ea110cdb43c2a406d2cabb/src/game/Maps/MapPersistentStateMgr.cpp#L723
However new instanceId's start at 1 or the lowest instanceId in the db + 1 seen here: https://github.com/cmangos/mangos-wotlk/blob/f286d747906d01fee9ea110cdb43c2a406d2cabb/src/game/Globals/ObjectMgr.cpp#L7455

In this PR we make sure that instanceId's start at 2 or the lowest instanceID in the db + 1 resolving this issue.

### How2Test
With a fresh server activate ebonhold for the horde side (instanceId 1) then try to enter an instance dungeon. 
