### PR TITLE
ICC: restore Lower Spire trash

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -120,6 +120,7 @@ static const DialogueEntry aCitadelDialogue[] =
 instance_icecrown_citadel::instance_icecrown_citadel(Map* pMap) : ScriptedInstance(pMap), DialogueHelper(aCitadelDialogue),
     m_uiTeam(0),
     m_uiPutricideValveTimer(0),
+    m_lightsHammerDamnedKills(0),
     m_bHasMarrowgarIntroYelled(false),
     m_bHasDeathwhisperIntroYelled(false),
     m_bHasRimefangLanded(false),
@@ -132,6 +133,8 @@ void instance_icecrown_citadel::Initialize()
 {
     InitializeDialogueHelper(this);
     memset(&m_auiEncounter, 0, sizeof(m_auiEncounter));
+    m_lightsHammerDamnedKills = 0;
+    m_lightsHammerDamnedGuids.clear();
 
     for (bool& i : m_abAchievCriteria)
         i = false;
@@ -221,6 +224,7 @@ void instance_icecrown_citadel::OnCreatureCreate(Creature* pCreature)
         case NPC_SINDRAGOSA:
         case NPC_LICH_KING:
         case NPC_TIRION_FORDRING:
+        case NPC_TIRION_LIGHTS_HAMMER:
         case NPC_RIMEFANG:
         case NPC_SPINESTALKER:
         case NPC_VALITHRIA_COMBAT_TRIGGER:
@@ -234,6 +238,13 @@ void instance_icecrown_citadel::OnCreatureCreate(Creature* pCreature)
         case NPC_SKYBREAKER:
         case NPC_ORGRIMS_HAMMER:
             m_npcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
+            break;
+        case NPC_THE_DAMNED:
+            // Only the pair immediately in front of Light's Hammer gates the
+            // prologue; later patrols with the same entry must not count.
+            if (pCreature->GetPositionX() > -142.0f && pCreature->GetPositionX() < -138.0f &&
+                    pCreature->GetPositionY() > 2204.0f && pCreature->GetPositionY() < 2219.0f)
+                m_lightsHammerDamnedGuids.insert(pCreature->GetObjectGuid());
             break;
         case NPC_SPIRE_FROSTWYRM:
             if (pCreature->IsTemporarySummon())
@@ -485,6 +496,18 @@ void instance_icecrown_citadel::OnCreatureDeath(Creature* pCreature)
 {
     switch (pCreature->GetEntry())
     {
+        case NPC_THE_DAMNED:
+            if (m_lightsHammerDamnedGuids.erase(pCreature->GetObjectGuid()) &&
+                    ++m_lightsHammerDamnedKills == 2)
+            {
+                if (Creature* tirion = GetSingleCreatureFromStorage(NPC_TIRION_LIGHTS_HAMMER))
+                {
+                    tirion->StopMoving();
+                    tirion->GetMotionMaster()->Clear(false, true);
+                    tirion->GetMotionMaster()->MoveWaypoint();
+                }
+            }
+            break;
         case NPC_STINKY:
             if (Creature* pFestergut = GetSingleCreatureFromStorage(NPC_FESTERGUT))
             {

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -240,14 +240,11 @@ void instance_icecrown_citadel::OnCreatureCreate(Creature* pCreature)
             m_npcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
             break;
         case NPC_THE_DAMNED:
-            // Only the pair immediately in front of Light's Hammer gates the
-            // prologue; later patrols with the same entry must not count.
-            if (pCreature->GetPositionX() > -142.0f && pCreature->GetPositionX() < -138.0f &&
-                    pCreature->GetPositionY() > 2204.0f && pCreature->GetPositionY() < 2219.0f)
+            if (pCreature->HasStringId("ICC_LIGHTS_HAMMER_DAMNED"))
                 m_lightsHammerDamnedGuids.insert(pCreature->GetObjectGuid());
             break;
         case NPC_SPIRE_FROSTWYRM:
-            if (pCreature->IsTemporarySummon())
+            if (pCreature->HasStringId("ICC_SPIRE_FROSTWYRM"))
                 m_npcEntryGuidStore[pCreature->GetEntry()] = pCreature->GetObjectGuid();
             break;
         case NPC_DEATHWHISPER_SPAWN_STALKER:

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.h
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.h
@@ -46,6 +46,9 @@ enum
     // boss-related and other NPCs
     NPC_COLDFLAME                   = 36672,
 
+    NPC_THE_DAMNED                  = 37011,        // Light's Hammer prologue
+    NPC_TIRION_LIGHTS_HAMMER        = 37119,
+
     NPC_DEATHWHISPER_SPAWN_STALKER  = 37947,        // Lady Deathwhisper stalkers
     NPC_DEATHWHISPER_CONTROLLER     = 37948,
 
@@ -223,7 +226,9 @@ enum
     AT_LIGHTS_HAMMER_INTRO_1        = 5611,
     AT_LIGHTS_HAMMER_INTRO_2        = 5612,
     AT_RAMPART_ALLIANCE             = 5628,
+    AT_RAMPART_ALLIANCE_2           = 5629,
     AT_RAMPART_HORDE                = 5630,
+    AT_RAMPART_HORDE_2              = 5631,
     AT_PUTRICIDES_TRAP              = 5647,
     AT_DEATHWHISPER_INTRO           = 5709,
     AT_FROZEN_THRONE_TELE           = 5718,
@@ -381,6 +386,7 @@ class instance_icecrown_citadel : public ScriptedInstance, private DialogueHelpe
 
         uint32 m_uiTeam;                                    // Team of first entered player, used on the Gunship event
         uint32 m_uiPutricideValveTimer;
+        uint8 m_lightsHammerDamnedKills;
 
         bool m_bHasMarrowgarIntroYelled;
         bool m_bHasDeathwhisperIntroYelled;
@@ -394,6 +400,7 @@ class instance_icecrown_citadel : public ScriptedInstance, private DialogueHelpe
         GuidList m_lDeathwhisperCultistsGuids;
         GuidList m_lRotfaceUpperStalkersGuids;
         GuidList m_lFactionTeleporterGuids[PVP_TEAM_COUNT];
+        GuidSet m_lightsHammerDamnedGuids;
         GuidSet m_sDarkfallenCreaturesLowerGuids;
         GuidSet m_sDarkfallenCreaturesLeftGuids;
         GuidSet m_sDarkfallenCreaturesRightGuids;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -270,6 +270,7 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
     void Reset() override
     {
         CombatAI::Reset();
+        SetCombatScriptStatus(m_landing);
         m_creature->SetSpellList(SPELL_LIST_SPIRE);
 
         if (!m_landing && m_creature->GetPositionZ() < 200.0f)
@@ -297,6 +298,7 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
 
         m_hordeSide = miscValue == AT_RAMPART_HORDE || miscValue == AT_RAMPART_HORDE_2;
         m_landing = true;
+        SetCombatScriptStatus(true);
         SetCombatMovement(false);
         m_creature->SetCanEnterCombat(false);
         m_creature->SetActiveObjectState(true);
@@ -330,6 +332,7 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
             m_creature->GetMotionMaster()->MoveIdle();
             m_creature->SetFacingTo(landing.o);
             m_landing = false;
+            SetCombatScriptStatus(false);
             SetCombatMovement(true);
             m_creature->SetAnimTier(AnimTier::Ground);
             m_creature->SetLevitate(false);
@@ -350,11 +353,6 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
         }
     }
 
-    void UpdateAI(const uint32 diff) override
-    {
-        if (!m_landing)
-            CombatAI::UpdateAI(diff);
-    }
 };
 
 bool AreaTrigger_at_rampart_skull(Player* player, AreaTriggerEntry const* areaTrigger)

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -250,8 +250,6 @@ enum SpireFrostwyrmData
     ACTION_SPIRE_MAX,
 };
 
-static const Position aFrostwyrmAllySpawnLoc(-361.154358f, 2305.821289f, 244.771713f, 2.704335f);
-static const Position aFrostwyrmHordeSpawnLoc(-375.538879f, 2120.774658f, 242.256775f, 3.714352f);
 static const Position aFrostwyrmAllyApproachLoc(-423.2222f, 2341.465f, 202.5808f, 2.543328f);
 static const Position aFrostwyrmHordeApproachLoc(-437.643f, 2078.05f, 197.009f, 3.825093f);
 static const Position aFrostwyrmAllyLandingLoc(-433.589508f, 2344.564697f, 191.253616f, 2.543328f);
@@ -260,14 +258,12 @@ static const Position aFrostwyrmHordeLandingLoc(-433.667084f, 2080.347412f, 191.
 struct npc_spire_frostwyrm_iccAI : public CombatAI
 {
     npc_spire_frostwyrm_iccAI(Creature* creature) : CombatAI(creature, ACTION_SPIRE_MAX),
-        m_instance(static_cast<instance_icecrown_citadel*>(creature->GetInstanceData())),
         m_landing(false), m_hordeSide(false)
     {
         AddTimerlessCombatAction(ACTION_SPIRE_ENRAGE, true);
         Reset();
     }
 
-    instance_icecrown_citadel* m_instance;
     bool m_landing;
     bool m_hordeSide;
 
@@ -276,7 +272,7 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
         CombatAI::Reset();
         m_creature->SetSpellList(SPELL_LIST_SPIRE);
 
-        if (!m_landing && m_creature->IsTemporarySummon() && m_creature->GetPositionZ() < 200.0f)
+        if (!m_landing && m_creature->GetPositionZ() < 200.0f)
         {
             SetCombatMovement(true);
             m_creature->SetCanEnterCombat(true);
@@ -315,7 +311,7 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
         m_creature->GetMotionMaster()->Clear();
         m_creature->GetMotionMaster()->MovePoint(POINT_SPIRE_FROSTWYRM_APPROACH, approach,
             FORCED_MOVEMENT_FLIGHT, 18.0f, false);
-        DoBroadcastText(BROADCAST_SPIRE_FROSTWYRM, m_creature);
+        DoBroadcastText(BROADCAST_SPIRE_FROSTWYRM, m_creature, nullptr, CHAT_TYPE_BOSS_EMOTE);
     }
 
     void MovementInform(uint32 movementType, uint32 pointId) override
@@ -361,11 +357,6 @@ struct npc_spire_frostwyrm_iccAI : public CombatAI
     }
 };
 
-UnitAI* GetAI_npc_spire_frostwyrm_icc(Creature* creature)
-{
-    return new npc_spire_frostwyrm_iccAI(creature);
-}
-
 bool AreaTrigger_at_rampart_skull(Player* player, AreaTriggerEntry const* areaTrigger)
 {
     if (player->IsGameMaster() || player->IsDead())
@@ -384,19 +375,20 @@ bool AreaTrigger_at_rampart_skull(Player* player, AreaTriggerEntry const* areaTr
             return false;
     }
 
-    // spawn a Spire Frostwyrm based on the team faction
-    Creature* frostwyrm = nullptr;
-    if ((areaTrigger->id == AT_RAMPART_ALLIANCE || areaTrigger->id == AT_RAMPART_ALLIANCE_2) &&
-            instance->GetPlayerTeam() == ALLIANCE)
-        frostwyrm = player->SummonCreature(NPC_SPIRE_FROSTWYRM, aFrostwyrmAllySpawnLoc.x, aFrostwyrmAllySpawnLoc.y,
-            aFrostwyrmAllySpawnLoc.z, aFrostwyrmAllySpawnLoc.o, TEMPSPAWN_DEAD_DESPAWN, 0, true, true);
-    else if ((areaTrigger->id == AT_RAMPART_HORDE || areaTrigger->id == AT_RAMPART_HORDE_2) &&
-            instance->GetPlayerTeam() == HORDE)
-        frostwyrm = player->SummonCreature(NPC_SPIRE_FROSTWYRM, aFrostwyrmHordeSpawnLoc.x, aFrostwyrmHordeSpawnLoc.y,
-            aFrostwyrmHordeSpawnLoc.z, aFrostwyrmHordeSpawnLoc.o, TEMPSPAWN_DEAD_DESPAWN, 0, true, true);
+    bool const validTrigger =
+        ((areaTrigger->id == AT_RAMPART_ALLIANCE || areaTrigger->id == AT_RAMPART_ALLIANCE_2) && instance->GetPlayerTeam() == ALLIANCE) ||
+        ((areaTrigger->id == AT_RAMPART_HORDE || areaTrigger->id == AT_RAMPART_HORDE_2) && instance->GetPlayerTeam() == HORDE);
+    if (!validTrigger)
+        return false;
 
-    if (frostwyrm)
+    SpawnGroup* spawnGroup = player->GetMap()->GetSpawnManager().GetSpawnGroup("ICC_SPIRE_FROSTWYRM");
+    if (spawnGroup)
+        spawnGroup->Spawn(true, false);
+
+    const std::vector<Creature*>* frostwyrms = player->GetMap()->GetCreatures("ICC_SPIRE_FROSTWYRM");
+    if (frostwyrms && !frostwyrms->empty())
     {
+        Creature* frostwyrm = frostwyrms->front();
         instance->SetData(TYPE_SPIRE_FROSTWYRM, IN_PROGRESS);
         frostwyrm->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, player, frostwyrm, areaTrigger->id);
     }
@@ -649,7 +641,7 @@ void AddSC_icecrown_citadel()
 
     pNewScript = new Script;
     pNewScript->Name = "npc_spire_frostwyrm_icc";
-    pNewScript->GetAI = &GetAI_npc_spire_frostwyrm_icc;
+    pNewScript->GetAI = &GetNewAIInstance<npc_spire_frostwyrm_iccAI>;
     pNewScript->RegisterSelf();
 
     pNewScript = new Script;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -23,6 +23,7 @@ EndScriptData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "icecrown_citadel.h"
+#include "AI/ScriptDevAI/base/CombatAI.h"
 #include "AI/BaseAI/GameObjectAI.h"
 #include "AI/ScriptDevAI/base/TimerAI.h"
 
@@ -234,29 +235,171 @@ bool AreaTrigger_at_lights_hammer(Player* pPlayer, AreaTriggerEntry const* pAt)
 ## at_rampart_skull
 #####*/
 
-static const float aFrostwyrmAllySpawnLocs[3] = { -326.5525f, 2236.194f, 328.9574f };
-static const float aFrostwyrmHordeSpawnLocs[3] = { -317.854f ,2190.76f ,328.711f };
-
-bool AreaTrigger_at_rampart_skull(Player* pPlayer, AreaTriggerEntry const* pAt)
+enum SpireFrostwyrmData
 {
-    if (pPlayer->IsGameMaster() || pPlayer->IsDead())
+    SPELL_SPIRE_ENRAGE                 = 47008,
+
+    SPELL_LIST_SPIRE                   = 3723001,
+
+    BROADCAST_SPIRE_FROSTWYRM          = 37161,
+
+    POINT_SPIRE_FROSTWYRM_APPROACH     = 1,
+    POINT_SPIRE_FROSTWYRM_LAND         = 2,
+
+    ACTION_SPIRE_ENRAGE                = 0,
+    ACTION_SPIRE_MAX,
+};
+
+static const Position aFrostwyrmAllySpawnLoc(-361.154358f, 2305.821289f, 244.771713f, 2.704335f);
+static const Position aFrostwyrmHordeSpawnLoc(-375.538879f, 2120.774658f, 242.256775f, 3.714352f);
+static const Position aFrostwyrmAllyApproachLoc(-423.2222f, 2341.465f, 202.5808f, 2.543328f);
+static const Position aFrostwyrmHordeApproachLoc(-437.643f, 2078.05f, 197.009f, 3.825093f);
+static const Position aFrostwyrmAllyLandingLoc(-433.589508f, 2344.564697f, 191.253616f, 2.543328f);
+static const Position aFrostwyrmHordeLandingLoc(-433.667084f, 2080.347412f, 191.253860f, 3.825093f);
+
+struct npc_spire_frostwyrm_iccAI : public CombatAI
+{
+    npc_spire_frostwyrm_iccAI(Creature* creature) : CombatAI(creature, ACTION_SPIRE_MAX),
+        m_instance(static_cast<instance_icecrown_citadel*>(creature->GetInstanceData())),
+        m_landing(false), m_hordeSide(false)
+    {
+        AddTimerlessCombatAction(ACTION_SPIRE_ENRAGE, true);
+        Reset();
+    }
+
+    instance_icecrown_citadel* m_instance;
+    bool m_landing;
+    bool m_hordeSide;
+
+    void Reset() override
+    {
+        CombatAI::Reset();
+        m_creature->SetSpellList(SPELL_LIST_SPIRE);
+
+        if (!m_landing && m_creature->IsTemporarySummon() && m_creature->GetPositionZ() < 200.0f)
+        {
+            SetCombatMovement(true);
+            m_creature->SetCanEnterCombat(true);
+            m_creature->SetAnimTier(AnimTier::Ground);
+            m_creature->SetLevitate(false);
+            m_creature->SetWalk(false);
+            m_creature->SetActiveObjectState(false);
+            m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER | UNIT_FLAG_IMMUNE_TO_NPC);
+        }
+    }
+
+    void EnterEvadeMode() override
+    {
+        if (!m_landing)
+            CombatAI::EnterEvadeMode();
+    }
+
+    void ReceiveAIEvent(AIEventType eventType, Unit* /*sender*/, Unit* /*invoker*/, uint32 miscValue) override
+    {
+        if (eventType != AI_EVENT_CUSTOM_A || m_landing)
+            return;
+
+        m_hordeSide = miscValue == AT_RAMPART_HORDE || miscValue == AT_RAMPART_HORDE_2;
+        m_landing = true;
+        SetCombatMovement(false);
+        m_creature->SetCanEnterCombat(false);
+        m_creature->SetActiveObjectState(true);
+        m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER | UNIT_FLAG_IMMUNE_TO_NPC);
+        m_creature->SetAnimTier(AnimTier::Fly);
+        m_creature->SetLevitate(true);
+        m_creature->SetWalk(false);
+
+        Position const& landing = m_hordeSide ? aFrostwyrmHordeLandingLoc : aFrostwyrmAllyLandingLoc;
+        Position const& approach = m_hordeSide ? aFrostwyrmHordeApproachLoc : aFrostwyrmAllyApproachLoc;
+        m_creature->SetRespawnCoord(landing.x, landing.y, landing.z, landing.o);
+        m_creature->GetMotionMaster()->Clear();
+        m_creature->GetMotionMaster()->MovePoint(POINT_SPIRE_FROSTWYRM_APPROACH, approach,
+            FORCED_MOVEMENT_FLIGHT, 18.0f, false);
+        DoBroadcastText(BROADCAST_SPIRE_FROSTWYRM, m_creature);
+    }
+
+    void MovementInform(uint32 movementType, uint32 pointId) override
+    {
+        if (movementType != POINT_MOTION_TYPE || !m_landing)
+            return;
+
+        Position const& landing = m_hordeSide ? aFrostwyrmHordeLandingLoc : aFrostwyrmAllyLandingLoc;
+        if (pointId == POINT_SPIRE_FROSTWYRM_APPROACH)
+        {
+            m_creature->GetMotionMaster()->MovePoint(POINT_SPIRE_FROSTWYRM_LAND, landing,
+                FORCED_MOVEMENT_FLIGHT, 8.5f, false, ObjectGuid(), 0, AnimTier::Fly);
+        }
+        else if (pointId == POINT_SPIRE_FROSTWYRM_LAND)
+        {
+            m_creature->GetMotionMaster()->MoveIdle();
+            m_creature->SetFacingTo(landing.o);
+            m_landing = false;
+            SetCombatMovement(true);
+            m_creature->SetAnimTier(AnimTier::Ground);
+            m_creature->SetLevitate(false);
+            m_creature->SetActiveObjectState(false);
+            m_creature->SetCanEnterCombat(true);
+            m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER | UNIT_FLAG_IMMUNE_TO_NPC);
+            m_creature->SetInCombatWithZone();
+            m_creature->AI()->AttackClosestEnemy();
+        }
+    }
+
+    void ExecuteAction(uint32 action) override
+    {
+        if (action == ACTION_SPIRE_ENRAGE && m_creature->GetHealthPercent() <= 10.0f)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_SPIRE_ENRAGE) == CAST_OK)
+                SetActionReadyStatus(action, false);
+        }
+    }
+
+    void UpdateAI(const uint32 diff) override
+    {
+        if (!m_landing)
+            CombatAI::UpdateAI(diff);
+    }
+};
+
+UnitAI* GetAI_npc_spire_frostwyrm_icc(Creature* creature)
+{
+    return new npc_spire_frostwyrm_iccAI(creature);
+}
+
+bool AreaTrigger_at_rampart_skull(Player* player, AreaTriggerEntry const* areaTrigger)
+{
+    if (player->IsGameMaster() || player->IsDead())
         return false;
 
-    instance_icecrown_citadel* pInstance = static_cast<instance_icecrown_citadel*>(pPlayer->GetInstanceData());
-    if (!pInstance)
+    instance_icecrown_citadel* instance = static_cast<instance_icecrown_citadel*>(player->GetInstanceData());
+    if (!instance)
         return false;
 
-    if (pInstance->GetData(TYPE_LADY_DEATHWHISPER) != DONE || pInstance->GetData(TYPE_SPIRE_FROSTWYRM) == DONE)
+    if (instance->GetData(TYPE_LADY_DEATHWHISPER) != DONE || instance->GetData(TYPE_SPIRE_FROSTWYRM) == DONE)
         return false;
 
-    if (pInstance->GetSingleCreatureFromStorage(NPC_SPIRE_FROSTWYRM))
-        return false;
+    if (Creature* frostwyrm = instance->GetSingleCreatureFromStorage(NPC_SPIRE_FROSTWYRM))
+    {
+        if (frostwyrm->IsAlive())
+            return false;
+    }
 
     // spawn a Spire Frostwyrm based on the team faction
-    if (pAt->id == AT_RAMPART_ALLIANCE && pInstance->GetPlayerTeam() == ALLIANCE)
-        pPlayer->SummonCreature(NPC_SPIRE_FROSTWYRM, aFrostwyrmAllySpawnLocs[0], aFrostwyrmAllySpawnLocs[1], aFrostwyrmAllySpawnLocs[2], 0, TEMPSPAWN_DEAD_DESPAWN, 0, true, true, 0);
-    else if (pAt->id == AT_RAMPART_HORDE && pInstance->GetPlayerTeam() == HORDE)
-        pPlayer->SummonCreature(NPC_SPIRE_FROSTWYRM, aFrostwyrmHordeSpawnLocs[0], aFrostwyrmHordeSpawnLocs[1], aFrostwyrmHordeSpawnLocs[2], 0, TEMPSPAWN_DEAD_DESPAWN, 0, true, true, 1);
+    Creature* frostwyrm = nullptr;
+    if ((areaTrigger->id == AT_RAMPART_ALLIANCE || areaTrigger->id == AT_RAMPART_ALLIANCE_2) &&
+            instance->GetPlayerTeam() == ALLIANCE)
+        frostwyrm = player->SummonCreature(NPC_SPIRE_FROSTWYRM, aFrostwyrmAllySpawnLoc.x, aFrostwyrmAllySpawnLoc.y,
+            aFrostwyrmAllySpawnLoc.z, aFrostwyrmAllySpawnLoc.o, TEMPSPAWN_DEAD_DESPAWN, 0, true, true);
+    else if ((areaTrigger->id == AT_RAMPART_HORDE || areaTrigger->id == AT_RAMPART_HORDE_2) &&
+            instance->GetPlayerTeam() == HORDE)
+        frostwyrm = player->SummonCreature(NPC_SPIRE_FROSTWYRM, aFrostwyrmHordeSpawnLoc.x, aFrostwyrmHordeSpawnLoc.y,
+            aFrostwyrmHordeSpawnLoc.z, aFrostwyrmHordeSpawnLoc.o, TEMPSPAWN_DEAD_DESPAWN, 0, true, true);
+
+    if (frostwyrm)
+    {
+        instance->SetData(TYPE_SPIRE_FROSTWYRM, IN_PROGRESS);
+        frostwyrm->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, player, frostwyrm, areaTrigger->id);
+    }
 
     return false;
 }
@@ -502,6 +645,11 @@ void AddSC_icecrown_citadel()
     pNewScript = new Script;
     pNewScript->Name = "at_rampart_skull";
     pNewScript->pAreaTrigger = &AreaTrigger_at_rampart_skull;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_spire_frostwyrm_icc";
+    pNewScript->GetAI = &GetAI_npc_spire_frostwyrm_icc;
     pNewScript->RegisterSelf();
 
     pNewScript = new Script;


### PR DESCRIPTION
Restores the Lower Spire trash and opening progression: the Light's Hammer prologue, forward gate, area triggers, Broodkeeper healing, and Spire Frostwyrm activation and movement.

Dialogue touched here uses BroadcastText rather than new `script_texts` entries.

DB companion: https://github.com/cmangos/wotlk-db/pull/1388

Tested in the combined ICC branch on 10-player and 25-player normal. Heroic-specific behavior still needs a dedicated pass.