### PR TITLE
ICC: restore Plagueworks trash

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -893,7 +893,7 @@ void instance_icecrown_citadel::SetData(uint32 uiType, uint32 uiData)
         case TYPE_PLAGUE_WING_ENTRANCE:
             m_auiEncounter[uiType] = uiData;
             // combat door
-            DoUseDoorOrButton(GO_SCIENTIST_DOOR_COLLISION);
+            DoUseOpenableObject(GO_SCIENTIST_DOOR_COLLISION, uiData != IN_PROGRESS);
             if (uiData == DONE)
                 DoUseDoorOrButton(GO_SCIENTIST_DOOR);
             // combat doors with custom anim

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -268,10 +268,11 @@ enum
 
     NPC_FLESH_EATING_INSECT         = 37782,
 
-    // NOTE: these numbers are quesswork
+    // The retail gauntlet advances after its one-minute insect phase. Keep
+    // the kill counter as an early-completion safeguard when the full swarm
+    // has already been cleared.
     MAX_INSECT_PER_ROUND            = 8,
     TOTAL_INSECTS_PER_EVENT         = 100,
-    PUTRICIDE_TRAP_DURATION         = MINUTE * IN_MILLISECONDS,
 };
 
 enum PutricideTrapActions
@@ -327,7 +328,7 @@ struct npc_putricides_trapAI : public CombatAI
     instance_icecrown_citadel* m_instance;
 
     uint8 m_insectCounter;
-    GuidList m_insectGuids;
+    GuidVector m_insectGuids;
 
     void Reset() override
     {
@@ -347,50 +348,31 @@ struct npc_putricides_trapAI : public CombatAI
             return;
 
         m_insectCounter = 0;
-        ResetTimer(PUTRICIDE_TRAP_SUMMON, 1000);
-        ResetTimer(PUTRICIDE_TRAP_FINISH, PUTRICIDE_TRAP_DURATION);
+        ResetTimer(PUTRICIDE_TRAP_SUMMON, 1s);
+        ResetTimer(PUTRICIDE_TRAP_FINISH, 1min);
     }
 
     void StopSwarm()
     {
-        m_creature->RemoveAurasDueToSpell(SPELL_GIANT_INSECT_SWARM);
+        m_creature->RemoveAllAuras();
         m_creature->RemoveAllDynObjects();
         m_creature->CombatStop(true);
         m_creature->DeleteThreatList();
-
-        GuidList insectGuids = m_insectGuids;
-        m_insectGuids.clear();
-        for (ObjectGuid const& guid : insectGuids)
-        {
-            if (Creature* insect = m_creature->GetMap()->GetCreature(guid))
-            {
-                insect->CombatStop(true);
-                insect->DeleteThreatList();
-                insect->ForcedDespawn();
-            }
-        }
-
-        // Recover summons whose GUID bookkeeping was lost across a reset or
-        // unload.  Keep this local to the gauntlet so unrelated ICC insects
-        // are never affected.
-        std::list<Creature*> insects;
-        GetCreatureListWithEntryInGrid(insects, m_creature, NPC_FLESH_EATING_INSECT, 120.0f);
-        for (Creature* insect : insects)
-        {
-            insect->CombatStop(true);
-            insect->DeleteThreatList();
-            insect->ForcedDespawn();
-        }
+        DespawnGuids(m_insectGuids);
     }
 
     void FinishEvent(EncounterState state)
     {
         DisableTimer(PUTRICIDE_TRAP_SUMMON);
         DisableTimer(PUTRICIDE_TRAP_FINISH);
-        StopSwarm();
 
         if (m_instance)
             m_instance->SetData(TYPE_PLAGUE_WING_ENTRANCE, state);
+
+        // Finalize the event before despawning its summons. ForcedDespawn can
+        // notify SummonedCreatureJustDied, which must not count cleanup as an
+        // event kill and re-enter FinishEvent while the GUID list is cleared.
+        StopSwarm();
     }
 
     void JustSummoned(Creature* summoned) override
