### PR TITLE
Fix compiler warnings about enums and arithmetics

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -386,7 +386,7 @@ struct npc_putricides_trapAI : public ScriptedAI
             if (m_uiSummonTimer <= uiDiff)
             {
                 float fX, fY, fZ;
-                uint8 uiMaxInsects = urand(MAX_INSECT_PER_ROUND * 0.5, MAX_INSECT_PER_ROUND);
+                uint8 uiMaxInsects = urand(static_cast<float>(MAX_INSECT_PER_ROUND) * 0.5f, static_cast<float>(MAX_INSECT_PER_ROUND));
                 for (uint8 i = 0; i < uiMaxInsects; ++i)
                 {
                     m_creature->GetRandomPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), 15.0f, fX, fY, fZ);

--- a/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/boss_hodir.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/boss_hodir.cpp
@@ -470,7 +470,7 @@ struct BitingColdDamage : public AuraScript
         Unit* target = aura->GetTarget();
         if (!target)
             return;
-        int32 damage = VALUE_BITING_COLD_BASE_DAMAGE * std::pow(2, aura->GetStackAmount() - 1);
+        int32 damage = static_cast<int32>(VALUE_BITING_COLD_BASE_DAMAGE) * static_cast<int32>(std::pow(2, aura->GetStackAmount() - 1));
         target->CastCustomSpell(target, SPELL_BITING_COLD_STACK, &damage, nullptr, nullptr, TRIGGERED_OLD_TRIGGERED);
     }
 };

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -382,7 +382,7 @@ void BattleGround::Update(uint32 diff)
     if (IsArena() && !m_arenaBuffSpawned)
     {
         // 60 seconds after start the buffobjects in arena should get spawned
-        if (m_startTime > uint32(m_startDelayTimes[BG_STARTING_EVENT_FIRST] + ARENA_SPAWN_BUFF_OBJECTS))
+        if (m_startTime > uint32(static_cast<uint32>(m_startDelayTimes[BG_STARTING_EVENT_FIRST]) + static_cast<uint32>(ARENA_SPAWN_BUFF_OBJECTS)))
         {
             SpawnEvent(ARENA_BUFF_EVENT, 0, true);
             m_arenaBuffSpawned = true;
@@ -498,7 +498,7 @@ void BattleGround::Update(uint32 diff)
     if (GetStatus() == STATUS_IN_PROGRESS && IsArena())
     {
         // after 45 minutes without one team losing, the arena closes with no winner and -16 rating change for both
-        if (m_startTime > uint32(m_startDelayTimes[BG_STARTING_EVENT_FIRST] + ARENA_FORCED_DRAW))
+        if (m_startTime > uint32(static_cast<uint32>(m_startDelayTimes[BG_STARTING_EVENT_FIRST]) + static_cast<uint32>(ARENA_FORCED_DRAW)))
         {
             EndBattleGround(TEAM_NONE);
         }

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -382,7 +382,7 @@ void BattleGround::Update(uint32 diff)
     if (IsArena() && !m_arenaBuffSpawned)
     {
         // 60 seconds after start the buffobjects in arena should get spawned
-        if (m_startTime > uint32(static_cast<uint32>(m_startDelayTimes[BG_STARTING_EVENT_FIRST]) + static_cast<uint32>(ARENA_SPAWN_BUFF_OBJECTS)))
+        if (m_startTime > static_cast<uint32>(m_startDelayTimes[BG_STARTING_EVENT_FIRST]) + static_cast<uint32>(ARENA_SPAWN_BUFF_OBJECTS))
         {
             SpawnEvent(ARENA_BUFF_EVENT, 0, true);
             m_arenaBuffSpawned = true;
@@ -498,7 +498,7 @@ void BattleGround::Update(uint32 diff)
     if (GetStatus() == STATUS_IN_PROGRESS && IsArena())
     {
         // after 45 minutes without one team losing, the arena closes with no winner and -16 rating change for both
-        if (m_startTime > uint32(static_cast<uint32>(m_startDelayTimes[BG_STARTING_EVENT_FIRST]) + static_cast<uint32>(ARENA_FORCED_DRAW)))
+        if (m_startTime > static_cast<uint32>(m_startDelayTimes[BG_STARTING_EVENT_FIRST]) + static_cast<uint32>(ARENA_FORCED_DRAW))
         {
             EndBattleGround(TEAM_NONE);
         }

--- a/src/game/BattleGround/BattleGroundAB.cpp
+++ b/src/game/BattleGround/BattleGroundAB.cpp
@@ -71,7 +71,7 @@ void BattleGroundAB::Update(uint32 diff)
                 Team team = GetTeamIdByTeamIndex(PvpTeamIndex(teamIndex));
 
                 m_prevNodeStatus[node] = m_nodeStatus[node];
-                m_nodeStatus[node] = ABNodeStatus(teamIndex + BG_AB_NODE_TYPE_OCCUPIED);
+                m_nodeStatus[node] = ABNodeStatus(static_cast<uint16>(teamIndex) + static_cast<uint16>(BG_AB_NODE_TYPE_OCCUPIED));
 
                 // create new occupied banner
                 DoUpdateBanner(node, m_nodeStatus[node], true);
@@ -324,7 +324,7 @@ void BattleGroundAB::HandlePlayerClickedOnFlag(Player* player, GameObject* go)
         worldState             = abContestedStates[teamIndex][node];
 
         m_prevNodeStatus[node] = m_nodeStatus[node];
-        m_nodeStatus[node]     = ABNodeStatus(teamIndex + BG_AB_NODE_TYPE_CONTESTED);
+        m_nodeStatus[node]     = ABNodeStatus(static_cast<uint16>(teamIndex) + static_cast<uint16>(BG_AB_NODE_TYPE_CONTESTED));
 
         m_nodeTimers[node]     = BG_AB_FLAG_CAPTURING_TIME;
 
@@ -345,7 +345,7 @@ void BattleGroundAB::HandlePlayerClickedOnFlag(Player* player, GameObject* go)
             worldState              = abContestedStates[teamIndex][node];
 
             m_prevNodeStatus[node]  = m_nodeStatus[node];
-            m_nodeStatus[node]      = ABNodeStatus(teamIndex + BG_AB_NODE_TYPE_CONTESTED);
+            m_nodeStatus[node]      = ABNodeStatus(static_cast<uint16>(teamIndex) + static_cast<uint16>(BG_AB_NODE_TYPE_CONTESTED));
 
             m_nodeTimers[node]      = BG_AB_FLAG_CAPTURING_TIME;
 
@@ -361,7 +361,7 @@ void BattleGroundAB::HandlePlayerClickedOnFlag(Player* player, GameObject* go)
             worldState              = abOccupiedStates[teamIndex][node];
 
             m_prevNodeStatus[node]  = m_nodeStatus[node];
-            m_nodeStatus[node]      = ABNodeStatus(teamIndex + BG_AB_NODE_TYPE_OCCUPIED);
+            m_nodeStatus[node]      = ABNodeStatus(static_cast<uint16>(teamIndex) + static_cast<uint16>(BG_AB_NODE_TYPE_OCCUPIED));
 
             m_nodeTimers[node]      = 0;
 
@@ -383,7 +383,7 @@ void BattleGroundAB::HandlePlayerClickedOnFlag(Player* player, GameObject* go)
         worldState              = abContestedStates[teamIndex][node];
 
         m_prevNodeStatus[node]  = m_nodeStatus[node];
-        m_nodeStatus[node]      = ABNodeStatus(teamIndex + BG_AB_NODE_TYPE_CONTESTED);
+        m_nodeStatus[node]      = ABNodeStatus(static_cast<uint16>(teamIndex) + static_cast<uint16>(BG_AB_NODE_TYPE_CONTESTED));
 
         m_nodeTimers[node]      = BG_AB_FLAG_CAPTURING_TIME;
 

--- a/src/game/BattleGround/BattleGroundAV.cpp
+++ b/src/game/BattleGround/BattleGroundAV.cpp
@@ -578,8 +578,8 @@ void BattleGroundAV::ChangeMineOwner(AVMineIds mineId, PvpTeamIndex newOwnerTeam
     m_mineOwner[mineId] = newOwnerTeamIdx;
     GetBgMap()->GetVariableManager().SetVariable(avMineWorldStates[mineId][m_mineOwner[mineId]], WORLD_STATE_ADD);
 
-    SpawnEvent(BG_AV_MINE_EVENT + mineId, newOwnerTeamIdx, true);
-    SpawnEvent(BG_AV_MINE_BOSSES + mineId, newOwnerTeamIdx, true);
+    SpawnEvent(static_cast<uint8>(BG_AV_MINE_EVENT) + static_cast<uint8>(mineId), newOwnerTeamIdx, true);
+    SpawnEvent(static_cast<uint8>(BG_AV_MINE_BOSSES) + static_cast<uint8>(mineId), newOwnerTeamIdx, true);
 
     if (newOwnerTeamIdx == TEAM_INDEX_NEUTRAL)
         return;
@@ -635,11 +635,11 @@ void BattleGroundAV::PopulateNode(AVNodeIds node)
             graveDefenderType = 3;
 
         if (m_nodes[node].state == POINT_CONTROLLED) // we can spawn the current owner event
-            SpawnEvent(BG_AV_MAX_NODES + node, teamIdx * BG_AV_MAX_GRAVETYPES + graveDefenderType, true);
+            SpawnEvent(static_cast<uint8>(BG_AV_MAX_NODES) + static_cast<uint8>(node), static_cast<uint8>(teamIdx) * static_cast<uint8>(BG_AV_MAX_GRAVETYPES) + graveDefenderType, true);
         else // we despawn the event from the prevowner
-            SpawnEvent(BG_AV_MAX_NODES + node, m_nodes[node].prevOwner * BG_AV_MAX_GRAVETYPES + graveDefenderType, false);
+            SpawnEvent(static_cast<uint8>(BG_AV_MAX_NODES) + static_cast<uint8>(node), static_cast<uint8>(m_nodes[node].prevOwner) * static_cast<uint8>(BG_AV_MAX_GRAVETYPES) + graveDefenderType, false);
     }
-    SpawnEvent(node, (teamIdx * BG_AV_MAX_STATES) + m_nodes[node].state, true);
+    SpawnEvent(node, (static_cast<uint8>(teamIdx) * static_cast<uint8>(BG_AV_MAX_STATES)) + static_cast<uint8>(m_nodes[node].state), true);
 }
 
 // Handle banner click
@@ -849,7 +849,7 @@ void BattleGroundAV::InitializeNode(AVNodeIds node)
 
     if (avNodeDefaults[node].graveyardId)                                      // grave-creatures are special cause of a quest
     {
-        m_activeEvents[node + BG_AV_MAX_NODES]  = avNodeDefaults[node].initialOwner * BG_AV_MAX_GRAVETYPES;
+        m_activeEvents[node + BG_AV_MAX_NODES] = static_cast<uint8>(avNodeDefaults[node].initialOwner) * static_cast<uint8>(BG_AV_MAX_GRAVETYPES);
 
         // initialize graveyards
         Team team = TEAM_INVALID;

--- a/src/game/BattleGround/BattleGroundAV.h
+++ b/src/game/BattleGround/BattleGroundAV.h
@@ -670,7 +670,7 @@ class BattleGroundAV : public BattleGround
         void ChangeMineOwner(AVMineIds mineId, PvpTeamIndex newOwnerTeamIdx);
 
         // World state helpers
-        uint8 GetWorldStateType(uint8 state, PvpTeamIndex teamIdx) const { return teamIdx * BG_AV_MAX_STATES + state; }
+        uint8 GetWorldStateType(uint8 state, PvpTeamIndex teamIdx) const { return static_cast<uint16>(teamIdx) * static_cast<uint16>(BG_AV_MAX_STATES) + state; }
         void UpdateNodeWorldState(AVNodeIds node, uint32 newState);
 
         // Herald announcements

--- a/src/game/BattleGround/BattleGroundAV.h
+++ b/src/game/BattleGround/BattleGroundAV.h
@@ -670,7 +670,7 @@ class BattleGroundAV : public BattleGround
         void ChangeMineOwner(AVMineIds mineId, PvpTeamIndex newOwnerTeamIdx);
 
         // World state helpers
-        uint8 GetWorldStateType(uint8 state, PvpTeamIndex teamIdx) const { return static_cast<uint16>(teamIdx) * static_cast<uint16>(BG_AV_MAX_STATES) + state; }
+        uint8 GetWorldStateType(uint8 state, PvpTeamIndex teamIdx) const { return static_cast<uint8>(teamIdx) * static_cast<uint8>(BG_AV_MAX_STATES) + state; }
         void UpdateNodeWorldState(AVNodeIds node, uint32 newState);
 
         // Herald announcements

--- a/src/game/BattleGround/BattleGroundQueue.cpp
+++ b/src/game/BattleGround/BattleGroundQueue.cpp
@@ -799,18 +799,18 @@ bool BattleGroundQueueItem::CheckSkirmishForSameFaction(BattleGroundBracketId br
     // store last ginfo pointer
     GroupQueueInfo* ginfo = m_selectionPools[teamIdx].selectedGroups.back();
     // set itr_team to group that was added to selection pool latest
-    GroupsQueueType::iterator itr_team = m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + teamIdx].begin();
-    for (; itr_team != m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + teamIdx].end(); ++itr_team)
+    GroupsQueueType::iterator itr_team = m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(teamIdx)].begin();
+    for (; itr_team != m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(teamIdx)].end(); ++itr_team)
         if (ginfo == *itr_team)
             break;
 
-    if (itr_team == m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + teamIdx].end())
+    if (itr_team == m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(teamIdx)].end())
         return false;
 
     GroupsQueueType::iterator itr_team2 = itr_team;
     ++itr_team2;
     // invite players to other selection pool
-    for (; itr_team2 != m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + teamIdx].end(); ++itr_team2)
+    for (; itr_team2 != m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(teamIdx)].end(); ++itr_team2)
     {
         // if selection pool is full then break;
         if (!(*itr_team2)->isInvitedToBgInstanceGuid && !m_selectionPools[otherTeamIdx].AddGroup(*itr_team2, minPlayersPerTeam, 0))
@@ -827,16 +827,16 @@ bool BattleGroundQueueItem::CheckSkirmishForSameFaction(BattleGroundBracketId br
         (*itr)->groupTeam = otherTeamId;
 
         // add team to other queue
-        m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + otherTeamIdx].push_front(*itr);
+        m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(otherTeamIdx)].push_front(*itr);
 
         // remove team from old queue
         GroupsQueueType::iterator itr2 = itr_team;
         ++itr2;
