### PR TITLE
Fix undefined behavior by adding missing va_end.

### DIFF
--- a/src/game/Anticheat/module/Antispam/antispam.cpp
+++ b/src/game/Anticheat/module/Antispam/antispam.cpp
@@ -132,6 +132,7 @@ void Antispam::Notify(const char *format, ...)
 
     // GM NOTIFICATION
     sWorld.SendGMTextFlags(ACCOUNT_FLAG_SHOW_ANTISPAM, LANG_GM_ANNOUNCE_COLOR, "AntiSpam", message.str().c_str());
+    va_end(args);
 }
 
 void Antispam::Silence(const char *format, ...)
@@ -205,6 +206,7 @@ void Antispam::Silence(const char *format, ...)
     
     // GM NOTIFICATION
     sWorld.SendGMTextFlags(ACCOUNT_FLAG_SHOW_ANTISPAM, LANG_GM_ANNOUNCE_COLOR, "AntiSpam", message.str().c_str());
+    va_end(args);
 }
 
 Antispam::Antispam(uint32 account) :


### PR DESCRIPTION
Add missing va_end() to properly clean up variadic arguments.

## 🍰 Pullrequest
va_end() is needed whenever va_start() is called, before ending the function.
