### PR TITLE
Spell: 19572, 19573 - Fix Improved Mend Pet

### DIFF
--- a/src/game/Spells/SpellAuras.cpp
+++ b/src/game/Spells/SpellAuras.cpp
@@ -8330,13 +8330,30 @@ void Aura::PeriodicTick()
             if (!pCaster)
                 break;
 
-            // don't heal target if max health or if not alive, mostly death persistent effects from items
-            if (!target->IsAlive() || (target->GetHealth() == target->GetMaxHealth()))
+            // don't heal target if not alive, mostly death persistent effects from items
+            if (!target->IsAlive())
                 break;
 
             // heal for caster damage (must be alive)
             if (target != pCaster && spellProto->SpellVisual[0] == 163 && !pCaster->IsAlive())
                 break;
+
+            if (target->GetHealth() == target->GetMaxHealth())
+            {
+                // Mend Pet:
+                // trigger auras even without healing, required for Improved Mend Pet to proc when the pet is at full hp:
+                if (spellProto->SpellFamilyName == SPELLFAMILY_HUNTER && spellProto->SpellFamilyFlags & uint64(0x0000000000800000))
+                {
+                    uint32 procAttacker = PROC_FLAG_DEAL_HARMFUL_PERIODIC;
+                    uint32 procVictim = PROC_FLAG_TAKE_HARMFUL_PERIODIC;
+                    uint32 procEx = PROC_EX_INTERNAL_HOT | PROC_EX_NORMAL_HIT;
+                    int32 gain = 0;
+
+                    Unit::ProcDamageAndSpell(ProcSystemArguments(pCaster, target, procAttacker, procVictim, procEx, gain, 0, BASE_ATTACK, spellProto, nullptr, gain, true));
+                }
+                
+                break;
+            }
 
             // ignore non positive values (can be result apply spellmods to aura damage
             uint32 amount = m_modifier.m_amount > 0 ? m_modifier.m_amount : 0;
@@ -8382,8 +8399,7 @@ void Aura::PeriodicTick()
             pCaster->CalculateHealAbsorb(pdamage, &absorbHeal);
             pdamage -= absorbHeal;
 
-            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s heal of %s for %u health  (absorbed %u) inflicted by %u",
-                GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, absorbHeal, GetId());
+            DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s heal of %s for %u health  (absorbed %u) inflicted by %u", GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, absorbHeal, GetId());
 
             int32 gain = target->ModifyHealth(pdamage);
             SpellPeriodicAuraLogInfo pInfo(this, pdamage, (pdamage - uint32(gain)), absorbHeal, 0, 0.0f, isCrit);

--- a/src/game/Spells/UnitAuraProcHandler.cpp
+++ b/src/game/Spells/UnitAuraProcHandler.cpp
@@ -2144,6 +2144,19 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(ProcExecutionData& data)
                 target = this;
                 break;
             }
+            // Improved Mend Pet
+            if (dummySpell->Id == 19572 || dummySpell->Id == 19573)
+            {
+                bool mendPetTick = data.spellInfo->SpellFamilyFlags & uint64(0x0000000000800000) && data.procExtra & PROC_EX_INTERNAL_HOT;
+
+                if (!mendPetTick || !roll_chance_i(triggerAmount))
+                    return SPELL_AURA_PROC_FAILED;
+
+                triggered_spell_id = 24406;
+                target = pVictim;
+                break;
+            }
+
             break;
         }
         case SPELLFAMILY_PALADIN:
@@ -3899,15 +3912,6 @@ SpellAuraProcResult Unit::HandleOverrideClassScriptAuraProc(ProcExecutionData& d
             // Check that only priest class can proc it is done in Spell::CheckTargetScript() for aura 23401
             if (IsSpellHaveEffect(spellInfo, SPELL_EFFECT_HEAL))
                 triggered_spell_id = 23402;
-            break;
-        }
-        case 4086:                                          // Improved Mend Pet (Rank 1)
-        case 4087:                                          // Improved Mend Pet (Rank 2)
-        {
-            if (!roll_chance_i(triggerAmount))
-                return SPELL_AURA_PROC_FAILED;
-
-            triggered_spell_id = 24406;
             break;
         }
         case 4533:                                          // Dreamwalker Raiment 2 pieces bonus


### PR DESCRIPTION
## 🍰 Pullrequest
Improved Mend Pet doesn't cure negative effects as the spell effect changed in WotLK compared to TBC: `SPELL_AURA_OVERRIDE_CLASS_SCRIPTS` -> `SPELL_AURA_DUMMY`

I also made it proc even when the pet is at full hp (correct me if I’m wrong).

### Proof
I fixed it based on the spell's description and its previous implementation, which works in TBC.

### Issues
- None

### How2Test
- `.character level 80`
- `.learn 1515` (Tame beast)
- `.learn 136` (Mend Pet - Rank 1)
- Learn Improved Mend Pet talent (I used the talent tree)
- `.tele elwyn`
- Tame a nearby wolf
- `.aura 702` (on pet)
- Cast Mend Pet (on pet)
- Improved Mend Pet should remove the curse with a 25% / 50% chance per tick depending on the rank.

### Todo / Checklist
- [ ] DB migration

```
UPDATE spell_proc_event SET procFlags = 278528, procEx = 3 WHERE entry = 19572;

INSERT INTO spell_proc_event (entry, SchoolMask, SpellFamilyName, SpellFamilyMaskA0, SpellFamilyMaskA1, SpellFamilyMaskA2, SpellFamilyMaskB0, SpellFamilyMaskB1, SpellFamilyMaskB2, SpellFamilyMaskC0, SpellFamilyMaskC1, SpellFamilyMaskC2, procFlags, procEx, ppmRate, CustomChance, Cooldown) VALUES
(19573, 0, 9, 8388608, 8388608, 8388608, 0, 0, 0, 0, 0, 0, 278528, 3, 0, 0, 0)
```
