### PR TITLE
Fix cooldowns

### DIFF
--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4198,6 +4198,7 @@ void Player::_SaveSpellCooldowns()
 
     static SqlStatementID insertSpellCooldown;
 
+    uint64 nowUnix = static_cast<uint64>(Clock::to_time_t(GetMap()->GetCurrentClockTime()));
     for (auto& cdItr : m_cooldownMap)
     {
         auto& cdData = cdItr.second;
@@ -4209,6 +4210,10 @@ void Player::_SaveSpellCooldowns()
             cdData->GetCatCDExpireTime(cTime);
             uint64 spellExpireTime = uint64(Clock::to_time_t(sTime));
             uint64 catExpireTime = uint64(Clock::to_time_t(cTime));
+
+            // Skip entries where both cooldowns have already expired - no point persisting them
+            if (spellExpireTime <= nowUnix && catExpireTime <= nowUnix)
+                continue;
 
             stmt = CharacterDatabase.CreateStatement(insertSpellCooldown, "INSERT INTO character_spell_cooldown (guid, SpellId, SpellExpireTime, Category, CategoryExpireTime, ItemId) VALUES( ?, ?, ?, ?, ?, ?)");
             stmt.addUInt32(GetGUIDLow());
@@ -25314,10 +25319,19 @@ void Player::AddCooldown(SpellEntry const& spellEntry, ItemPrototype const* item
     }
 
     // blizzlike code for choosing which is recTime > categoryRecTime after spellmod application
+    // We use signed intermediates to prevent uint32 underflow when a flat reduction exceeds the CD value
     if (recTime)
-        ApplySpellMod(spellEntry.Id, SPELLMOD_COOLDOWN, recTime);
+    {
+        int32 signedRecTime = static_cast<int32>(recTime);
+        ApplySpellMod(spellEntry.Id, SPELLMOD_COOLDOWN, signedRecTime);
+        recTime = signedRecTime > 0 ? static_cast<uint32>(signedRecTime) : 0;
+    }
     if (spellCategory && categoryRecTime && !spellEntry.HasAttribute(SPELL_ATTR_EX6_NO_CATEGORY_COOLDOWN_MODS))
-        ApplySpellMod(spellEntry.Id, SPELLMOD_COOLDOWN, categoryRecTime);
+    {
+        int32 signedCatRecTime = static_cast<int32>(categoryRecTime);
+        ApplySpellMod(spellEntry.Id, SPELLMOD_COOLDOWN, signedCatRecTime);
+        categoryRecTime = signedCatRecTime > 0 ? static_cast<uint32>(signedCatRecTime) : 0;
+    }
 
     if (recTime || categoryRecTime || wasPermanent)
     {

--- a/src/game/Entities/Player.cpp
+++ b/src/game/Entities/Player.cpp
@@ -4198,7 +4198,7 @@ void Player::_SaveSpellCooldowns()
 
     static SqlStatementID insertSpellCooldown;
 
-    uint64 nowUnix = static_cast<uint64>(Clock::to_time_t(GetMap()->GetCurrentClockTime()));
+    TimePoint now = GetMap()->GetCurrentClockTime();
     for (auto& cdItr : m_cooldownMap)
     {
         auto& cdData = cdItr.second;
@@ -4208,12 +4208,13 @@ void Player::_SaveSpellCooldowns()
             TimePoint cTime = TimePoint::min();
             cdData->GetSpellCDExpireTime(sTime);
             cdData->GetCatCDExpireTime(cTime);
-            uint64 spellExpireTime = uint64(Clock::to_time_t(sTime));
-            uint64 catExpireTime = uint64(Clock::to_time_t(cTime));
 
             // Skip entries where both cooldowns have already expired - no point persisting them
-            if (spellExpireTime <= nowUnix && catExpireTime <= nowUnix)
+            if (sTime <= now && cTime <= now)
                 continue;
+
+            uint64 spellExpireTime = uint64(Clock::to_time_t(sTime));
+            uint64 catExpireTime = uint64(Clock::to_time_t(cTime));
 
             stmt = CharacterDatabase.CreateStatement(insertSpellCooldown, "INSERT INTO character_spell_cooldown (guid, SpellId, SpellExpireTime, Category, CategoryExpireTime, ItemId) VALUES( ?, ?, ?, ?, ?, ?)");
             stmt.addUInt32(GetGUIDLow());


### PR DESCRIPTION
## 🍰 Pullrequest
Fixes 2 cooldown problems where spells like Blind with CategoryRecoveryTime were stored with an enormous (12h+) value which was caused by an unsigned integer underflow. My original issue gave a detailed view of how the bug occurs and what happens in the database when the player logs off.

Aside from fixing the underflow, my fix takes care of the useless persisting of expired cooldowns on logout / .save (which was a secondary bug linked to the unsigned integer underflow one).

### Issues
- fixes [#4021](https://github.com/cmangos/issues/issues/4021)
- fixes [#3877](https://github.com/cmangos/issues/issues/3877)
- fixes [#3418](https://github.com/cmangos/issues/issues/3418)

### How2Test
- Horde rogue, target Gamon
- Cast Blind
- While on cooldown, try to recast blind
- When the 2 mins cooldown is finished, you should be able to cast Blind again :)
- Logout and back on, the cooldown is accurate and not 12+ hours.