### PR TITLE
Fix client crash when a session is reused

### DIFF
--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -496,15 +496,15 @@ bool WorldSession::Update(uint32 /*diff*/)
                 m_socket = m_requestSocket;
                 m_requestSocket = nullptr;
                 sLog.outDetail("New Session key %s", m_socket->GetSessionKey().AsHexStr());
-                SendAuthOk();
             }
+            
+            if (m_inQueue)
+                SendAuthQueued();
             else
-            {
-                if (m_inQueue)
-                    SendAuthQueued();
-                else
-                    SendAuthOk();
-            }
+                SendAuthOk();
+
+            SendClientCacheVersion();
+            SendTutorialsData();
             SetInCharSelection();
             return true;
         }
@@ -1327,6 +1327,13 @@ void WorldSession::SendTimeSync()
     m_pendingTimeSyncRequests[m_timeSyncNextCounter] = WorldTimer::getMSTime();
 
     m_timeSyncNextCounter++;
+}
+
+void WorldSession::SendClientCacheVersion() const
+{
+    WorldPacket pkt(SMSG_CLIENTCACHE_VERSION, 4);
+    pkt << uint32(sWorld.getConfig(CONFIG_UINT32_CLIENTCACHE_VERSION));
+    SendPacket(pkt);
 }
 
 void WorldSession::InitializeAnticheat(const BigNumber& K)

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -273,6 +273,7 @@ class WorldSession
         void SendOfflineNameQueryResponses();
         void SendNotification(const char* format, ...) const ATTR_PRINTF(2, 3);
         void SendNotification(int32 string_id, ...) const;
+        void SendClientCacheVersion() const;
         void SendPetNameInvalid(uint32 error, const std::string& name, DeclinedName* declinedName) const;
         static WorldPacket BuildLfgJoinResult(LfgJoinResultData joinResult);
         static WorldPacket BuildLfgUpdate(LfgUpdateData const& updateData, bool isGroup);

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -571,8 +571,6 @@ bool WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
             std::unique_ptr<SessionAnticheatInterface> anticheat = sAnticheatLib->NewSession(session, K);
 
-            session->SendAuthOk();
-
             // when false, the client sent invalid addon data.  kick!
             WorldPacket addonPacket; // yes its copypasted atm cos of reconnect
             if (!anticheat->ReadAddonInfo(const_cast<WorldPacket*>(&recvPacket), addonPacket))
@@ -618,8 +616,6 @@ bool WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         m_session->SetOS(clientOS);
         m_session->SetPlatform(clientPlatform);
         m_session->InitializeAnticheat(K);
-
-        m_session->SendAuthOk();
 
         // when false, the client sent invalid addon data.  kick!
         WorldPacket addonPacket;

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -275,12 +275,6 @@ World::AddSession_(WorldSession* s)
         return;
     }
 
-    WorldPacket pkt(SMSG_CLIENTCACHE_VERSION, 4);
-    pkt << uint32(getConfig(CONFIG_UINT32_CLIENTCACHE_VERSION));
-    s->SendPacket(pkt);
-
-    s->SendTutorialsData();
-
     UpdateMaxSessionCounters();
 
     // Updates the population
@@ -363,12 +357,7 @@ bool World::RemoveQueuedSession(WorldSession* sess)
         pop_sess->SetInQueue(false);
         pop_sess->SendAuthWaitQue(0);
 
-        WorldPacket pkt(SMSG_CLIENTCACHE_VERSION, 4);
-        pkt << uint32(getConfig(CONFIG_UINT32_CLIENTCACHE_VERSION));
-        pop_sess->SendPacket(pkt);
-
         pop_sess->SendAccountDataTimes(GLOBAL_CACHE_MASK);
-        pop_sess->SendTutorialsData();
 
         m_QueuedSessions.pop_front();
 


### PR DESCRIPTION
## 🍰 Pullrequest
The client crashes when a chat message is sent after it was previously closed without properly logging out.

The game crashes with an access violation at `0x00530475` caused by a null pointer dereference. The crash occurs because the server does not send the tutorial data flags when a session is reused after a client reconnects. The pointer to the tutorial flags is stored in a global variable at `0x00BD1AFC`, which remains null if the client does not receive this data from the server, leading to a null pointer exception when the client checks whether the chat related tutorial flag is set.

### Proof
<!-- Link resources as proof -->
- None

### Issues
- None

### How2Test
- Start the game and log in
- Send a chat message -> all good, works fine
- Close the game with Alt+F4
- Restart and log in again using the same account
- Send another message -> client crashes

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