-        for (; itr2 != m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + teamIdx].end(); ++itr2)
+        for (; itr2 != m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(teamIdx)].end(); ++itr2)
         {
             if (*itr2 == *itr)
             {
-                m_queuedGroups[bracketId][BG_QUEUE_NORMAL_ALLIANCE + teamIdx].erase(itr2);
+                m_queuedGroups[bracketId][static_cast<uint8>(BG_QUEUE_NORMAL_ALLIANCE) + static_cast<uint8>(teamIdx)].erase(itr2);
                 break;
             }
         }

--- a/src/game/Entities/Creature.h
+++ b/src/game/Entities/Creature.h
@@ -849,7 +849,7 @@ class Creature : public Unit
 
         void SendAreaSpiritHealerQueryOpcode(Player* pl) const;
 
-        void SetVirtualItem(VirtualItemSlot slot, uint32 item_id) { SetUInt32Value(UNIT_VIRTUAL_ITEM_SLOT_ID + slot, item_id); }
+        void SetVirtualItem(VirtualItemSlot slot, uint32 item_id) { SetUInt32Value(static_cast<uint16>(UNIT_VIRTUAL_ITEM_SLOT_ID) + static_cast<uint16>(slot), item_id); }
 
         bool hasWeapon(WeaponAttackType type) const override;
         bool hasWeaponForAttack(WeaponAttackType type) const override { return (Unit::hasWeaponForAttack(type) && hasWeapon(type)); }