@@ -398,21 +380,17 @@ struct npc_putricides_trapAI : public CombatAI
         if (summoned->GetEntry() == NPC_FLESH_EATING_INSECT)
         {
             m_insectGuids.push_back(summoned->GetObjectGuid());
-            float x, y, z;
-            summoned->GetPosition(x, y, z);
-            summoned->UpdateAllowedPositionZ(x, y, z);
-            summoned->SetWalk(false);
-            summoned->SetLevitate(true);
-            summoned->GetMotionMaster()->MovePoint(1, x, y, z);
+            if (!summoned->GetMotionMaster()->MoveFall())
+                summoned->SetInCombatWithZone();
         }
     }
 
     void SummonedMovementInform(Creature* summoned, uint32 motionType, uint32 pointId) override
     {
-        if (motionType != POINT_MOTION_TYPE || !pointId)
+        if (motionType != FALL_MOTION_TYPE || pointId != EVENT_FALL)
             return;
 
-        summoned->SetLevitate(false);
+        summoned->SetInCombatWithZone();
     }
 
     void SummonedCreatureJustDied(Creature* summoned) override
@@ -422,7 +400,6 @@ struct npc_putricides_trapAI : public CombatAI
 
         if (summoned->GetEntry() == NPC_FLESH_EATING_INSECT)
         {
-            m_insectGuids.remove(summoned->GetObjectGuid());
             ++m_insectCounter;
             if (m_insectCounter >= TOTAL_INSECTS_PER_EVENT)
             {
@@ -430,12 +407,6 @@ struct npc_putricides_trapAI : public CombatAI
                 m_creature->ForcedDespawn();
             }
         }
-    }
-
-    void SummonedCreatureDespawn(Creature* summoned) override
-    {
-        if (summoned->GetEntry() == NPC_FLESH_EATING_INSECT)
-            m_insectGuids.remove(summoned->GetObjectGuid());
     }
 
     void SummonInsects()
@@ -451,7 +422,8 @@ struct npc_putricides_trapAI : public CombatAI
         for (uint8 i = 0; i < insectCount; ++i)
         {
             m_creature->GetRandomPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), 15.0f, x, y, z);
-            m_creature->SummonCreature(NPC_FLESH_EATING_INSECT, x, y, z + 20.0f, 0, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 5 * MINUTE * IN_MILLISECONDS);
+            m_creature->SummonCreature(NPC_FLESH_EATING_INSECT, x, y, z + 20.0f, 0,
+                TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 15s.count());
         }
 
         ResetTimer(PUTRICIDE_TRAP_SUMMON, urand(2000, 5000));
@@ -478,18 +450,6 @@ struct npc_putricides_trapAI : public CombatAI
 
         FinishEvent(eventFailed ? FAIL : DONE);
     }
-
-    void UpdateAI(const uint32 diff) override
-    {
-        if (!m_instance || m_instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
-        {
-            if (m_creature->HasAura(SPELL_GIANT_INSECT_SWARM) || !m_insectGuids.empty())
-                StopSwarm();
-            return;
-        }
-
-        CombatAI::UpdateAI(diff);
-    }
 };
 
 UnitAI* GetAI_npc_putricides_trap(Creature* pCreature)
@@ -506,13 +466,15 @@ enum VengefulFleshreaperActions
     POINT_PIPE_JUMP = 3703801,
 };
 
