### PR TITLE
Fix server crash on player login, part 2

### DIFF
--- a/src/game/Achievements/AchievementMgr.cpp
+++ b/src/game/Achievements/AchievementMgr.cpp
@@ -772,7 +772,7 @@ void AchievementMgr::SendCriteriaUpdate(uint32 id, CriteriaProgress const* progr
     WorldPacket data(SMSG_CRITERIA_UPDATE, 8 + 4 + 8);
     data << uint32(id);
 
-    TimePoint now = GetPlayer()->GetMap()->GetCurrentClockTime();
+    TimePoint now = sWorld.GetCurrentClockTime();
     // the counter is packed like a packed Guid
     data.appendPackGUID(progress->counter);
 


### PR DESCRIPTION
## 🍰 Pullrequest
Second part of my original pull request that addressed the same problem which was dealt with in another commit, but only partially. It still crashes without this modification (inspired by @killerwife 's solution).

### Issues
- relates https://github.com/cmangos/issues/issues/4017

### How2Test
(Not all) characters crash on login.