--- a/src/game/Entities/GameObject.cpp
+++ b/src/game/Entities/GameObject.cpp
@@ -2123,9 +2123,9 @@ struct QuaternionCompressed
     void Set(const Quat& quat)
     {
         int8 w_sign = (quat.w >= 0 ? 1 : -1);
-        int64 X = int32(quat.x * PACK_COEFF_X) * w_sign & ((1 << 22) - 1);
-        int64 Y = int32(quat.y * PACK_COEFF_YZ) * w_sign & ((1 << 21) - 1);
-        int64 Z = int32(quat.z * PACK_COEFF_YZ) * w_sign & ((1 << 21) - 1);
+        int64 X = int32(quat.x * static_cast<double>(PACK_COEFF_X)) * w_sign & ((1 << 22) - 1);
+        int64 Y = int32(quat.y * static_cast<double>(PACK_COEFF_YZ)) * w_sign & ((1 << 21) - 1);
+        int64 Z = int32(quat.z * static_cast<double>(PACK_COEFF_YZ)) * w_sign & ((1 << 21) - 1);
         m_raw = Z | (Y << 21) | (X << 42);
     }
 

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -5652,7 +5652,7 @@ float Player::GetRatingMultiplier(CombatRating cr) const
 
 float Player::GetRatingBonusValue(CombatRating cr) const
 {
-    return float(GetUInt32Value(PLAYER_FIELD_COMBAT_RATING_1 + cr)) * GetRatingMultiplier(cr);
+    return float(GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_COMBAT_RATING_1) + static_cast<uint16>(cr))) * GetRatingMultiplier(cr);
 }
 
 void Player::ApplyRatingMod(CombatRating cr, int32 value, bool apply)
