### PR TITLE
ICC: restore Lord Marrowgar

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_lord_marrowgar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_lord_marrowgar.cpp
@@ -56,14 +56,14 @@ enum
     NPC_BONE_SPIKE_2            = 38711,                    // summoned by spell 72670
     NPC_BONE_SPIKE_3            = 38712,                    // summoned by spell 72669
 
-    // phases and max cold flame charges
+    // phases and max Bone Storm charges
     PHASE_NORMAL                = 1,
     PHASE_BONE_STORM_CHARGE     = 2,
     PHASE_BONE_STORM_CHARGING   = 3,
     PHASE_BONE_STORM_COLDFLAME  = 4,
 
-    MAX_CHARGES_NORMAL          = 4,
-    MAX_CHARGES_HEROIC          = 5,
+    MAX_CHARGES_10_PLAYER       = 4,
+    MAX_CHARGES_25_PLAYER       = 6,
 };
 
 struct boss_lord_marrowgarAI : public ScriptedAI
@@ -71,8 +71,8 @@ struct boss_lord_marrowgarAI : public ScriptedAI
     boss_lord_marrowgarAI(Creature* pCreature) : ScriptedAI(pCreature)
     {
         m_pInstance = static_cast<instance_icecrown_citadel*>(pCreature->GetInstanceData());
-        // on heroic, there is 1 more Bone Storm charge
-        m_uiMaxCharges = m_pInstance && m_pInstance->IsHeroicDifficulty() ? MAX_CHARGES_HEROIC : MAX_CHARGES_NORMAL;
+        // Bone Storm lasts 20 seconds in 10 player and 30 seconds in 25 player.
+        m_uiMaxCharges = m_pInstance && m_pInstance->Is25ManDifficulty() ? MAX_CHARGES_25_PLAYER : MAX_CHARGES_10_PLAYER;
         m_bIsHeroicMode = m_pInstance && m_pInstance->IsHeroicDifficulty();
         Reset();
     }
