### PR TITLE
Various (very minor) fixes suggested by CppCheck

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/violet_hold/violet_hold.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/violet_hold/violet_hold.cpp
@@ -401,8 +401,7 @@ void instance_violet_hold::SetData(uint32 uiType, uint32 uiData)
                 }
 
                 // set achiev to failed
-                if (m_bIsDefenseless)
-                    m_bIsDefenseless = false;
+                m_bIsDefenseless = false;
 
                 if (!m_uiWorldStateSealCount)
                 {

--- a/src/game/AI/ScriptDevAI/scripts/world/mob_generic_creature.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/world/mob_generic_creature.cpp
@@ -137,11 +137,8 @@ struct generic_creatureAI : public ScriptedAI
             // Found a spell, check if we arn't on cooldown
             if (info && !GlobalCooldown)
             {
-                // If we are currently moving stop us and set the movement generator
-                if (!IsSelfRooted)
-                {
-                    IsSelfRooted = true;
-                }
+                // Stop us and set the movement generator
+                IsSelfRooted = true;
 
                 // Cast spell
                 if (Healing)

--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -581,7 +581,7 @@ void AuctionHouseBot::ParseItemValueConfig(char const* fieldname, std::vector<ui
 
 void AuctionHouseBot::AddLootToItemMap(LootStore* store, std::vector<int32>& lootConfig, std::vector<uint32>& lootTemplates, std::unordered_map<uint32, uint32>& itemMap)
 {
-    if (lootConfig[1] <= 0 || lootConfig[3] <= 0 || lootTemplates.size() <= 0)
+    if (lootConfig[1] <= 0 || lootConfig[3] <= 0 || lootTemplates.empty())
         return;
     int32 maxTemplates = lootConfig[0] < 0 ? urand(0, lootConfig[1] - lootConfig[0]) + lootConfig[0] : urand(lootConfig[0], lootConfig[1]);
     if (maxTemplates <= 0)

--- a/src/game/Combat/ThreatManager.cpp
+++ b/src/game/Combat/ThreatManager.cpp
@@ -316,7 +316,7 @@ void ThreatContainer::update(bool force, bool isPlayer)
                 bool first = owner->CanReachWithMeleeAttack(lhs->getTarget());
                 bool second = owner->CanReachWithMeleeAttack(rhs->getTarget());
                 if (first != second)
-                    return first > second;
+                    return first;
             }
             if (lhs->GetHostileState() != rhs->GetHostileState())
                 return lhs->GetHostileState() > rhs->GetHostileState();

--- a/src/game/Entities/GossipDef.cpp
+++ b/src/game/Entities/GossipDef.cpp
@@ -513,7 +513,7 @@ void PlayerMenu::SendQuestGiverOfferReward(Quest const* pQuest, ObjectGuid npcGU
     uint32 EmoteCount = 0;
     for (unsigned int i : pQuest->OfferRewardEmote)
     {
-        if (i <= 0)
+        if (i == 0)
             break;
         ++EmoteCount;
     }

--- a/src/game/Entities/Unit.cpp
+++ b/src/game/Entities/Unit.cpp
@@ -729,8 +729,7 @@ void Unit::SendMoveRoot(bool state, bool/* broadcastOnly*/)
         {
             m_movementInfo.RemoveMovementFlag(movementFlagsMask);
             m_movementInfo.AddMovementFlag(MOVEFLAG_ROOT);
-            if (!client)
-                StopMoving(true);
+            StopMoving(true);
         }
         else
             m_movementInfo.RemoveMovementFlag(MOVEFLAG_ROOT);

--- a/src/game/PlayerBot/Base/PlayerbotAI.cpp
+++ b/src/game/PlayerBot/Base/PlayerbotAI.cpp
@@ -2044,12 +2044,9 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
         // Handle Group invites (auto accept if master is in group, otherwise decline & send message
         case SMSG_GROUP_INVITE:
         {
-            if (m_bot->GetGroupInvite())
+            const Group* const grp = m_bot->GetGroupInvite();
+            if (grp)
             {
-                const Group* const grp = m_bot->GetGroupInvite();
-                if (!grp)
-                    return;
-
                 Player* const inviter = sObjectMgr.GetPlayer(grp->GetLeaderGuid());
                 if (!inviter)
                     return;
@@ -2210,7 +2207,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                 uint32 copper = m_bot->GetMoney();
                 out.str("");
                 out << "I have |cff00ff00" << Cash(copper) << "|r";
-                SendWhisper(out.str().c_str(), *(m_bot->GetTrader()));
+                SendWhisper(out.str(), *(m_bot->GetTrader()));
             }
             return;
         }
@@ -11479,7 +11476,7 @@ void PlayerbotAI::_HandleCommandSurvey(std::string& /*text*/, Player& fromPlayer
         while (queryResult->NextRow());
 
     }
-    SendWhisper(detectout.str().c_str(), fromPlayer);
+    SendWhisper(detectout.str(), fromPlayer);
 }
 
 // _HandleCommandSkill: Handle class & professions training:

--- a/src/game/Spells/Spell.h
+++ b/src/game/Spells/Spell.h
@@ -126,6 +126,7 @@ class SpellCastTargets
             m_unitTarget = target.m_unitTarget;
             m_itemTarget = target.m_itemTarget;
             m_GOTarget   = target.m_GOTarget;
+            m_CorpseTarget = target.m_CorpseTarget;
 
             m_unitTargetGUID    = target.m_unitTargetGUID;
             m_GOTargetGUID      = target.m_GOTargetGUID;


### PR DESCRIPTION
## 🍰 Pullrequest
This is a minor pullrequest that adresses some of the problems indicated by CppCheck. In essence it deals with minor logic errors by applying the most logical fix.

Fixes are : 
- _"if myBoolean = true then myBoolean = false"_ ===> _"myBoolean = false"_.
- Testing if unsigned ints < 0.
- ThreatManager : numeric comparison of two pure boolean variables. If booleans were to be interpreted as integers (1 for true and 0 for false) as it was the case eons ago, then this test can be converted to "return first" since 1 > 0.
- Unit.cpp  = this "if" will always be true since we're in a parent "if" with the same condition.
- Spell.h = member variable not copied in copy constructor.
- PlayerbotAI : That second "if (!grp)" was never going to happen since grp is the same value we test inside the parent "if".