@@ -5699,7 +5699,7 @@ void Player::UpdateRating(CombatRating cr)
             amount += int32(GetStat(Stats(i->GetMiscBValue())) * i->GetModifier()->m_amount / 100.0f);
     if (amount < 0)
         amount = 0;
-    SetUInt32Value(PLAYER_FIELD_COMBAT_RATING_1 + cr, uint32(amount));
+    SetUInt32Value(static_cast<uint16>(PLAYER_FIELD_COMBAT_RATING_1) + static_cast<uint16>(cr), uint32(amount));
 
     bool affectStats = CanModifyStats();
 

--- a/src/game/Entities/StatSystem.cpp
+++ b/src/game/Entities/StatSystem.cpp
@@ -244,7 +244,7 @@ void Unit::UpdateMaxHealth()
 
 void Unit::UpdateMaxPower(Powers power)
 {
-    UnitMods unitMod = UnitMods(UNIT_MOD_POWER_START + power);
+    UnitMods unitMod = UnitMods(static_cast<uint32>(UNIT_MOD_POWER_START) + static_cast<uint32>(power));
 
     uint32 create_power = GetCreatePowers(power);
 
@@ -634,7 +634,7 @@ void Player::UpdateDodgePercentage()
     // Set current dodge chance
     m_modDodgeChance = value;
     // Set value for diminishing when in combat
-    m_modDodgeChanceDiminishing = GetDodgeFromAgility((GetStat(STAT_AGILITY) - (GetCreateStat(STAT_AGILITY) * m_auraModifiersGroup[UNIT_MOD_STAT_START + STAT_AGILITY][BASE_PCT])));
+    m_modDodgeChanceDiminishing = GetDodgeFromAgility((GetStat(STAT_AGILITY) - (GetCreateStat(STAT_AGILITY) * m_auraModifiersGroup[static_cast<uint32>(UNIT_MOD_STAT_START) + static_cast<uint32>(STAT_AGILITY)][BASE_PCT])));
     m_modDodgeChanceDiminishing += GetRatingBonusValue(CR_DODGE);
     // Set UI display value: modify value from defense skill against same level target
     value += (int32(GetDefenseSkillValue()) - int32(GetSkillMaxForLevel())) * 0.04f;
@@ -1134,7 +1134,7 @@ void Pet::UpdateMaxPower(Powers power)
         return;
     }
 