+const std::string STRING_ID_PIPE_FLESHREAPER = "ICC_PLAGUEWORKS_PIPE_FLESHREAPER";
+
 // Pipe movement cannot build a generic chase path to players on the floor.
 // Combat spells are supplied by creature_spell_list; this AI only performs
 // the geometry-specific jump before normal combat begins.
 struct npc_icc_vengeful_fleshreaperAI : public CombatAI
 {
     npc_icc_vengeful_fleshreaperAI(Creature* creature) : CombatAI(creature, 0),
-        m_pipeSpawn(creature->GetRespawnPosition().z > 365.0f)
+        m_pipeSpawn(creature->HasStringId(STRING_ID_PIPE_FLESHREAPER))
     {
         Reset();
     }
@@ -524,6 +486,7 @@ struct npc_icc_vengeful_fleshreaperAI : public CombatAI
     void Reset() override
     {
         CombatAI::Reset();
+        SetCombatScriptStatus(false);
         m_jumping = false;
         m_jumpTargetGuid.Clear();
         m_creature->SetWalk(false);
@@ -544,20 +507,17 @@ struct npc_icc_vengeful_fleshreaperAI : public CombatAI
 
     void AttackStart(Unit* who) override
     {
-        if (!who)
-            return;
-
         CombatAI::AttackStart(who);
 
-        if (!m_pipeSpawn || m_jumping || m_creature->GetPositionZ() < 365.0f)
+        if (!m_pipeSpawn || m_jumping)
             return;
 
-        float angle = who->GetAngle(m_creature);
-        float x = who->GetPositionX() + std::cos(angle) * 3.0f;
-        float y = who->GetPositionY() + std::sin(angle) * 3.0f;
+        float x, y, z;
+        who->GetContactPoint(m_creature, x, y, z);
+        SetCombatScriptStatus(true);
         m_jumping = true;
         m_jumpTargetGuid = who->GetObjectGuid();
-        m_creature->GetMotionMaster()->MoveJump(x, y, who->GetPositionZ(), 10.0f, 6.0f, POINT_PIPE_JUMP);
+        m_creature->GetMotionMaster()->MoveJump(x, y, z, 10.0f, 6.0f, POINT_PIPE_JUMP);
     }
 
     void MovementInform(uint32 movementType, uint32 pointId) override
@@ -566,24 +526,15 @@ struct npc_icc_vengeful_fleshreaperAI : public CombatAI
             return;
 
         m_jumping = false;
+        SetCombatScriptStatus(false);
         if (Unit* target = m_creature->GetMap()->GetUnit(m_jumpTargetGuid))
         {
             if (target->IsAlive() && m_creature->CanAttack(target))
                 CombatAI::AttackStart(target);
         }
-    }
-
-    void UpdateAI(const uint32 diff) override
-    {
-        if (!m_jumping)
-            CombatAI::UpdateAI(diff);
+        m_jumpTargetGuid.Clear();
     }
 };
-
-UnitAI* GetAI_npc_icc_vengeful_fleshreaper(Creature* creature)
-{
-    return new npc_icc_vengeful_fleshreaperAI(creature);
-}
 
 struct LadyDeathwhisperElevator : public GameObjectAI, public TimerManager
 {
@@ -665,7 +616,7 @@ void AddSC_icecrown_citadel()
 
     pNewScript = new Script;
     pNewScript->Name = "npc_icc_vengeful_fleshreaper";
-    pNewScript->GetAI = &GetAI_npc_icc_vengeful_fleshreaper;
+    pNewScript->GetAI = &GetNewAIInstance<npc_icc_vengeful_fleshreaperAI>;
     pNewScript->RegisterSelf();
 
     pNewScript = new Script;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -24,6 +24,7 @@ EndScriptData */
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "icecrown_citadel.h"
 #include "AI/BaseAI/GameObjectAI.h"
+#include "AI/ScriptDevAI/base/CombatAI.h"
 #include "AI/ScriptDevAI/base/TimerAI.h"
 
 /*#####
@@ -270,32 +271,40 @@ enum
     // NOTE: these numbers are quesswork
     MAX_INSECT_PER_ROUND            = 8,
     TOTAL_INSECTS_PER_EVENT         = 100,
+    PUTRICIDE_TRAP_DURATION         = MINUTE * IN_MILLISECONDS,
+};
+
+enum PutricideTrapActions
+{
+    PUTRICIDE_TRAP_SUMMON,
+    PUTRICIDE_TRAP_FINISH,
 };
 
 /*#####
 ## at_putricides_trap
 #####*/
 
-bool AreaTrigger_at_putricides_trap(Player* pPlayer, AreaTriggerEntry const* pAt)
+bool AreaTrigger_at_putricides_trap(Player* player, AreaTriggerEntry const* areaTrigger)
 {
-    if (pPlayer->IsGameMaster() || pPlayer->IsDead())
+    if (player->IsGameMaster() || player->IsDead())
         return false;
 
-    if (pAt->id != AT_PUTRICIDES_TRAP)
+    if (areaTrigger->id != AT_PUTRICIDES_TRAP)
         return false;
 
-    instance_icecrown_citadel* pInstance = (instance_icecrown_citadel*)pPlayer->GetInstanceData();
-    if (!pInstance)
+    instance_icecrown_citadel* instance = static_cast<instance_icecrown_citadel*>(player->GetInstanceData());
+    if (!instance)
         return false;
 
-    if (pInstance->GetData(TYPE_PLAGUE_WING_ENTRANCE) == DONE || pInstance->GetData(TYPE_PLAGUE_WING_ENTRANCE) == IN_PROGRESS)
+    if (instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) == DONE || instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) == IN_PROGRESS)
         return false;
 
     // cast spell and start event
