### PR TITLE
Fix misplaced parenthesis in Broggok script

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/boss_broggok.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/outland/hellfire_citadel/blood_furnace/boss_broggok.cpp
@@ -134,7 +134,7 @@ struct npc_fel_orc : public CombatAI
         CombatAI::JustReachedHome();
          // Only Event Envolved NPCs should trigger fail condition
         if (m_creature->HasStringId(FIRST_BROGGOK_CELL_STRING) || m_creature->HasStringId(SECOND_BROGGOK_CELL_STRING) || m_creature->HasStringId(THIRD_BROGGOK_CELL_STRING) || m_creature->HasStringId(FOURTH_BROGGOK_CELL_STRING))
-            if (m_instance->GetData(TYPE_BROGGOK_EVENT == IN_PROGRESS))
+            if (m_instance->GetData(TYPE_BROGGOK_EVENT) == IN_PROGRESS)
                 m_instance->SetData(TYPE_BROGGOK_EVENT, FAIL);
     }
 };


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes a misplaced parenthesis in Broggok's script.

Based on the line just below, this is very likely a typo.