-    UnitMods unitMod = UnitMods(UNIT_MOD_POWER_START + power);
+    UnitMods unitMod = UnitMods(static_cast<uint32>(UNIT_MOD_POWER_START) + static_cast<uint32>(power));
 
     float addValue = (power == POWER_MANA) ? GetStat(STAT_INTELLECT) - GetCreateStat(STAT_INTELLECT) : 0.0f;
 

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -10389,7 +10389,7 @@ float Unit::GetModifierValue(UnitMods unitMod, UnitModifierType modifierType) co
 
 float Unit::GetTotalStatValue(Stats stat) const
 {
-    UnitMods unitMod = UnitMods(UNIT_MOD_STAT_START + stat);
+    UnitMods unitMod = UnitMods(static_cast<uint32>(UNIT_MOD_STAT_START) + static_cast<uint32>(stat));
 
     if (m_auraModifiersGroup[unitMod][TOTAL_PCT] <= 0.0f)
         return 0.0f;
@@ -10405,7 +10405,7 @@ float Unit::GetTotalStatValue(Stats stat) const
 
 float Unit::GetTotalResistanceValue(SpellSchools school) const
 {
-    UnitMods unitMod = UnitMods(UNIT_MOD_RESISTANCE_START + school);
+    UnitMods unitMod = UnitMods(static_cast<uint32>(UNIT_MOD_RESISTANCE_START) + static_cast<uint32>(school));
 
     if (m_auraModifiersGroup[unitMod][TOTAL_PCT] <= 0.0f)
         return 0.0f;
@@ -10618,7 +10618,7 @@ void Unit::SetPower(Powers power, float val, bool withPowerUpdate /*= true*/)
     if (maxPower < val)
         val = maxPower;
 
-    SetStatInt32Value(UNIT_FIELD_POWER1 + power, int32(val));
+    SetStatInt32Value(static_cast<uint16>(UNIT_FIELD_POWER1) + static_cast<uint16>(power), int32(val));
     m_unitPower[power] = val;
 
     if (withPowerUpdate && !GetMap()->IsUpdateObjectTick())
@@ -10655,7 +10655,7 @@ void Unit::SetPower(Powers power, float val, bool withPowerUpdate /*= true*/)
 void Unit::SetMaxPower(Powers power, uint32 val)
 {
     uint32 cur_power = GetPower(power);
-    SetStatInt32Value(UNIT_FIELD_MAXPOWER1 + power, val);
+    SetStatInt32Value(static_cast<uint16>(UNIT_FIELD_MAXPOWER1) + static_cast<uint16>(power), val);
 
     // group update
     if (GetTypeId() == TYPEID_PLAYER)
@@ -10677,7 +10677,7 @@ void Unit::SetMaxPower(Powers power, uint32 val)
 void Unit::ApplyPowerMod(Powers power, uint32 val, bool apply)
 {
     m_unitPower[power] = m_unitPower[power] + (apply ? val : -val);
-    ApplyModUInt32Value(UNIT_FIELD_POWER1 + power, val, apply);
+    ApplyModUInt32Value(static_cast<uint16>(UNIT_FIELD_POWER1) + static_cast<uint16>(power), val, apply);
 
     // group update
     if (GetTypeId() == TYPEID_PLAYER)
@@ -10695,7 +10695,7 @@ void Unit::ApplyPowerMod(Powers power, uint32 val, bool apply)
 
 void Unit::ApplyMaxPowerMod(Powers power, uint32 val, bool apply)
 {
-    ApplyModUInt32Value(UNIT_FIELD_MAXPOWER1 + power, val, apply);
+    ApplyModUInt32Value(static_cast<uint16>(UNIT_FIELD_MAXPOWER1) + static_cast<uint16>(power), val, apply);
 
     // group update
     if (GetTypeId() == TYPEID_PLAYER)
@@ -11822,18 +11822,18 @@ bool Unit::HasBreakableByDamageCrowdControlAura(Unit* excludeCasterChannel, uint
 
 void Unit::ApplyAttackTimePercentMod(WeaponAttackType att, float val, bool apply)
 {
-    float oldVal = GetFloatValue(UNIT_FIELD_BASEATTACKTIME + att);
+    float oldVal = GetFloatValue(static_cast<uint16>(UNIT_FIELD_BASEATTACKTIME) + static_cast<uint16>(att));
     if (val > 0)
     {
         ApplyPercentModFloatVar(m_modAttackSpeedPct[att], val, !apply);
-        ApplyPercentModFloatValue(UNIT_FIELD_BASEATTACKTIME + att, val, !apply);
+        ApplyPercentModFloatValue(static_cast<uint16>(UNIT_FIELD_BASEATTACKTIME) + static_cast<uint16>(att), val, !apply);
     }
     else
     {
         ApplyPercentModFloatVar(m_modAttackSpeedPct[att], -val, apply);
-        ApplyPercentModFloatValue(UNIT_FIELD_BASEATTACKTIME + att, -val, apply);
+        ApplyPercentModFloatValue(static_cast<uint16>(UNIT_FIELD_BASEATTACKTIME) + static_cast<uint16>(att), -val, apply);
     }
-    float newVal = GetFloatValue(UNIT_FIELD_BASEATTACKTIME + att);
+    float newVal = GetFloatValue(static_cast<uint16>(UNIT_FIELD_BASEATTACKTIME) + static_cast<uint16>(att));
     uint32 attackTimer = getAttackTimer(att);
     int32 diff = newVal - oldVal;
     setAttackTimer(att, diff < -int32(attackTimer) ? 0 : attackTimer + diff);

--- a/src/game/Entities/Unit.h
+++ b/src/game/Entities/Unit.h
@@ -1393,14 +1393,13 @@ class Unit : public WorldObject
         uint32 getClassMask() const { return 1 << (getClass() - 1); }
         uint8 getGender() const { return GetByteValue(UNIT_FIELD_BYTES_0, UNIT_BYTES_0_OFFSET_GENDER); }
 
-        float GetStat(Stats stat) const { return float(GetUInt32Value(UNIT_FIELD_STAT0 + stat)); }
-        void SetStat(Stats stat, int32 val) { SetStatInt32Value(UNIT_FIELD_STAT0 + stat, val); }
+        float GetStat(Stats stat) const { return float(GetUInt32Value(static_cast<uint16>(UNIT_FIELD_STAT0) + static_cast<uint16>(stat))); }
+        void SetStat(Stats stat, int32 val) { SetStatInt32Value(static_cast<uint16>(UNIT_FIELD_STAT0) + static_cast<uint16>(stat), val); }
 
         inline int32 GetArmor() const { return GetResistance(SPELL_SCHOOL_NORMAL) ; }
-        inline void SetArmor(int32 val) { SetStatInt32Value(UNIT_FIELD_RESISTANCES, val); }
-
-        inline int32 GetResistance(SpellSchools school) const { return GetInt32Value(UNIT_FIELD_RESISTANCES + school); }
-        inline void SetResistance(SpellSchools school, int32 val) { SetInt32Value(UNIT_FIELD_RESISTANCES + school, val); }
+        inline void SetArmor(int32 val) { SetStatInt32Value(static_cast<uint16>(UNIT_FIELD_RESISTANCES), val); }
+        inline int32 GetResistance(SpellSchools school) const { return GetInt32Value(static_cast<uint16>(UNIT_FIELD_RESISTANCES) + static_cast<uint16>(school)); }
+        inline void SetResistance(SpellSchools school, int32 val) { SetInt32Value(static_cast<uint16>(UNIT_FIELD_RESISTANCES) + static_cast<uint16>(school), val); }
 
         uint32 GetHealth()    const { return GetUInt32Value(UNIT_FIELD_HEALTH); }
         float GetRealHealth() const { return m_unitHealth; }
@@ -1415,9 +1414,9 @@ class Unit : public WorldObject
 
         Powers GetPowerType() const { return Powers(GetByteValue(UNIT_FIELD_BYTES_0, UNIT_BYTES_0_OFFSET_POWER_TYPE)); }
         void SetPowerType(Powers new_powertype, bool sendUpdate = true);
-        uint32 GetPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_POWER1 + power); }
+        uint32 GetPower(Powers power) const { return GetUInt32Value(static_cast<uint16>(UNIT_FIELD_POWER1) + static_cast<uint16>(power)); }
         float GetRealPower(Powers power) const { return m_unitPower[power]; }
-        uint32 GetMaxPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_MAXPOWER1 + power); }
+        uint32 GetMaxPower(Powers power) const { return GetUInt32Value(static_cast<uint16>(UNIT_FIELD_MAXPOWER1) + static_cast<uint16>(power)); }
         float GetPowerPercent() const { return (GetMaxPower(GetPowerType()) == 0) ? 0.0f : (GetPower(GetPowerType()) * 100.0f) / GetMaxPower(GetPowerType()); }
         float GetPowerPercent(Powers power) const { return (GetMaxPower(power) == 0) ? 0.0f : (GetPower(power) * 100.0f) / GetMaxPower(power); }
         void SetPower(Powers power, float val, bool withPowerUpdate = true);
@@ -1428,8 +1427,8 @@ class Unit : public WorldObject
         void ApplyMaxPowerMod(Powers power, uint32 val, bool apply);
         bool HasMana() { return GetPowerType() == POWER_MANA; }
 
-        uint32 GetAttackTime(WeaponAttackType att) const { return (uint32)(GetFloatValue(UNIT_FIELD_BASEATTACKTIME + att) / m_modAttackSpeedPct[att]); }
-        void SetAttackTime(WeaponAttackType att, uint32 val) { SetFloatValue(UNIT_FIELD_BASEATTACKTIME + att, val * m_modAttackSpeedPct[att]); }
+        uint32 GetAttackTime(WeaponAttackType att) const { return (uint32)(GetFloatValue(static_cast<uint16>(UNIT_FIELD_BASEATTACKTIME) + static_cast<uint16>(att)) / m_modAttackSpeedPct[att]); }
+        void SetAttackTime(WeaponAttackType att, uint32 val) { SetFloatValue(static_cast<uint16>(UNIT_FIELD_BASEATTACKTIME) + static_cast<uint16>(att), val * m_modAttackSpeedPct[att]); }
         void ApplyAttackTimePercentMod(WeaponAttackType att, float val, bool apply);
         void ApplyCastTimePercentMod(float val, bool apply);
 
@@ -2058,20 +2057,20 @@ class Unit : public WorldObject
 
         void DelaySpellAuraHolder(uint32 spellId, int32 delaytime, ObjectGuid casterGuid);
 
-        float GetResistanceBuffMods(SpellSchools school, bool positive) const { return GetFloatValue(positive ? UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + school : UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + school); }
-        void SetResistanceBuffMods(SpellSchools school, bool positive, float val) { SetFloatValue(positive ? UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + school : UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + school, val); }
-        void ApplyResistanceBuffModsMod(SpellSchools school, bool positive, float val, bool apply) { ApplyModSignedFloatValue(positive ? UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + school : UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + school, val, apply); }
-        void ApplyResistanceBuffModsPercentMod(SpellSchools school, bool positive, float val, bool apply) { ApplyPercentModFloatValue(positive ? UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + school : UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + school, val, apply); }
+        float GetResistanceBuffMods(SpellSchools school, bool positive) const { return GetFloatValue(positive ? static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE) + static_cast<uint16>(school) : static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE) + static_cast<uint16>(school)); }
+        void SetResistanceBuffMods(SpellSchools school, bool positive, float val) { SetFloatValue(positive ? static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE) + static_cast<uint16>(school) : static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE) + static_cast<uint16>(school), val); }
+        void ApplyResistanceBuffModsMod(SpellSchools school, bool positive, float val, bool apply) { ApplyModSignedFloatValue(positive ? static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE) + static_cast<uint16>(school) : static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE) + static_cast<uint16>(school), val, apply); }
+        void ApplyResistanceBuffModsPercentMod(SpellSchools school, bool positive, float val, bool apply) { ApplyPercentModFloatValue(positive ? static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE) + static_cast<uint16>(school) : static_cast<uint16>(UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE) + static_cast<uint16>(school), val, apply); }
         void InitStatBuffMods()
         {
-            for (int i = STAT_STRENGTH; i < MAX_STATS; ++i) SetFloatValue(UNIT_FIELD_POSSTAT0 + i, 0);
-            for (int i = STAT_STRENGTH; i < MAX_STATS; ++i) SetFloatValue(UNIT_FIELD_NEGSTAT0 + i, 0);
+            for (int i = STAT_STRENGTH; i < MAX_STATS; ++i) SetFloatValue(static_cast<uint16>(UNIT_FIELD_POSSTAT0) + i, 0);
+            for (int i = STAT_STRENGTH; i < MAX_STATS; ++i) SetFloatValue(static_cast<uint16>(UNIT_FIELD_NEGSTAT0) + i, 0);
         }
