### PR TITLE
Visibility: Fix crash when entry of large creature is changed

### DIFF
--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -354,6 +354,10 @@ bool Creature::InitEntry(uint32 Entry, CreatureData const* data /*=nullptr*/, Ga
         }
     }
 
+    // Remove from large objects list if the new entry is not also a large object
+    if (!cinfo->IsLargeOrBiggerCreature())
+        GetMap()->RemoveFromLargeObjects(this);
+
     SetEntry(Entry);                                        // normal entry always
     m_creatureInfo = cinfo;                                 // map mode related always
 

--- a/src/game/Entities/Creature.cpp
+++ b/src/game/Entities/Creature.cpp
@@ -356,7 +356,9 @@ bool Creature::InitEntry(uint32 Entry, CreatureData const* data /*=nullptr*/, Ga
 
     // Remove from large objects list if the new entry is not also a large object
     if (!cinfo->IsLargeOrBiggerCreature())
-        GetMap()->RemoveFromLargeObjects(this);
+        GetMap()->RemoveEntryFromLargeObjects(this);
+    else
+        GetMap()->RemoveEntryFromLargeObjects(this, Entry);
 
     SetEntry(Entry);                                        // normal entry always
     m_creatureInfo = cinfo;                                 // map mode related always

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2051,10 +2051,16 @@ void Map::RemoveFromActive(WorldObject* obj)
     }
 }
 
-void Map::RemoveFromLargeObjects(WorldObject* obj)
+void Map::RemoveEntryFromLargeObjects(WorldObject* obj, uint32 newEntry)
 {
     if (obj->GetVisibilityData().IsLargeVisibility())
+    {
         m_largeObjects.erase(std::make_pair(obj, obj->GetEntry()));
+        if (newEntry)
+        {
+            m_largeObjects.insert(std::make_pair(obj, newEntry));
+        }
+    }
 }
 
 void Map::AddToOnEventNotified(WorldObject* obj)

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2056,10 +2056,9 @@ void Map::RemoveEntryFromLargeObjects(WorldObject* obj, uint32 newEntry)
     if (obj->GetVisibilityData().IsLargeVisibility())
     {
         m_largeObjects.erase(std::make_pair(obj, obj->GetEntry()));
-        if (newEntry)
-        {
-            m_largeObjects.insert(std::make_pair(obj, newEntry));
-        }
+        if (!newEntry)
+            return;
+        m_largeObjects.insert(std::make_pair(obj, newEntry));
     }
 }
 

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2053,13 +2053,12 @@ void Map::RemoveFromActive(WorldObject* obj)
 
 void Map::RemoveEntryFromLargeObjects(WorldObject* obj, uint32 newEntry)
 {
-    if (obj->GetVisibilityData().IsLargeVisibility())
-    {
-        m_largeObjects.erase(std::make_pair(obj, obj->GetEntry()));
-        if (!newEntry)
-            return;
-        m_largeObjects.insert(std::make_pair(obj, newEntry));
-    }
+    if (!obj->GetVisibilityData().IsLargeVisibility())
+        return;
+    m_largeObjects.erase(std::make_pair(obj, obj->GetEntry()));
+    if (!newEntry)
+        return;
+    m_largeObjects.insert(std::make_pair(obj, newEntry));
 }
 
 void Map::AddToOnEventNotified(WorldObject* obj)

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -2051,6 +2051,12 @@ void Map::RemoveFromActive(WorldObject* obj)
     }
 }
 
+void Map::RemoveFromLargeObjects(WorldObject* obj)
+{
+    if (obj->GetVisibilityData().IsLargeVisibility())
+        m_largeObjects.erase(std::make_pair(obj, obj->GetEntry()));
+}
+
 void Map::AddToOnEventNotified(WorldObject* obj)
 {
     m_onEventNotifiedObjects.insert(obj);

--- a/src/game/Maps/Map.h
+++ b/src/game/Maps/Map.h
@@ -298,6 +298,9 @@ class Map : public GridRefManager<NGridType>
         // must called with RemoveFromWorld
         void RemoveFromActive(WorldObject* obj);
 
+        // remove object from large objects list
+        void RemoveFromLargeObjects(WorldObject* obj);
+
         // Game Event notification system
         void AddToOnEventNotified(WorldObject* obj);
         void RemoveFromOnEventNotified(WorldObject* obj);

--- a/src/game/Maps/Map.h
+++ b/src/game/Maps/Map.h
@@ -299,7 +299,7 @@ class Map : public GridRefManager<NGridType>
         void RemoveFromActive(WorldObject* obj);
 
         // remove object from large objects list
-        void RemoveFromLargeObjects(WorldObject* obj);
+        void RemoveEntryFromLargeObjects(WorldObject* obj, uint32 newEntry = 0);
 
         // Game Event notification system
         void AddToOnEventNotified(WorldObject* obj);


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes a crash caused by changing the Entry of a creature that is marked as a large object to the entry of a creature that is not marked as a large object, upon the despawning of said new object.

Edit: The crash as it was reported actually did have the NPC that InitEntry() was used for also as a Large Creature, but because the Entry was no longer the same, `Map::Remove()` couldn't delete the creature from the `m_largeObjects` set, causing later map updates to access this already removed object.

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Learn skinning to at least 310
- Teleport to Hellfire Ramparts
- Start the Nazruden the Herald encounter
- Kill Nazruden
- Kill Nazan
- Skin Nazan
- Wait for crash

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [x] None
