### PR TITLE
Tweak conditional compilation and linking for MinGW compatibility

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -797,7 +797,7 @@ void Map::Update(const uint32& t_diff)
 
     m_curTime = time(nullptr);
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     localtime_s(&m_curTimeTm, &m_curTime);
 #else
     localtime_r(&m_curTime, &m_curTimeTm);

--- a/src/mangosd/CMakeLists.txt
+++ b/src/mangosd/CMakeLists.txt
@@ -61,10 +61,12 @@ target_link_libraries(${EXECUTABLE_NAME}
 )
 
 if(WIN32)
+  target_link_libraries(${EXECUTABLE_NAME}
+    winmm
+  )
   if(MSVC)
     target_link_libraries(${EXECUTABLE_NAME}
       dbghelp
-      winmm.lib
     )
   endif()
   if(MINGW)


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Changes two occasions of conditional statements for compiler and linker from being MSVC only to Win32 in general, which fixes project building when using MinGW toolchain. Otherwise build process fails for `game` and `mangosd` targets with undefined references.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
Build using MinGW-W64 v13, GCC 15.2, UCRT or MSVCRT runtimes (tested with both), CMake 3.31, Boost 1.87. MinGW binary releases can be taken from https://github.com/niXman/mingw-builds-binaries. Tested for all three mainline CMaNGOS cores.