-        void ApplyStatBuffMod(Stats stat, float val, bool apply) { ApplyModSignedFloatValue((val > 0 ? UNIT_FIELD_POSSTAT0 + stat : UNIT_FIELD_NEGSTAT0 + stat), val, apply); }
+        void ApplyStatBuffMod(Stats stat, float val, bool apply) { ApplyModSignedFloatValue((val > 0 ? static_cast<uint16>(UNIT_FIELD_POSSTAT0) + stat : static_cast<uint16>(UNIT_FIELD_NEGSTAT0) + stat), val, apply); }
         void ApplyStatPercentBuffMod(Stats stat, float val, bool apply)
         {
-            ApplyPercentModFloatValue(UNIT_FIELD_POSSTAT0 + stat, val, apply);
-            ApplyPercentModFloatValue(UNIT_FIELD_NEGSTAT0 + stat, val, apply);
+            ApplyPercentModFloatValue(static_cast<uint16>(UNIT_FIELD_POSSTAT0) + stat, val, apply);
+            ApplyPercentModFloatValue(static_cast<uint16>(UNIT_FIELD_NEGSTAT0) + stat, val, apply);
         }
         void SetCreateStat(Stats stat, float val) { m_createStats[stat] = val; }
         void SetCreateHealth(uint32 val) { SetUInt32Value(UNIT_FIELD_BASE_HEALTH, val); }
@@ -2079,8 +2078,8 @@ class Unit : public WorldObject
         void SetCreateMana(uint32 val) { SetUInt32Value(UNIT_FIELD_BASE_MANA, val); }
         uint32 GetCreateMana() const { return GetUInt32Value(UNIT_FIELD_BASE_MANA); }
         uint32 GetCreatePowers(Powers power) const;