@@ -287,7 +287,7 @@ struct boss_lord_marrowgarAI : public ScriptedAI
         {
             if (m_uiBerserkTimer <= uiDiff)
             {
-                if (DoCastSpellIfCan(m_creature, SPELL_BERSERK))
+                if (DoCastSpellIfCan(m_creature, SPELL_BERSERK) == CAST_OK)
                 {
                     DoScriptText(SAY_BERSERK, m_creature);
                     m_uiBerserkTimer = 0;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_lord_marrowgar.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_lord_marrowgar.cpp
@@ -28,15 +28,15 @@ EndScriptData */
 
 enum
 {
-    SAY_AGGRO                   = -1631002,
-    SAY_BONE_STORM              = -1631003,
-    SAY_BONE_SPIKE_1            = -1631004,
-    SAY_BONE_SPIKE_2            = -1631005,
-    SAY_BONE_SPIKE_3            = -1631006,
-    SAY_SLAY_1                  = -1631007,
-    SAY_SLAY_2                  = -1631008,
-    SAY_DEATH                   = -1631009,
-    SAY_BERSERK                 = -1631010,
+    SAY_AGGRO                   = 37684,
+    SAY_BONE_STORM              = 36554,
+    SAY_BONE_SPIKE_1            = 37695,
+    SAY_BONE_SPIKE_2            = 37696,
+    SAY_BONE_SPIKE_3            = 37693,
+    SAY_SLAY_1                  = 37686,
+    SAY_SLAY_2                  = 37687,
+    SAY_DEATH                   = 37688,
+    SAY_BERSERK                 = 37690,
 
     // spells
     SPELL_BERSERK               = 26662,
@@ -108,7 +108,7 @@ struct boss_lord_marrowgarAI : public ScriptedAI
 
     void Aggro(Unit* /*pWho*/) override
     {
-        DoScriptText(SAY_AGGRO, m_creature);
+        DoBroadcastText(SAY_AGGRO, m_creature);
 
         if (m_pInstance)
             m_pInstance->SetData(TYPE_MARROWGAR, IN_PROGRESS);
@@ -120,12 +120,12 @@ struct boss_lord_marrowgarAI : public ScriptedAI
             return;
 
         if (urand(0, 1))
-            DoScriptText(urand(0, 1) ? SAY_SLAY_1 : SAY_SLAY_2, m_creature);
+            DoBroadcastText(urand(0, 1) ? SAY_SLAY_1 : SAY_SLAY_2, m_creature);
     }
 
     void JustDied(Unit* /*pKiller*/) override
     {
-        DoScriptText(SAY_DEATH, m_creature);
+        DoBroadcastText(SAY_DEATH, m_creature);
 
         if (m_pInstance)
             m_pInstance->SetData(TYPE_MARROWGAR, DONE);
@@ -187,7 +187,7 @@ struct boss_lord_marrowgarAI : public ScriptedAI
                     if (DoCastSpellIfCan(m_creature, SPELL_BONE_STORM) == CAST_OK)
                     {
                         // ToDo: research if we need to increase the speed here
-                        DoScriptText(SAY_BONE_STORM, m_creature);
+                        DoBroadcastText(SAY_BONE_STORM, m_creature);
                         m_uiPhase = PHASE_BONE_STORM_CHARGE;
                         SetCombatMovement(false);
                         m_creature->GetMotionMaster()->MoveIdle();
@@ -271,9 +271,9 @@ struct boss_lord_marrowgarAI : public ScriptedAI
                 {
                     switch (urand(0, 2))
                     {
-                        case 0: DoScriptText(SAY_BONE_SPIKE_1, m_creature); break;
-                        case 1: DoScriptText(SAY_BONE_SPIKE_2, m_creature); break;
-                        case 2: DoScriptText(SAY_BONE_SPIKE_3, m_creature); break;
+                        case 0: DoBroadcastText(SAY_BONE_SPIKE_1, m_creature); break;
+                        case 1: DoBroadcastText(SAY_BONE_SPIKE_2, m_creature); break;
+                        case 2: DoBroadcastText(SAY_BONE_SPIKE_3, m_creature); break;
                     }
                     m_uiBoneSpikeTimer = 18000;
                 }
@@ -289,7 +289,7 @@ struct boss_lord_marrowgarAI : public ScriptedAI
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_BERSERK) == CAST_OK)
                 {
-                    DoScriptText(SAY_BERSERK, m_creature);
+                    DoBroadcastText(SAY_BERSERK, m_creature);
                     m_uiBerserkTimer = 0;
                 }
             }

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -28,7 +28,7 @@ EndScriptData */
 enum
 {
     // Marrowgar
-    SAY_MARROWGAR_INTRO             = -1631001,
+    SAY_MARROWGAR_INTRO             = 38508,
 
     // Deathwhisper
     SAY_DEATHWHISPER_SPEECH_1       = -1631011,
@@ -154,7 +154,7 @@ void instance_icecrown_citadel::DoHandleCitadelAreaTrigger(uint32 uiTriggerId, P
     {
         if (Creature* pMarrowgar = GetSingleCreatureFromStorage(NPC_LORD_MARROWGAR))
         {
-            DoScriptText(SAY_MARROWGAR_INTRO, pMarrowgar);
+            DoBroadcastText(SAY_MARROWGAR_INTRO, pMarrowgar);
             m_bHasMarrowgarIntroYelled = true;
         }
     }
@@ -565,7 +565,7 @@ void instance_icecrown_citadel::SetData(uint32 uiType, uint32 uiData)
     {
         case TYPE_MARROWGAR:
             m_auiEncounter[uiType] = uiData;
-            DoUseDoorOrButton(GO_MARROWGAR_DOOR);
+            DoUseOpenableObject(GO_MARROWGAR_DOOR, uiData != IN_PROGRESS);
             if (uiData == DONE)
             {
                 DoUseDoorOrButton(GO_ICEWALL_1);


### PR DESCRIPTION
Restores Lord Marrowgar's Bone Storm movement and target cycle, Coldflame spawning, Bone Spike cleanup, intro, and reset handling.

Encounter dialogue is delivered through BroadcastText; this does not add legacy `script_texts` or `DoScriptText` calls.

DB companion: https://github.com/cmangos/wotlk-db/pull/1389

Built in Release and tested in full 10-player and 25-player normal ICC runs. Heroic remains to be tested separately.