### PR TITLE
Fix for talents that modify AP based on another stat

### DIFF
--- a/src/game/Entities/StatSystem.cpp
+++ b/src/game/Entities/StatSystem.cpp
@@ -380,9 +380,10 @@ void Player::UpdateAttackPowerAndDamage(bool ranged)
     }
 
     float attPowerMultiplier = GetModifierValue(unitMod, TOTAL_PCT) - 1.0f;
+    int32 statBonus = int32(attPowerMod) - int32(GetModifierValue(unitMod, TOTAL_VALUE));
 
     SetInt32Value(index, (uint32)base_attPower);            // UNIT_FIELD_(RANGED)_ATTACK_POWER field
-    SetInt16Value(index_mod, 0, m_attackPowerMod[size_t(mod)][size_t(AttackPowerModSign::MOD_SIGN_POS)]);
+    SetInt16Value(index_mod, 0, int32(m_attackPowerMod[size_t(mod)][size_t(AttackPowerModSign::MOD_SIGN_POS)]) + statBonus);
     SetInt16Value(index_mod, 1, m_attackPowerMod[size_t(mod)][size_t(AttackPowerModSign::MOD_SIGN_NEG)]);
     SetFloatValue(index_mult, attPowerMultiplier);          // UNIT_FIELD_(RANGED)_ATTACK_POWER_MULTIPLIER field
 


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes a regression that broke talents that buffed AP based from other stats : Shaman's Mental Dexterity (51883-51885), Hunter's Careful Aim (34482-34484), and Warrior's Armored to the Teeth (61216-61222).

A bit of explanation on this one since it's a bit tricky :sweat_smile: the commit 75b1d0a8b introduced a bug in Player::UpdateAttackPowerAndDamage : the function correctly computes stat-based bonus into attPowerMod (lines 361–379):
```cpp
float attPowerMod = GetModifierValue(unitMod, TOTAL_VALUE);  // line 358
// ... stat-based bonuses added to attPowerMod (lines 365–379)
```

But at lines 384–387, it writes m_attackPowerMod[pos/neg] to the unit fields, which only tracks regular flat AP bonuses added via HandleStatModifier, not the dynamically computed stat-based part :
```cpp
SetInt16Value(index_mod, 0, m_attackPowerMod[...][MOD_SIGN_POS]);  // missing stat bonus
SetInt16Value(index_mod, 1, m_attackPowerMod[...][MOD_SIGN_NEG]);
```
The attPowerMod local variable (which includes the stat bonuses) is never written to any field. Since GetTotalAttackPowerValue reads from the unit fields, all AP-based calculations silently ignore these talents.

Basically what my commit does is compute the stat-based bonus as the difference between attPowerMod (after the loops) and GetModifierValue(unitMod, TOTAL_VALUE) (which equals m_attackPowerMod[pos] +m_attackPowerMod[neg] and has not changed since line 358), plus add this bonus to the positive mod field.

GetModifierValue(unitMod, TOTAL_VALUE) is unchanged between line 358 and line 382 (nothing modifies it during this function)
attPowerMod - TOTAL_VALUE = the net stat-based bonus (always >= 0)
Adding it to the positive field slot correctly reflects it in GetTotalAttackPowerValue which reads field[0] + field[1]

### Proof
Before : no AP gain.
After : AP gain / loss when buffing with Arcane Intellect, equipping/unequipping intellect stuff, etc.

### Issues
- fixes [#3990](https://github.com/cmangos/issues/issues/3990)

### How2Test
* Log in with a Shaman with Mental Dexterity talented
* Check AP, it should increase proportionally to Intellect
* Equip/unequip INT gear, AP should change
* Repeat for hunt (Careful Aim) and warrior (Armored to the Teeth)
* Use a buff that changes Intellect (e.g., Arcane Intellect) and verify AP updates live