-        float GetPosStat(Stats stat) const { return GetFloatValue(UNIT_FIELD_POSSTAT0 + stat); }
-        float GetNegStat(Stats stat) const { return GetFloatValue(UNIT_FIELD_NEGSTAT0 + stat); }
+        float GetPosStat(Stats stat) const { return GetFloatValue(static_cast<uint16>(UNIT_FIELD_POSSTAT0) + static_cast<uint16>(stat)); }
+        float GetNegStat(Stats stat) const { return GetFloatValue(static_cast<uint16>(UNIT_FIELD_NEGSTAT0) + static_cast<uint16>(stat)); }
         float GetCreateStat(Stats stat) const { return m_createStats[stat]; }
         void SetCreateResistance(SpellSchools school, int32 val) { m_createResistances[school] = val; }
         int32 GetCreateResistance(SpellSchools school) const { return m_createResistances[school]; }

--- a/src/game/Entities/Vehicle.cpp
+++ b/src/game/Entities/Vehicle.cpp
@@ -538,12 +538,12 @@ void VehicleInfo::UnBoard(Unit* passenger, bool changeVehicle)
 
         if (VehicleSeatParameters const* params = sObjectMgr.GetVehicleSeatParameters(seatEntry->m_ID))
         {
-            if (params->exitParamValue == SEAT_EXIT_PARAMS_OFFSET)
+            if (params->exitParamValue == static_cast<float>(SEAT_EXIT_PARAMS_OFFSET))
             {
                 exitPos.RelocateOffset(Position(params->exitParamX, params->exitParamY, params->exitParamZ, params->exitParamO));
                 m_owner->UpdateAllowedPositionZ(exitPos.x, exitPos.y, exitPos.z);
             }
-            else if (params->exitParamValue == SEAT_EXIT_PARAMS_ABSOLUTE_POS)
+            else if (params->exitParamValue == static_cast<float>(SEAT_EXIT_PARAMS_ABSOLUTE_POS))
             {
                 exitPos.x = params->exitParamX;
                 exitPos.y = params->exitParamY;

--- a/src/game/Maps/MapPersistentStateMgr.cpp
+++ b/src/game/Maps/MapPersistentStateMgr.cpp
@@ -1213,7 +1213,7 @@ time_t MapPersistentStateManager::GetSubsequentResetTime(uint32 mapid, Difficult
     }
 
     time_t resetHour = sWorld.getConfig(CONFIG_UINT32_INSTANCE_RESET_TIME_HOUR);
-    time_t period = uint32(((mapDiff->resetTime * sWorld.getConfig(CONFIG_FLOAT_RATE_INSTANCE_RESET_TIME)) / DAY) * DAY);
+    time_t period = uint32(((mapDiff->resetTime * sWorld.getConfig(CONFIG_FLOAT_RATE_INSTANCE_RESET_TIME)) / static_cast<float>(DAY)) * DAY);
     if (period < DAY)
         period = DAY;
 

--- a/src/game/Spells/Scripts/Scripting/ClassScripts/ScalingAuras.cpp
+++ b/src/game/Spells/Scripts/Scripting/ClassScripts/ScalingAuras.cpp
@@ -173,8 +173,8 @@ struct WarlockPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 fire = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_FIRE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_FIRE);
-                        int32 shadow = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_SHADOW);
+                        int32 fire = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_FIRE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_FIRE));
+                        int32 shadow = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_SHADOW))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_SHADOW));
                         int32 maximum = (fire > shadow) ? fire : shadow;
                         if (maximum < 0)
                             maximum = 0;
@@ -187,8 +187,8 @@ struct WarlockPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 fire = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_FIRE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_FIRE);
-                        int32 shadow = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_SHADOW);
+                        int32 fire = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_FIRE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_FIRE));
+                        int32 shadow = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_SHADOW))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_SHADOW));
                         int32 maximum = (fire > shadow) ? fire : shadow;
                         if (maximum < 0)
                             maximum = 0;
@@ -322,7 +322,7 @@ struct MagePetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 frost = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_FROST)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_FROST);
+                        int32 frost = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_FROST))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_FROST));
                         if (frost < 0)
                             frost = 0;
                         value = frost * 0.4f;
@@ -411,7 +411,7 @@ struct PriestPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 shadow = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_SHADOW);
+                        int32 shadow = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_SHADOW))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_SHADOW));
                         if (shadow < 0)
                             shadow = 0;
                         value = shadow * 0.65f;
@@ -498,7 +498,7 @@ struct ElementalPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 nature = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_NATURE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_NATURE);
+                        int32 nature = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_NATURE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_NATURE));
                         if (nature < 0)
                             nature = 0;
                         value = nature * 0.57f;
@@ -510,7 +510,7 @@ struct ElementalPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 nature = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_NATURE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_NATURE);
+                        int32 nature = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_NATURE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_NATURE));
                         if (nature < 0)
                             nature = 0;
                         value = nature * 0.65f;
@@ -599,7 +599,7 @@ struct DruidPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 nature = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_NATURE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_NATURE);
+                        int32 nature = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_NATURE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_NATURE));
                         if (nature < 0)
                             nature = 0;
                         value = nature * 0.5f;
@@ -693,7 +693,7 @@ struct FeralSpiritPetScaling1 : public AuraScript
                         float mod = 0.5f;
                         if (Aura* aura = owner->GetAura(63271, EFFECT_INDEX_0))
                             mod += float(aura->GetAmount()) / 100;
-                        int32 nature = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_NATURE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_NATURE);
+                        int32 nature = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_NATURE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_NATURE));
                         if (nature < 0)
                             nature = 0;
                         value = nature * mod;
@@ -705,7 +705,7 @@ struct FeralSpiritPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 nature = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_NATURE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_NATURE);
+                        int32 nature = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_NATURE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_NATURE));
                         if (nature < 0)
                             nature = 0;
                         value = nature * 0.65f;
@@ -864,8 +864,8 @@ struct InfernalPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 fire = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_FIRE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_FIRE);
-                        int32 shadow = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_SHADOW);
+                        int32 fire = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_FIRE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_FIRE));
+                        int32 shadow = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_SHADOW))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_SHADOW));
                         int32 maximum = (fire > shadow) ? fire : shadow;
                         if (maximum < 0)
                             maximum = 0;