-    if (Creature* pTrap = pInstance->GetSingleCreatureFromStorage(NPC_PUTRICIDES_TRAP))
+    if (Creature* trap = instance->GetSingleCreatureFromStorage(NPC_PUTRICIDES_TRAP))
     {
-        pTrap->CastSpell(pTrap, SPELL_GIANT_INSECT_SWARM, TRIGGERED_NONE);
-        pInstance->SetData(TYPE_PLAGUE_WING_ENTRANCE, IN_PROGRESS);
+        trap->CastSpell(trap, SPELL_GIANT_INSECT_SWARM, TRIGGERED_NONE);
+        instance->SetData(TYPE_PLAGUE_WING_ENTRANCE, IN_PROGRESS);
+        trap->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, player, trap);
     }
 
     return false;
@@ -305,129 +314,181 @@ bool AreaTrigger_at_putricides_trap(Player* pPlayer, AreaTriggerEntry const* pAt
 ## npc_putricides_trap
 ######*/
 
-struct npc_putricides_trapAI : public ScriptedAI
+struct npc_putricides_trapAI : public CombatAI
 {
-    npc_putricides_trapAI(Creature* pCreature) : ScriptedAI(pCreature)
+    npc_putricides_trapAI(Creature* creature) : CombatAI(creature, 0),
+        m_instance(static_cast<instance_icecrown_citadel*>(creature->GetInstanceData()))
     {
-        m_pInstance = (instance_icecrown_citadel*)pCreature->GetInstanceData();
+        AddCustomAction(PUTRICIDE_TRAP_SUMMON, true, [&]() { SummonInsects(); });
+        AddCustomAction(PUTRICIDE_TRAP_FINISH, true, [&]() { FinishByTimer(); });
         Reset();
     }
 
-    instance_icecrown_citadel* m_pInstance;
+    instance_icecrown_citadel* m_instance;
 
-    uint8 m_uiInsectCounter;
-    uint32 m_uiEventTimer;
-    uint32 m_uiSummonTimer;
+    uint8 m_insectCounter;
+    GuidList m_insectGuids;
 
     void Reset() override
     {
-        m_uiInsectCounter = 0;
-        m_uiSummonTimer = 1000;
-        m_uiEventTimer = 5 * MINUTE * IN_MILLISECONDS;
+        CombatAI::Reset();
+        m_insectCounter = 0;
+        DisableTimer(PUTRICIDE_TRAP_SUMMON);
+        DisableTimer(PUTRICIDE_TRAP_FINISH);
+        StopSwarm();
     }
 
-    void MoveInLineOfSight(Unit* /*pWho*/) override { }
-    void AttackStart(Unit* /*pWho*/) override { }
+    void MoveInLineOfSight(Unit* /*who*/) override { }
+    void AttackStart(Unit* /*who*/) override { }
 
-    void JustSummoned(Creature* pSummoned) override
+    void ReceiveAIEvent(AIEventType eventType, Unit* /*sender*/, Unit* /*invoker*/, uint32 /*miscValue*/) override
     {
-        if (pSummoned->GetEntry() == NPC_FLESH_EATING_INSECT)
+        if (eventType != AI_EVENT_CUSTOM_A || !m_instance || m_instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
+            return;
+
+        m_insectCounter = 0;
+        ResetTimer(PUTRICIDE_TRAP_SUMMON, 1000);
+        ResetTimer(PUTRICIDE_TRAP_FINISH, PUTRICIDE_TRAP_DURATION);
+    }
+
+    void StopSwarm()
+    {
+        m_creature->RemoveAurasDueToSpell(SPELL_GIANT_INSECT_SWARM);
+        m_creature->RemoveAllDynObjects();
+        m_creature->CombatStop(true);
+        m_creature->DeleteThreatList();
+
+        GuidList insectGuids = m_insectGuids;
+        m_insectGuids.clear();
+        for (ObjectGuid const& guid : insectGuids)
         {
-            float fX, fY, fZ;
-            pSummoned->GetPosition(fX, fY, fZ);
-            pSummoned->UpdateAllowedPositionZ(fX, fY, fZ);
-            pSummoned->SetWalk(false);
-            pSummoned->SetLevitate(true);
-            pSummoned->GetMotionMaster()->MovePoint(1, fX, fY, fZ);
+            if (Creature* insect = m_creature->GetMap()->GetCreature(guid))
+            {
+                insect->CombatStop(true);
+                insect->DeleteThreatList();
+                insect->ForcedDespawn();
+            }
+        }
+
+        // Recover summons whose GUID bookkeeping was lost across a reset or
+        // unload.  Keep this local to the gauntlet so unrelated ICC insects
+        // are never affected.
+        std::list<Creature*> insects;
+        GetCreatureListWithEntryInGrid(insects, m_creature, NPC_FLESH_EATING_INSECT, 120.0f);
+        for (Creature* insect : insects)
+        {
+            insect->CombatStop(true);
+            insect->DeleteThreatList();
+            insect->ForcedDespawn();
         }
     }
 
-    void SummonedMovementInform(Creature* pSummoned, uint32 uiMotionType, uint32 uiPointId) override
+    void FinishEvent(EncounterState state)
     {
-        if (uiMotionType != POINT_MOTION_TYPE || !uiPointId)
-            return;
+        DisableTimer(PUTRICIDE_TRAP_SUMMON);
+        DisableTimer(PUTRICIDE_TRAP_FINISH);
+        StopSwarm();
 
-        pSummoned->SetLevitate(false);
+        if (m_instance)
+            m_instance->SetData(TYPE_PLAGUE_WING_ENTRANCE, state);
     }
 
-    void SummonedCreatureJustDied(Creature* pSummoned) override
+    void JustSummoned(Creature* summoned) override
     {
-        if (!m_pInstance)
-            return;
-
-        if (m_pInstance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
-            return;
-
-        if (pSummoned->GetEntry() == NPC_FLESH_EATING_INSECT)
+        if (summoned->GetEntry() == NPC_FLESH_EATING_INSECT)
         {
-            ++m_uiInsectCounter;
-            if (m_uiInsectCounter >= TOTAL_INSECTS_PER_EVENT)
-            {
-                m_uiSummonTimer = 0;
-                m_uiEventTimer = 0;
+            m_insectGuids.push_back(summoned->GetObjectGuid());
+            float x, y, z;
+            summoned->GetPosition(x, y, z);
+            summoned->UpdateAllowedPositionZ(x, y, z);
+            summoned->SetWalk(false);
+            summoned->SetLevitate(true);
+            summoned->GetMotionMaster()->MovePoint(1, x, y, z);
+        }
+    }
 
-                m_pInstance->SetData(TYPE_PLAGUE_WING_ENTRANCE, DONE);
+    void SummonedMovementInform(Creature* summoned, uint32 motionType, uint32 pointId) override
+    {
+        if (motionType != POINT_MOTION_TYPE || !pointId)
+            return;
+
+        summoned->SetLevitate(false);
+    }
+
+    void SummonedCreatureJustDied(Creature* summoned) override
+    {
+        if (!m_instance || m_instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
+            return;
+
+        if (summoned->GetEntry() == NPC_FLESH_EATING_INSECT)
+        {
+            m_insectGuids.remove(summoned->GetObjectGuid());
+            ++m_insectCounter;
+            if (m_insectCounter >= TOTAL_INSECTS_PER_EVENT)
+            {
+                FinishEvent(DONE);
                 m_creature->ForcedDespawn();
             }
         }
     }
 
-    void UpdateAI(const uint32 uiDiff) override
+    void SummonedCreatureDespawn(Creature* summoned) override
     {
-        if (!m_pInstance)
-            return;
+        if (summoned->GetEntry() == NPC_FLESH_EATING_INSECT)
+            m_insectGuids.remove(summoned->GetObjectGuid());
+    }
 
-        if (m_pInstance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
-            return;
-
-        // random summon creatures
-        if (m_uiSummonTimer)
+    void SummonInsects()
+    {
+        if (!m_instance || m_instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
         {
-            if (m_uiSummonTimer <= uiDiff)
-            {
-                float fX, fY, fZ;
-                uint8 uiMaxInsects = urand(static_cast<float>(MAX_INSECT_PER_ROUND) * 0.5f, static_cast<float>(MAX_INSECT_PER_ROUND));
-                for (uint8 i = 0; i < uiMaxInsects; ++i)
-                {
-                    m_creature->GetRandomPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), 15.0f, fX, fY, fZ);
-                    m_creature->SummonCreature(NPC_FLESH_EATING_INSECT, fX, fY, fZ + 20.0f, 0, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 5 * MINUTE * IN_MILLISECONDS);
-                }
-                m_uiSummonTimer = urand(2000, 5000);
-            }
-            else
-                m_uiSummonTimer -= uiDiff;
+            DisableTimer(PUTRICIDE_TRAP_SUMMON);
+            return;
         }
 
-        // event can last max 5 min
-        if (m_uiEventTimer)
+        float x, y, z;
+        uint8 insectCount = urand(MAX_INSECT_PER_ROUND / 2, MAX_INSECT_PER_ROUND);
+        for (uint8 i = 0; i < insectCount; ++i)
         {
-            if (m_uiEventTimer <= uiDiff)
-            {
-                bool bEventFailed = true;
-
-                // check withing all players in map if any are still alive and in LoS
-                Map::PlayerList const& pAllPlayers = m_pInstance->instance->GetPlayers();
-
-                if (!pAllPlayers.isEmpty())
-                {
-                    for (const auto& pAllPlayer : pAllPlayers)
-                    {
-                        if (Player* pPlayer = pAllPlayer.getSource())
-                        {
-                            if (pPlayer->IsAlive() && pPlayer->IsWithinLOSInMap(m_creature))
-                                bEventFailed = false;
-                        }
-                    }
-                }
-
-                // set event as done if there are still players around
-                m_pInstance->SetData(TYPE_PLAGUE_WING_ENTRANCE, bEventFailed ? FAIL : DONE);
-                m_uiSummonTimer = 0;
-                m_uiEventTimer = 0;
-            }
-            else
-                m_uiEventTimer -= uiDiff;
+            m_creature->GetRandomPoint(m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(), 15.0f, x, y, z);
+            m_creature->SummonCreature(NPC_FLESH_EATING_INSECT, x, y, z + 20.0f, 0, TEMPSPAWN_TIMED_OOC_OR_DEAD_DESPAWN, 5 * MINUTE * IN_MILLISECONDS);
         }
+
+        ResetTimer(PUTRICIDE_TRAP_SUMMON, urand(2000, 5000));
+    }
+
+    void FinishByTimer()
+    {
+        if (!m_instance || m_instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
+            return;
+
+        bool eventFailed = true;
+        Map::PlayerList const& players = m_instance->instance->GetPlayers();
+        for (const auto& playerReference : players)
+        {
+            if (Player* player = playerReference.getSource())
+            {
+                if (player->IsAlive() && player->IsWithinLOSInMap(m_creature))
+                {
+                    eventFailed = false;
+                    break;
+                }
+            }
+        }
+
+        FinishEvent(eventFailed ? FAIL : DONE);
+    }
+
+    void UpdateAI(const uint32 diff) override
+    {
+        if (!m_instance || m_instance->GetData(TYPE_PLAGUE_WING_ENTRANCE) != IN_PROGRESS)
+        {
+            if (m_creature->HasAura(SPELL_GIANT_INSECT_SWARM) || !m_insectGuids.empty())
+                StopSwarm();
+            return;
+        }
+
+        CombatAI::UpdateAI(diff);
     }
 };
 
@@ -435,6 +496,94 @@ UnitAI* GetAI_npc_putricides_trap(Creature* pCreature)
 {
     return new npc_putricides_trapAI(pCreature);
 };
+
+/*#####
+## npc_icc_vengeful_fleshreaper
+#####*/
+
+enum VengefulFleshreaperActions
+{
+    POINT_PIPE_JUMP = 3703801,
+};
+
+// Pipe movement cannot build a generic chase path to players on the floor.
+// Combat spells are supplied by creature_spell_list; this AI only performs
+// the geometry-specific jump before normal combat begins.
+struct npc_icc_vengeful_fleshreaperAI : public CombatAI
+{
+    npc_icc_vengeful_fleshreaperAI(Creature* creature) : CombatAI(creature, 0),
+        m_pipeSpawn(creature->GetRespawnPosition().z > 365.0f)
+    {
+        Reset();
+    }
+
+    bool m_pipeSpawn;
+    bool m_jumping;
+    ObjectGuid m_jumpTargetGuid;
+
+    void Reset() override
+    {
+        CombatAI::Reset();
+        m_jumping = false;
+        m_jumpTargetGuid.Clear();
+        m_creature->SetWalk(false);
+    }
+
+    void MoveInLineOfSight(Unit* who) override
+    {
+        if (!m_pipeSpawn)
+        {
+            CombatAI::MoveInLineOfSight(who);
+            return;
+        }
+
+        if (!m_jumping && !m_creature->IsInCombat() && who->IsPlayer() && who->IsAlive() &&
+                m_creature->CanAttack(who) && m_creature->IsWithinDistInMap(who, 25.0f))
+            AttackStart(who);
+    }
+
+    void AttackStart(Unit* who) override
+    {
+        if (!who)
+            return;
+
+        CombatAI::AttackStart(who);
+
+        if (!m_pipeSpawn || m_jumping || m_creature->GetPositionZ() < 365.0f)
+            return;
+
+        float angle = who->GetAngle(m_creature);
+        float x = who->GetPositionX() + std::cos(angle) * 3.0f;
+        float y = who->GetPositionY() + std::sin(angle) * 3.0f;
+        m_jumping = true;
+        m_jumpTargetGuid = who->GetObjectGuid();
+        m_creature->GetMotionMaster()->MoveJump(x, y, who->GetPositionZ(), 10.0f, 6.0f, POINT_PIPE_JUMP);
+    }
+
+    void MovementInform(uint32 movementType, uint32 pointId) override
+    {
+        if (movementType != EFFECT_MOTION_TYPE || pointId != POINT_PIPE_JUMP)
+            return;
+
+        m_jumping = false;
+        if (Unit* target = m_creature->GetMap()->GetUnit(m_jumpTargetGuid))
+        {
+            if (target->IsAlive() && m_creature->CanAttack(target))
+                CombatAI::AttackStart(target);
+        }
+    }
+
+    void UpdateAI(const uint32 diff) override
+    {
+        if (!m_jumping)
+            CombatAI::UpdateAI(diff);
+    }
+};
+
+UnitAI* GetAI_npc_icc_vengeful_fleshreaper(Creature* creature)
+{
+    return new npc_icc_vengeful_fleshreaperAI(creature);
+}
 
 struct LadyDeathwhisperElevator : public GameObjectAI, public TimerManager
 {
@@ -512,6 +661,11 @@ void AddSC_icecrown_citadel()
     pNewScript = new Script;
     pNewScript->Name = "npc_putricides_trap";
     pNewScript->GetAI = &GetAI_npc_putricides_trap;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_icc_vengeful_fleshreaper";
+    pNewScript->GetAI = &GetAI_npc_icc_vengeful_fleshreaper;
     pNewScript->RegisterSelf();
 
     pNewScript = new Script;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadelScripts.cpp
@@ -320,6 +320,7 @@ struct npc_putricides_trapAI : public CombatAI
     npc_putricides_trapAI(Creature* creature) : CombatAI(creature, 0),
         m_instance(static_cast<instance_icecrown_citadel*>(creature->GetInstanceData()))
     {
+        SetReactState(REACT_PASSIVE);
         AddCustomAction(PUTRICIDE_TRAP_SUMMON, true, [&]() { SummonInsects(); });
         AddCustomAction(PUTRICIDE_TRAP_FINISH, true, [&]() { FinishByTimer(); });
         Reset();
@@ -338,9 +339,6 @@ struct npc_putricides_trapAI : public CombatAI
         DisableTimer(PUTRICIDE_TRAP_FINISH);
         StopSwarm();
     }
-
-    void MoveInLineOfSight(Unit* /*who*/) override { }
-    void AttackStart(Unit* /*who*/) override { }
 
     void ReceiveAIEvent(AIEventType eventType, Unit* /*sender*/, Unit* /*invoker*/, uint32 /*miscValue*/) override
     {


### PR DESCRIPTION
Restores Plagueworks corridor and pipe-trap behavior, including missing trash AI and jump handling.

Routine trash rotations use DB spell lists. The core script handles the Fleshreaper jump and insect trap sequence.

DB companion: https://github.com/cmangos/wotlk-db/pull/1393

Retested on 10- and 25-player normal after the review changes. Both Fleshreapers jump and engage, and the insect event completes, clears its swarm, debuff, and combat state, and does not retrigger. Heroic still needs testing.
