### PR TITLE
Fix: Check if unit exists when attempting to validate spline

### DIFF
--- a/src/game/Movement/MoveSpline.cpp
+++ b/src/game/Movement/MoveSpline.cpp
@@ -209,6 +209,8 @@ namespace Movement
 
     bool MoveSplineInitArgs::Validate(Unit* unit) const
     {
+        if (!unit)
+            return false;
 #define CHECK(exp) \
     if (!(exp))\
     {\


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. -->
This PR fixes a common crash in WotLK while playerbots are active.

The root cause is unfortunately not fixed, I don't know how it is even possible that splines for non-existing units are being validated, ~~but that may have to be checked in playerbot code~~.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/cmangos/issues/issues/4064

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [ ] ~~Investigate root cause in playerbot code~~

Edit: Correction: The root cause may not be in the playerbot code. The entire MoveSpline.cpp code looks sus.
