### PR TITLE
Dialogue: Separate broadcast_text entries out in Dialogue Helper steps

### DIFF
--- a/src/game/AI/ScriptDevAI/include/sc_instance.cpp
+++ b/src/game/AI/ScriptDevAI/include/sc_instance.cpp
@@ -395,7 +395,7 @@ void DialogueHelper::DoNextDialogueStep()
                 DoScriptText(iTextEntry, pSpeaker);
         }
     }
-    else if (uiSpeakerEntry && iTextEntry > 0)
+    else if (uiSpeakerEntry && iTextEntry > 0 && m_currentEntry->type == DIALOGUE_STEP_TEXT)
     {
         // Use Speaker if directly provided
         Creature* speaker = GetSpeakerByEntry(uiSpeakerEntry);

--- a/src/game/AI/ScriptDevAI/include/sc_instance.h
+++ b/src/game/AI/ScriptDevAI/include/sc_instance.h
@@ -85,12 +85,20 @@ class ScriptedMap : public ScriptedInstance
         ScriptedMap(Map* map) : ScriptedInstance(map) {}
 };
 
+enum DialogueStepType
+{
+    DIALOGUE_STEP_ACTION,
+    DIALOGUE_STEP_TEXT,
+    DIALOGUE_STEP_MAX
+};
+
 /// A static const array of this structure must be handled to DialogueHelper
 struct DialogueEntry
 {
     int32 textEntry;                                       ///< To be said text entry
     uint32 sayerEntry;                                    ///< Entry of the mob who should say
     uint32 timer;                                         ///< Time delay until next text of array is said (0 stops)
+    DialogueStepType type {DIALOGUE_STEP_ACTION};
 };
 
 /// A static const array of this structure must be handled to DialogueHelper
@@ -101,6 +109,7 @@ struct DialogueEntryTwoSide
     int32 textEntryAlt;                                    ///< To be said text entry (second side)
     uint32 sayerEntryAlt;                                 ///< Entry of the mob who should say (second side)
     uint32 timer;                                         ///< Time delay until next text of array is said (0 stops)
+    DialogueStepType type {DIALOGUE_STEP_ACTION};
 };
 
 /// Helper class handling a dialogue given as static const array of DialogueEntry or DialogueEntryTwoSide


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
Few years ago I screwed up Dialogue Helpers by allowing the usage of Broadcast Text while discounting other uses that the `iTextEntry` field could have for using positive integers. This PR disables positive integers from being interpreted as broadcast text entries unless `DIALOGUE_STEP_TEXT` is added as a type into the array at the end.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/3821

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- Teleport into Shadowfang Keep
- Walk to the gate
- look at the dialogue

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] Test for all circumstances

Example of how a dialoguehelper array would have to be changed to interpret broadcast_text entries in the `textEntry` field correctly
<img width="1199" height="767" alt="image" src="https://github.com/user-attachments/assets/665ec64f-7c12-47d1-a66d-51bd4fe27955" />