@@ -878,8 +878,8 @@ struct InfernalPetScaling1 : public AuraScript
                 {
                     if (owner->IsPlayer())
                     {
-                        int32 fire = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_FIRE)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_FIRE);
-                        int32 shadow = int32(owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_POS + SPELL_SCHOOL_SHADOW)) - owner->GetUInt32Value(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + SPELL_SCHOOL_SHADOW);
+                        int32 fire = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_FIRE))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_FIRE));
+                        int32 shadow = int32(owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_POS) + static_cast<uint16>(SPELL_SCHOOL_SHADOW))) - owner->GetUInt32Value(static_cast<uint16>(PLAYER_FIELD_MOD_DAMAGE_DONE_NEG) + static_cast<uint16>(SPELL_SCHOOL_SHADOW));
                         int32 maximum = (fire > shadow) ? fire : shadow;
                         if (maximum < 0)
                             maximum = 0;

--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -7625,7 +7625,7 @@ uint32 Spell::CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spel
     }
     SpellSchools school = GetFirstSchoolInMask(spell ? spell->m_spellSchoolMask : GetSpellSchoolMask(spellInfo));
     // Flat mod from caster auras by spell school
-    powerCost += caster->GetInt32Value(UNIT_FIELD_POWER_COST_MODIFIER + school);
+    powerCost += caster->GetInt32Value(static_cast<uint16>(UNIT_FIELD_POWER_COST_MODIFIER) + static_cast<uint16>(school));
     // Shiv - costs 20 + weaponSpeed*10 energy (apply only to non-triggered spell with energy cost)
     if (spellInfo->HasAttribute(SPELL_ATTR_EX4_WEAPON_SPEED_COST_SCALING))
         powerCost += caster->GetAttackTime(OFF_ATTACK) / 100;
@@ -7643,7 +7643,7 @@ uint32 Spell::CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spel
     }
 
     // PCT mod from user auras by school
-    powerCost = int32(powerCost * (1.0f + caster->GetFloatValue(UNIT_FIELD_POWER_COST_MULTIPLIER + school)));
+    powerCost = int32(powerCost * (1.0f + caster->GetFloatValue(static_cast<uint16>(UNIT_FIELD_POWER_COST_MULTIPLIER) + static_cast<uint16>(school))));
     if (powerCost < 0)
         powerCost = 0;
     return powerCost;

--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -6874,7 +6874,7 @@ void Aura::HandleAuraModIncreaseEnergy(bool apply, bool Real)
     Unit* target = GetTarget();
     Powers powerType = Powers(m_modifier.m_miscvalue);
 
-    UnitMods unitMod = UnitMods(UNIT_MOD_POWER_START + powerType);
+    UnitMods unitMod = UnitMods(static_cast<uint32>(UNIT_MOD_POWER_START) + static_cast<uint32>(powerType));
 
     // Special case with temporary increase max/current power (percent)
     if (GetId() == 64904)                                   // Hymn of Hope
@@ -6897,7 +6897,7 @@ void Aura::HandleAuraModIncreaseEnergyPercent(bool apply, bool /*Real*/)
     Unit* target = GetTarget();
     Powers powerType = Powers(m_modifier.m_miscvalue);
 
-    UnitMods unitMod = UnitMods(UNIT_MOD_POWER_START + powerType);
+    UnitMods unitMod = UnitMods(static_cast<uint32>(UNIT_MOD_POWER_START) + static_cast<uint32>(powerType));
 
     target->HandleStatModifier(unitMod, TOTAL_PCT, float(m_modifier.m_amount), apply);
     target->ModifyPower(powerType, apply ? m_modifier.m_amount : -m_modifier.m_amount);

--- a/src/game/Spells/SpellEffects.cpp
+++ b/src/game/Spells/SpellEffects.cpp
@@ -710,7 +710,7 @@ void Spell::EffectSchoolDMG(SpellEffectIndex eff_idx)
                     // Add main hand dps * effect[2] amount
                     float average = (m_caster->GetFloatValue(UNIT_FIELD_MINDAMAGE) + m_caster->GetFloatValue(UNIT_FIELD_MAXDAMAGE)) / 2;
                     int32 count = m_caster->CalculateSpellEffectValue(unitTarget, m_spellInfo, EFFECT_INDEX_2);
-                    damage += count * int32(average * IN_MILLISECONDS) / m_caster->GetAttackTime(BASE_ATTACK);
+                    damage += count * int32(average * static_cast<uint32>(IN_MILLISECONDS)) / m_caster->GetAttackTime(BASE_ATTACK);
                 }
                 // Shield of Righteousness
                 else if (m_spellInfo->SpellFamilyFlags & uint64(0x0010000000000000))

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -201,7 +201,7 @@ void Log::SetLogLevel(char* level)
 
     m_logLevel = LogLevel(newLevel);
 
-    printf("LogLevel is %u\n", m_logLevel);
+    printf("LogLevel is %u\n", static_cast<uint8>(m_logLevel));
 }
 
 void Log::SetLogFileLevel(char* level)
@@ -215,7 +215,7 @@ void Log::SetLogFileLevel(char* level)
 
     m_logFileLevel = LogLevel(newLevel);
 
-    printf("LogFileLevel is %u\n", m_logFileLevel);
+    printf("LogFileLevel is %u\n", static_cast<uint8>(m_logFileLevel));
 }
 
 void Log::Initialize()
@@ -986,7 +986,7 @@ void Log::WaitBeforeContinueIfNeed()
     }
     else if (mode > 0)
     {
-        printf("\nWait %u secs for continue.\n", mode);
+        printf("\nWait %u secs for continue.\n", static_cast<uint8>(mode));
         BarGoLink bar(mode);
         for (int i = 0; i < mode; ++i)
         {


### PR DESCRIPTION
## 🍰 Pullrequest
Force casting enums when used for arithmetic operations into integer or float values (said types will depend on their intended usage, i.e the signature of the method that takes them).
