### PR TITLE
ICC: restore Frostwing Halls and Upper Spire trash

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sister_svalna.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sister_svalna.cpp
@@ -8,14 +8,14 @@
 
 enum
 {
-    SAY_CROK_INTRO_1       = -1631130,
-    SAY_ARNATH_INTRO_2     = -1631131,
-    SAY_CROK_INTRO_3       = -1631132,
-    SAY_SVALNA_EVENT_START = -1631133,
-    SAY_SVALNA_RESURRECT   = -1631135,
-    SAY_SVALNA_AGGRO       = -1631136,
-    SAY_SVALNA_KILL_PLAYER = -1631138,
-    SAY_SVALNA_DEATH       = -1631139,
+    SAY_CROK_INTRO_1       = 36945,
+    SAY_ARNATH_INTRO_2     = 36948,
+    SAY_CROK_INTRO_3       = 36946,
+    SAY_SVALNA_EVENT_START = 37024,
+    SAY_SVALNA_RESURRECT   = 37020,
+    SAY_SVALNA_AGGRO       = 37653,
+    SAY_SVALNA_KILL_PLAYER = 37654,
+    SAY_SVALNA_DEATH       = 37135,
 
     SPELL_SCOURGE_STRIKE   = 71488,
     SPELL_DEATH_STRIKE     = 71489,
@@ -63,11 +63,11 @@ struct boss_sister_svalnaAI : public ScriptedAI
         if (eventType == AI_EVENT_CUSTOM_A && !m_eventStarted)
         {
             m_eventStarted = true;
-            DoScriptText(SAY_SVALNA_EVENT_START, m_creature);
+            DoBroadcastText(SAY_SVALNA_EVENT_START, m_creature);
         }
         else if (eventType == AI_EVENT_CUSTOM_B && !m_landed)
         {
-            DoScriptText(SAY_SVALNA_RESURRECT, m_creature);
+            DoBroadcastText(SAY_SVALNA_RESURRECT, m_creature);
             DoCastSpellIfCan(m_creature, SPELL_REVIVE_CHAMPION);
             m_creature->SetLevitate(true);
             m_creature->GetMotionMaster()->MovePoint(POINT_SVALNA_LAND, 4356.88f, 2512.40f, 358.436f);
@@ -96,19 +96,19 @@ struct boss_sister_svalnaAI : public ScriptedAI
         m_creature->SetLevitate(false);
         m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
         SetCombatMovement(true);
-        DoScriptText(SAY_SVALNA_AGGRO, m_creature);
+        DoBroadcastText(SAY_SVALNA_AGGRO, m_creature);
         m_creature->SetInCombatWithZone();
     }
 
     void KilledUnit(Unit* victim) override
     {
         if (victim->GetTypeId() == TYPEID_PLAYER)
-            DoScriptText(SAY_SVALNA_KILL_PLAYER, m_creature);
+            DoBroadcastText(SAY_SVALNA_KILL_PLAYER, m_creature);
     }
 
     void JustDied(Unit*) override
     {
-        DoScriptText(SAY_SVALNA_DEATH, m_creature);
+        DoBroadcastText(SAY_SVALNA_DEATH, m_creature);
     }
 
     void JustReachedHome() override
@@ -193,7 +193,7 @@ struct npc_crok_scourgebaneAI : public npc_escortAI
         m_started = true;
         m_introStep = 1;
         m_introTimer = 7000;
-        DoScriptText(SAY_CROK_INTRO_1, m_creature);
+        DoBroadcastText(SAY_CROK_INTRO_1, m_creature);
 
         if (Creature* svalna = m_instance->GetSingleCreatureFromStorage(NPC_SISTER_SVALNA))
             svalna->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, m_creature, svalna);
@@ -277,12 +277,12 @@ struct npc_crok_scourgebaneAI : public npc_escortAI
                 if (m_introStep == 2)
                 {
                     if (Creature* arnath = m_instance->GetSingleCreatureFromStorage(NPC_CAPTAIN_ARNATH))
-                        DoScriptText(SAY_ARNATH_INTRO_2, arnath);
+                        DoBroadcastText(SAY_ARNATH_INTRO_2, arnath);
                     m_introTimer = 7000;
                 }
                 else if (m_introStep == 3)
                 {
-                    DoScriptText(SAY_CROK_INTRO_3, m_creature);
+                    DoBroadcastText(SAY_CROK_INTRO_3, m_creature);
                     m_introTimer = 21000;
                 }
                 else

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sister_svalna.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sister_svalna.cpp
@@ -1,0 +1,332 @@
+/* Frostwing Halls gauntlet and Sister Svalna encounter.
+ * Adapted to CMaNGOS ScriptDevAI from the retail flow preserved by
+ * TrinityCore's 3.3.5 implementation. */
+
+#include "AI/ScriptDevAI/include/sc_common.h"
+#include "AI/ScriptDevAI/base/escort_ai.h"
+#include "icecrown_citadel.h"
+
+enum
+{
+    SAY_CROK_INTRO_1       = -1631130,
+    SAY_ARNATH_INTRO_2     = -1631131,
+    SAY_CROK_INTRO_3       = -1631132,
+    SAY_SVALNA_EVENT_START = -1631133,
+    SAY_SVALNA_RESURRECT   = -1631135,
+    SAY_SVALNA_AGGRO       = -1631136,
+    SAY_SVALNA_KILL_PLAYER = -1631138,
+    SAY_SVALNA_DEATH       = -1631139,
+
+    SPELL_SCOURGE_STRIKE   = 71488,
+    SPELL_DEATH_STRIKE     = 71489,
+    SPELL_REVIVE_CHAMPION  = 70053,
+    SPELL_CARESS_OF_DEATH  = 70078,
+    SPELL_IMPALING_SPEAR   = 71443,
+    SPELL_AETHER_SHIELD    = 71463,
+    SPELL_HURL_SPEAR       = 71466,
+
+    POINT_SVALNA_LAND      = 1,
+};
+
+static uint32 const aCaptainEntries[] =
+{
+    NPC_CAPTAIN_ARNATH, NPC_CAPTAIN_BRANDON,
+    NPC_CAPTAIN_GRONDEL, NPC_CAPTAIN_RUPERT
+};
+
+struct boss_sister_svalnaAI : public ScriptedAI
+{
+    boss_sister_svalnaAI(Creature* creature) : ScriptedAI(creature)
+    {
+        m_instance = static_cast<instance_icecrown_citadel*>(creature->GetInstanceData());
+        Reset();
+    }
+
+    instance_icecrown_citadel* m_instance;
+    uint32 m_spearTimer;
+    uint32 m_shieldTimer;
+    bool m_eventStarted;
+    bool m_landed;
+
+    void Reset() override
+    {
+        m_spearTimer = urand(40000, 50000);
+        m_shieldTimer = urand(100000, 110000);
+        m_eventStarted = false;
+        m_landed = false;
+        m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+        SetCombatMovement(false);
+    }
+
+    void ReceiveAIEvent(AIEventType eventType, Unit*, Unit*, uint32) override
+    {
+        if (eventType == AI_EVENT_CUSTOM_A && !m_eventStarted)
+        {
+            m_eventStarted = true;
+            DoScriptText(SAY_SVALNA_EVENT_START, m_creature);
+        }
+        else if (eventType == AI_EVENT_CUSTOM_B && !m_landed)
+        {
+            DoScriptText(SAY_SVALNA_RESURRECT, m_creature);
+            DoCastSpellIfCan(m_creature, SPELL_REVIVE_CHAMPION);
+            m_creature->SetLevitate(true);
+            m_creature->GetMotionMaster()->MovePoint(POINT_SVALNA_LAND, 4356.88f, 2512.40f, 358.436f);
+        }
+        else if (eventType == AI_EVENT_CUSTOM_C && m_eventStarted && !m_landed)
+        {
+            // Retail kills one random surviving captain at each of the two
+            // middle gauntlet stops. The revive spell later converts them
+            // into Svalna's undead champions.
+            std::vector<Creature*> captains;
+            for (uint32 entry : aCaptainEntries)
+                if (Creature* captain = m_instance->GetSingleCreatureFromStorage(entry))
+                    if (captain->IsAlive())
+                        captains.push_back(captain);
+            if (!captains.empty())
+                m_creature->CastSpell(captains[urand(0, captains.size() - 1)], SPELL_CARESS_OF_DEATH, TRIGGERED_NONE);
+        }
+    }
+
+    void MovementInform(uint32 type, uint32 point) override
+    {
+        if (type != POINT_MOTION_TYPE || point != POINT_SVALNA_LAND)
+            return;
+
+        m_landed = true;
+        m_creature->SetLevitate(false);
+        m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+        SetCombatMovement(true);
+        DoScriptText(SAY_SVALNA_AGGRO, m_creature);
+        m_creature->SetInCombatWithZone();
+    }
+
+    void KilledUnit(Unit* victim) override
+    {
+        if (victim->GetTypeId() == TYPEID_PLAYER)
+            DoScriptText(SAY_SVALNA_KILL_PLAYER, m_creature);
+    }
+
+    void JustDied(Unit*) override
+    {
+        DoScriptText(SAY_SVALNA_DEATH, m_creature);
+    }
+
+    void JustReachedHome() override
+    {
+        if (!m_instance || m_instance->GetData(TYPE_FROST_WING_ENTRANCE) == DONE)
+            return;
+
+        for (uint32 entry : aCaptainEntries)
+            if (Creature* captain = m_instance->GetSingleCreatureFromStorage(entry))
+                if (!captain->IsAlive())
+                    captain->Respawn();
+
+        if (Creature* crok = m_instance->GetSingleCreatureFromStorage(NPC_CROK_SCOURGEBANE))
+            crok->Respawn();
+    }
+
+    void SpellHit(Unit*, SpellEntry const* spellInfo) override
+    {
+        if (spellInfo->Id == SPELL_HURL_SPEAR && m_creature->HasAura(SPELL_AETHER_SHIELD))
+            m_creature->RemoveAurasDueToSpell(SPELL_AETHER_SHIELD);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
+            return;
+
+        if (m_spearTimer <= diff)
+        {
+            if (Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1, SPELL_IMPALING_SPEAR, SELECT_FLAG_PLAYER))
+                if (DoCastSpellIfCan(target, SPELL_IMPALING_SPEAR) == CAST_OK)
+                    m_spearTimer = urand(20000, 25000);
+        }
+        else
+            m_spearTimer -= diff;
+
+        if (m_shieldTimer <= diff)
+        {
+            if (DoCastSpellIfCan(m_creature, SPELL_AETHER_SHIELD) == CAST_OK)
+                m_shieldTimer = urand(100000, 110000);
+        }
+        else
+            m_shieldTimer -= diff;
+
+        DoMeleeAttackIfReady();
+    }
+};
+
+struct npc_crok_scourgebaneAI : public npc_escortAI
+{
+    npc_crok_scourgebaneAI(Creature* creature) : npc_escortAI(creature)
+    {
+        m_instance = static_cast<instance_icecrown_citadel*>(creature->GetInstanceData());
+        m_started = false;
+        m_introStep = 0;
+        m_introTimer = 0;
+        m_strikeTimer = urand(7500, 12500);
+        m_deathStrikeTimer = urand(25000, 30000);
+        m_trashCheckTimer = 1000;
+        m_pausedPoint = 0;
+    }
+
+    instance_icecrown_citadel* m_instance;
+    bool m_started;
+    uint8 m_introStep;
+    uint32 m_introTimer;
+    uint32 m_strikeTimer;
+    uint32 m_deathStrikeTimer;
+    uint32 m_trashCheckTimer;
+    uint8 m_pausedPoint;
+
+    void Reset() override { }
+
+    void MoveInLineOfSight(Unit* who) override
+    {
+        npc_escortAI::MoveInLineOfSight(who);
+        if (m_started || who->GetTypeId() != TYPEID_PLAYER || !m_instance ||
+                m_instance->GetData(TYPE_FROST_WING_ENTRANCE) == DONE ||
+                !m_creature->IsWithinDistInMap(who, 35.0f))
+            return;
+
+        m_started = true;
+        m_introStep = 1;
+        m_introTimer = 7000;
+        DoScriptText(SAY_CROK_INTRO_1, m_creature);
+
+        if (Creature* svalna = m_instance->GetSingleCreatureFromStorage(NPC_SISTER_SVALNA))
+            svalna->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, m_creature, svalna);
+
+        for (uint32 entry : aCaptainEntries)
+            if (Creature* captain = m_instance->GetSingleCreatureFromStorage(entry))
+                captain->GetMotionMaster()->MoveFollow(m_creature, captain->GetDistance(m_creature), captain->GetAngle(m_creature));
+    }
+
+    void WaypointReached(uint32 point) override
+    {
+        if (point == 1 || point == 2 || point == 5)
+        {
+            m_pausedPoint = point;
+            if (HasAliveTrashForPoint(point))
+                SetEscortPaused(true);
+            else if (point == 5)
+                StartSvalnaEncounter();
+        }
+    }
+
+    void WaypointStart(uint32 point) override
+    {
+        if ((point == 2 || point == 3) && m_instance)
+            if (Creature* svalna = m_instance->GetSingleCreatureFromStorage(NPC_SISTER_SVALNA))
+                svalna->AI()->SendAIEvent(AI_EVENT_CUSTOM_C, m_creature, svalna);
+    }
+
+    bool HasAliveTrashForPoint(uint8 point)
+    {
+        float minY = point == 1 ? 2600.0f : point == 2 ? 2550.0f : 2500.0f;
+        float maxY = minY + 50.0f;
+        uint32 const entries[] = {37127, 37132, 37133, 37134};
+        for (uint32 entry : entries)
+        {
+            CreatureList trash;
+            GetCreatureListWithEntryInGrid(trash, m_creature, entry, 100.0f);
+            for (Creature* creature : trash)
+            {
+                float x, y, z;
+                creature->GetRespawnCoord(x, y, z);
+                if (creature->IsAlive() && y > minY && y < maxY)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    void StartSvalnaEncounter()
+    {
+        m_pausedPoint = 0;
+        if (Creature* svalna = m_instance->GetSingleCreatureFromStorage(NPC_SISTER_SVALNA))
+            svalna->AI()->SendAIEvent(AI_EVENT_CUSTOM_B, m_creature, svalna);
+    }
+
+    void UpdateEscortAI(uint32 diff) override
+    {
+        if (m_pausedPoint && HasEscortState(STATE_ESCORT_PAUSED))
+        {
+            if (m_trashCheckTimer <= diff)
+            {
+                m_trashCheckTimer = 1000;
+                if (!HasAliveTrashForPoint(m_pausedPoint))
+                {
+                    uint8 clearedPoint = m_pausedPoint;
+                    m_pausedPoint = 0;
+                    SetEscortPaused(false);
+                    if (clearedPoint == 5)
+                        StartSvalnaEncounter();
+                }
+            }
+            else
+                m_trashCheckTimer -= diff;
+        }
+
+        if (m_introTimer)
+        {
+            if (m_introTimer <= diff)
+            {
+                ++m_introStep;
+                if (m_introStep == 2)
+                {
+                    if (Creature* arnath = m_instance->GetSingleCreatureFromStorage(NPC_CAPTAIN_ARNATH))
+                        DoScriptText(SAY_ARNATH_INTRO_2, arnath);
+                    m_introTimer = 7000;
+                }
+                else if (m_introStep == 3)
+                {
+                    DoScriptText(SAY_CROK_INTRO_3, m_creature);
+                    m_introTimer = 21000;
+                }
+                else
+                {
+                    m_introTimer = 0;
+                    Start(false);
+                }
+            }
+            else
+                m_introTimer -= diff;
+        }
+
+        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
+            return;
+
+        if (m_strikeTimer <= diff)
+        {
+            if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_SCOURGE_STRIKE) == CAST_OK)
+                m_strikeTimer = urand(10000, 14000);
+        }
+        else
+            m_strikeTimer -= diff;
+
+        if (m_deathStrikeTimer <= diff)
+        {
+            if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_DEATH_STRIKE) == CAST_OK)
+                m_deathStrikeTimer = urand(25000, 30000);
+        }
+        else
+            m_deathStrikeTimer -= diff;
+
+        DoMeleeAttackIfReady();
+    }
+};
+
+void AddSC_boss_sister_svalna()
+{
+    Script* script = new Script;
+    script->Name = "boss_sister_svalna";
+    script->GetAI = &GetNewAIInstance<boss_sister_svalnaAI>;
+    script->RegisterSelf();
+
+    script = new Script;
+    script->Name = "npc_crok_scourgebane";
+    script->GetAI = &GetNewAIInstance<npc_crok_scourgebaneAI>;
+    script->RegisterSelf();
+}

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -82,6 +82,7 @@ enum
     SPELL_GUNSHIP_ACHIEVEMENT       = 72959,
     SPELL_TELEPORT_PLAYERS_VICTORY  = 72340,
     SPELL_CHECK_FOR_PLAYERS         = 70332,                // check for aura 70120 or 70121 on player; if not found cast 67335
+    SPELL_COLDFLAME_JETS            = 70460,
 };
 
 static const DialogueEntry aCitadelDialogue[] =
@@ -120,6 +121,8 @@ static const DialogueEntry aCitadelDialogue[] =
 instance_icecrown_citadel::instance_icecrown_citadel(Map* pMap) : ScriptedInstance(pMap), DialogueHelper(aCitadelDialogue),
     m_uiTeam(0),
     m_uiPutricideValveTimer(0),
+    m_coldflameJetsState(NOT_STARTED),
+    m_sindragosaGauntletState(NOT_STARTED),
     m_bHasMarrowgarIntroYelled(false),
     m_bHasDeathwhisperIntroYelled(false),
     m_bHasRimefangLanded(false),
@@ -132,6 +135,10 @@ void instance_icecrown_citadel::Initialize()
 {
     InitializeDialogueHelper(this);
     memset(&m_auiEncounter, 0, sizeof(m_auiEncounter));
+    m_coldflameJetsState = NOT_STARTED;
+    m_sindragosaGauntletState = NOT_STARTED;
+    m_rimefangTrashGuids.clear();
+    m_spinestalkerTrashGuids.clear();
 
     for (bool& i : m_abAchievCriteria)
         i = false;
@@ -145,7 +152,7 @@ bool instance_icecrown_citadel::IsEncounterInProgress() const
             return true;
     }
 
-    return false;
+    return m_sindragosaGauntletState == IN_PROGRESS;
 }
 
 void instance_icecrown_citadel::DoHandleCitadelAreaTrigger(uint32 uiTriggerId, Player* pPlayer)
@@ -172,25 +179,198 @@ void instance_icecrown_citadel::DoHandleCitadelAreaTrigger(uint32 uiTriggerId, P
         }
         else
         {
-            if (!m_bHasRimefangLanded)
-            {
-                if (Creature* pRimefang = GetSingleCreatureFromStorage(NPC_RIMEFANG))
-                {
-                    pRimefang->AI()->AttackStart(pPlayer);
-                    m_bHasRimefangLanded = true;
-                }
-            }
-
-            if (!m_bHasSpinestalkerLanded)
-            {
-                if (Creature* pSpinestalker = GetSingleCreatureFromStorage(NPC_SPINESTALKER))
-                {
-                    pSpinestalker->AI()->AttackStart(pPlayer);
-                    m_bHasSpinestalkerLanded = true;
-                }
-            }
+            // The normal start signal is clearing each frostwyrm's own pack.
+            // Keep the platform trigger as a grid-load safety net only.
+            if (m_rimefangTrashGuids.empty())
+                StartSindragosaFrostwyrm(NPC_RIMEFANG, pPlayer);
+            if (m_spinestalkerTrashGuids.empty())
+                StartSindragosaFrostwyrm(NPC_SPINESTALKER, pPlayer);
         }
     }
+    else if (uiTriggerId == AT_SINDRAGOSA_GAUNTLET)
+    {
+        if (m_sindragosaGauntletState != NOT_STARTED)
+            return;
+
+        if (Creature* controller = GetSingleCreatureFromStorage(NPC_SINDRAGOSA_GAUNTLET))
+            controller->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, pPlayer, controller);
+    }
+    else if (uiTriggerId == AT_SAURFANG_PORTAL)
+    {
+        if (GetData(TYPE_DEATHBRINGER_SAURFANG) != DONE)
+            return;
+
+        float const destinationX = 4126.35f;
+        float const destinationY = 2769.23f;
+        float const destinationZ = 350.963f;
+        float const destinationO = 0.0f;
+
+        if (m_coldflameJetsState == NOT_STARTED)
+        {
+            // Trap AIs join the alternating schedule from the instance state.
+            // A one-time proximity scan here is unreliable in CMaNGOS because
+            // only the destination cell may be active while the player is
+            // being relocated; the other visible corridor emitters would
+            // then never receive an activation timer.
+            m_coldflameJetsState = IN_PROGRESS;
+        }
+
+        pPlayer->TeleportTo(instance->GetId(), destinationX, destinationY, destinationZ, destinationO);
+    }
+    else if (uiTriggerId == AT_SHUTDOWN_FROST_JETS)
+        SetData(DATA_COLDFLAME_JETS, DONE);
+}
+
+void instance_icecrown_citadel::StartSindragosaFrostwyrm(uint32 entry, Player* player)
+{
+    bool& landed = entry == NPC_RIMEFANG ? m_bHasRimefangLanded : m_bHasSpinestalkerLanded;
+    if (landed)
+        return;
+
+    if (!player)
+        player = GetPlayerInMap(true, false);
+
+    if (player)
+    {
+        if (Creature* frostwyrm = GetSingleCreatureFromStorage(entry))
+        {
+            frostwyrm->AI()->AttackStart(player);
+            landed = true;
+        }
+    }
+}
+
+struct ColdflameJetSchedule
+{
+    float x;
+    float y;
+    uint32 initialDelay;
+};
+
+// Retail trap placements ordered by distance from the Upper Spire teleporter.
+// TrinityCore and AzerothCore alternate the initial delay in this order. Keep
+// that cadence while allowing every CMaNGOS grid-loaded trap to initialize
+// itself instead of depending on one proximity collection.
+static ColdflameJetSchedule const aColdflameJetSchedules[] =
+{
+    {4135.747f, 2781.602f, 11000},
+    {4156.651f, 2781.518f,  1000},
+    {4160.112f, 2788.294f, 11000},
+    {4159.713f, 2735.113f,  1000},
+    {4159.799f, 2804.188f, 11000},
+    {4183.785f, 2751.657f,  1000},
+    {4192.597f, 2733.280f, 11000},
+    {4201.849f, 2750.526f,  1000},
+    {4193.007f, 2829.084f, 11000},
+    {4225.138f, 2788.188f,  1000},
+    {4224.835f, 2735.236f, 11000},
+    {4224.706f, 2804.109f,  1000},
+};
+
+static uint32 GetColdflameJetInitialDelay(Creature* trap)
+{
+    float spawnX, spawnY, spawnZ;
+    trap->GetRespawnCoord(spawnX, spawnY, spawnZ);
+
+    float closestDistanceSq = 1000000.0f;
+    uint32 initialDelay = 11000;
+    for (ColdflameJetSchedule const& schedule : aColdflameJetSchedules)
+    {
+        float const deltaX = spawnX - schedule.x;
+        float const deltaY = spawnY - schedule.y;
+        float const distanceSq = deltaX * deltaX + deltaY * deltaY;
+        if (distanceSq < closestDistanceSq)
+        {
+            closestDistanceSq = distanceSq;
+            initialDelay = schedule.initialDelay;
+        }
+    }
+
+    return initialDelay;
+}
+
+// The corridor alternates two trap rows. Each loaded trap independently joins
+// the shared 22-second cycle with the reference 1- or 11-second initial offset.
+struct npc_frost_freeze_trapAI : public ScriptedAI
+{
+    npc_frost_freeze_trapAI(Creature* creature) : ScriptedAI(creature),
+        m_instance(static_cast<instance_icecrown_citadel*>(creature->GetInstanceData())),
+        m_activationTimer(0), m_scheduleInitialized(false)
+    {
+        SetCombatMovement(false);
+        // Keep the whole short gauntlet updating once its grids are loaded.
+        // Otherwise the first emitter can remain the only repeating caster
+        // while the more distant trap grids unload behind the player.
+        m_creature->SetActiveObjectState(true);
+    }
+
+    instance_icecrown_citadel* m_instance;
+    uint32 m_activationTimer;
+    bool m_scheduleInitialized;
+
+    void Reset() override
+    {
+        m_activationTimer = 0;
+        m_scheduleInitialized = false;
+        RestoreSpawnFacing();
+    }
+
+    void RestoreSpawnFacing()
+    {
+        float spawnX, spawnY, spawnZ, spawnOrientation;
+        m_creature->GetRespawnCoord(spawnX, spawnY, spawnZ, &spawnOrientation);
+        m_creature->SetOrientation(spawnOrientation);
+        m_creature->SetFacingTo(spawnOrientation);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        // Match the passive TC/AC trap behavior without disabling combat on
+        // the caster. 70460 must be allowed to trigger hostile spell 70461.
+        if (m_creature->IsInCombat())
+        {
+            m_creature->CombatStop(false);
+            RestoreSpawnFacing();
+        }
+
+        uint32 const state = m_instance ? m_instance->GetData(DATA_COLDFLAME_JETS) : NOT_STARTED;
+        if (state != IN_PROGRESS)
+        {
+            if (m_scheduleInitialized)
+                m_creature->RemoveAurasDueToSpell(SPELL_COLDFLAME_JETS);
+            m_activationTimer = 0;
+            m_scheduleInitialized = false;
+            if (state == DONE)
+                m_creature->SetActiveObjectState(false);
+            return;
+        }
+
+        if (!m_scheduleInitialized)
+        {
+            m_activationTimer = GetColdflameJetInitialDelay(m_creature);
+            m_scheduleInitialized = true;
+        }
+
+        if (m_activationTimer > diff)
+        {
+            m_activationTimer -= diff;
+            return;
+        }
+
+        // 70461 is a narrow hostile cone periodically triggered by 70460.
+        // A hit may turn an otherwise passive trigger toward its victim in
+        // CMaNGOS, so restore the spawn facing before every activation.
+        RestoreSpawnFacing();
+        if (DoCastSpellIfCan(m_creature, SPELL_COLDFLAME_JETS) == CAST_OK)
+            m_activationTimer = 22000;
+        else
+            m_activationTimer = 1000;
+    }
+};
+
+UnitAI* GetAI_npc_frost_freeze_trap(Creature* creature)
+{
+    return new npc_frost_freeze_trapAI(creature);
 }
 
 void instance_icecrown_citadel::OnPlayerEnter(Player* pPlayer)
@@ -223,6 +403,13 @@ void instance_icecrown_citadel::OnCreatureCreate(Creature* pCreature)
         case NPC_TIRION_FORDRING:
         case NPC_RIMEFANG:
         case NPC_SPINESTALKER:
+        case NPC_CAPTAIN_ARNATH:
+        case NPC_CAPTAIN_BRANDON:
+        case NPC_CAPTAIN_GRONDEL:
+        case NPC_CAPTAIN_RUPERT:
+        case NPC_SISTER_SVALNA:
+        case NPC_CROK_SCOURGEBANE:
+        case NPC_SINDRAGOSA_GAUNTLET:
         case NPC_VALITHRIA_COMBAT_TRIGGER:
         case NPC_BLOOD_ORB_CONTROL:
         case NPC_PUTRICIDES_TRAP:
@@ -272,6 +459,17 @@ void instance_icecrown_citadel::OnCreatureCreate(Creature* pCreature)
                 m_leftScientistStalkerGuid = pCreature->GetObjectGuid();
             else
                 m_rightScientistStalkerGuid = pCreature->GetObjectGuid();
+            return;
+        case NPC_FROSTWING_WHELP:
+        {
+            float x, y, z;
+            pCreature->GetRespawnCoord(x, y, z);
+            if (y < 2484.35f)
+                m_rimefangTrashGuids.insert(pCreature->GetObjectGuid());
+            else
+                m_spinestalkerTrashGuids.insert(pCreature->GetObjectGuid());
+            return;
+        }
     }
 }
 
@@ -282,11 +480,15 @@ void instance_icecrown_citadel::OnCreatureRespawn(Creature* pCreature)
         // following have passive behavior movement
         case NPC_COLDFLAME:
         case NPC_DEATHWHISPER_SPAWN_STALKER:
-        case NPC_FROST_FREEZE_TRAP:
         case NPC_SKYBREAKER:
         case NPC_ORGRIMS_HAMMER:
             pCreature->AI()->SetReactState(REACT_PASSIVE);
             pCreature->SetCanEnterCombat(false);
+            break;
+        case NPC_FROST_FREEZE_TRAP:
+            // The reference trap is passive but still allowed to cast its
+            // hostile periodic damage trigger.
+            pCreature->AI()->SetReactState(REACT_PASSIVE);
             break;
     }
 }
@@ -358,6 +560,15 @@ void instance_icecrown_citadel::OnObjectCreate(GameObject* pGo)
             if (m_auiEncounter[TYPE_VALITHRIA] == DONE)
                 pGo->SetGoState(GO_STATE_ACTIVE);
             break;
+        case GO_SINDRAGOSA_ENTRANCE:
+            if (m_sindragosaGauntletState == DONE)
+                pGo->SetGoState(GO_STATE_ACTIVE);
+            break;
+        case GO_SINDRAGOSA_SHORTCUT_ENTRANCE:
+        case GO_SINDRAGOSA_SHORTCUT_EXIT:
+            if (m_auiEncounter[TYPE_SINDRAGOSA] == DONE)
+                pGo->SetGoState(GO_STATE_ACTIVE);
+            break;
         case GO_SAURFANG_CACHE:
         case GO_SAURFANG_CACHE_25:
         case GO_SAURFANG_CACHE_10_H:
@@ -393,14 +604,11 @@ void instance_icecrown_citadel::OnObjectCreate(GameObject* pGo)
         case GO_ARTHAS_PRECIPICE:
         case GO_MARROWGAR_DOOR:
         case GO_BLOODPRINCE_DOOR:
-        case GO_SINDRAGOSA_ENTRANCE:
         case GO_VALITHRIA_DOOR_1:
         case GO_VALITHRIA_DOOR_2:
         case GO_VALITHRIA_DOOR_3:
         case GO_VALITHRIA_DOOR_4:
         case GO_ICECROWN_GRATE:
-        case GO_SINDRAGOSA_SHORTCUT_ENTRANCE:
-        case GO_SINDRAGOSA_SHORTCUT_EXIT:
         case GO_ORANGE_PLAGUE:
         case GO_GREEN_PLAGUE:
         case GO_ORANGE_VALVE:
@@ -547,6 +755,20 @@ void instance_icecrown_citadel::OnCreatureDeath(Creature* pCreature)
                         DoToggleGameObjectFlags(pOrb->GetObjectGuid(), GO_FLAG_NO_INTERACT, false);
                 }
             }
+            break;
+        case NPC_SISTER_SVALNA:
+            SetData(TYPE_FROST_WING_ENTRANCE, DONE);
+            break;
+        case NPC_FROSTWING_WHELP:
+        {
+            GuidSet& pack = pCreature->GetRespawnPosition().GetPositionY() < 2484.35f ?
+                m_rimefangTrashGuids : m_spinestalkerTrashGuids;
+            pack.erase(pCreature->GetObjectGuid());
+            if (pack.empty())
+                StartSindragosaFrostwyrm(pCreature->GetRespawnPosition().GetPositionY() < 2484.35f ?
+                    NPC_RIMEFANG : NPC_SPINESTALKER);
+            break;
+        }
         case NPC_SPIRE_FROSTWYRM:
             SetData(TYPE_SPIRE_FROSTWYRM, DONE);
             break;
@@ -561,6 +783,24 @@ void instance_icecrown_citadel::OnCreatureDeath(Creature* pCreature)
 
 void instance_icecrown_citadel::SetData(uint32 uiType, uint32 uiData)
 {
+    if (uiType == DATA_COLDFLAME_JETS)
+    {
+        m_coldflameJetsState = uiData;
+
+        if (uiData == DONE)
+        {
+            OUT_SAVE_INST_DATA;
+            std::ostringstream saveStream;
+            for (uint32 i = 0; i < MAX_ENCOUNTER; ++i)
+                saveStream << m_auiEncounter[i] << " ";
+            saveStream << m_coldflameJetsState;
+            m_strInstData = saveStream.str();
+            SaveToDB();
+            OUT_SAVE_INST_DATA_COMPLETE;
+        }
+        return;
+    }
+
     switch (uiType)
     {
         case TYPE_MARROWGAR:
@@ -913,6 +1153,19 @@ void instance_icecrown_citadel::SetData(uint32 uiType, uint32 uiData)
         case TYPE_SPIRE_FROSTWYRM:
             m_auiEncounter[uiType] = uiData;
             break;
+        case DATA_COLDFLAME_JETS:
+            m_coldflameJetsState = uiData;
+            break;
+        case DATA_SINDRAGOSA_GAUNTLET:
+            m_sindragosaGauntletState = uiData;
+            if (uiData == IN_PROGRESS)
+                DoUseDoorOrButton(GO_SINDRAGOSA_ENTRANCE);
+            else if (uiData == DONE || uiData == FAIL)
+            {
+                if (GameObject* door = GetSingleGameObjectFromStorage(GO_SINDRAGOSA_ENTRANCE))
+                    door->SetGoState(GO_STATE_ACTIVE);
+            }
+            break;
         default:
             script_error_log("Instance Icecrown Citadel: ERROR SetData = %u for type %u does not exist/not implemented.", uiType, uiData);
             return;
@@ -929,7 +1182,7 @@ void instance_icecrown_citadel::SetData(uint32 uiType, uint32 uiData)
                    << m_auiEncounter[6] << " " << m_auiEncounter[7] << " " << m_auiEncounter[8] << " "
                    << m_auiEncounter[9] << " " << m_auiEncounter[10] << " " << m_auiEncounter[11] << " "
                    << m_auiEncounter[12] << " " << m_auiEncounter[13] << " " << m_auiEncounter[14] << " "
-                   << m_auiEncounter[15];
+                   << m_auiEncounter[15] << " " << m_coldflameJetsState << " " << m_sindragosaGauntletState;
 
         m_strInstData = saveStream.str();
 
@@ -937,7 +1190,7 @@ void instance_icecrown_citadel::SetData(uint32 uiType, uint32 uiData)
         OUT_SAVE_INST_DATA_COMPLETE;
     }
 
-    if (uiData == FAIL || uiData == DONE) // this would need to be done in all dynamic difficulty instances but wotlk only really needs it in icc
+    if (uiType < MAX_ENCOUNTER && (uiData == FAIL || uiData == DONE)) // this would need to be done in all dynamic difficulty instances but wotlk only really needs it in icc
     {
         instance->SetNewDifficultyCooldown(instance->GetCurrentClockTime() + std::chrono::milliseconds(60000));
     }
@@ -978,8 +1231,16 @@ void instance_icecrown_citadel::JustDidDialogueStep(int32 iEntry)
 
 uint32 instance_icecrown_citadel::GetData(uint32 uiType) const
 {
+    if (uiType == DATA_COLDFLAME_JETS)
+        return m_coldflameJetsState;
+
     if (uiType < MAX_ENCOUNTER)
         return m_auiEncounter[uiType];
+
+    if (uiType == DATA_COLDFLAME_JETS)
+        return m_coldflameJetsState;
+    if (uiType == DATA_SINDRAGOSA_GAUNTLET)
+        return m_sindragosaGauntletState;
 
     return 0;
 }
@@ -1046,11 +1307,27 @@ void instance_icecrown_citadel::Load(const char* strIn)
                >> m_auiEncounter[8] >> m_auiEncounter[9] >> m_auiEncounter[10] >> m_auiEncounter[11]
                >> m_auiEncounter[12] >> m_auiEncounter[13] >> m_auiEncounter[14] >> m_auiEncounter[15];
 
+    if (!(loadStream >> m_coldflameJetsState))
+        m_coldflameJetsState = NOT_STARTED;
+
+    // Only completed jet progression survives an instance reload; an active
+    // alternating sequence must restart cleanly after a server restart.
+    if (m_coldflameJetsState != DONE)
+        m_coldflameJetsState = NOT_STARTED;
+
+    if (!(loadStream >> m_sindragosaGauntletState))
+        m_sindragosaGauntletState = NOT_STARTED;
+
     for (uint32& i : m_auiEncounter)
     {
         if (i == IN_PROGRESS)
             i = NOT_STARTED;
     }
+
+    if (m_coldflameJetsState == IN_PROGRESS)
+        m_coldflameJetsState = NOT_STARTED;
+    if (m_sindragosaGauntletState == IN_PROGRESS)
+        m_sindragosaGauntletState = NOT_STARTED;
 
     OUT_LOAD_INST_DATA_COMPLETE;
 }
@@ -1164,13 +1441,25 @@ InstanceData* GetInstanceData_instance_icecrown_citadel(Map* pMap)
 
 bool AreaTrigger_at_icecrown_citadel(Player* pPlayer, AreaTriggerEntry const* pAt)
 {
+    if (pAt->id == AT_SAURFANG_PORTAL || pAt->id == AT_SHUTDOWN_FROST_JETS)
+    {
+        if (pPlayer->IsDead())
+            return false;
+
+        if (instance_icecrown_citadel* instance = static_cast<instance_icecrown_citadel*>(pPlayer->GetInstanceData()))
+            instance->DoHandleCitadelAreaTrigger(pAt->id, pPlayer);
+
+        return true;
+    }
+
     if (pAt->id == AT_MARROWGAR_INTRO || pAt->id == AT_DEATHWHISPER_INTRO ||
-            pAt->id == AT_SINDRAGOSA_PLATFORM)
+            pAt->id == AT_SINDRAGOSA_PLATFORM || pAt->id == AT_SINDRAGOSA_GAUNTLET ||
+            pAt->id == AT_SAURFANG_PORTAL || pAt->id == AT_SHUTDOWN_FROST_JETS)
     {
         if (pPlayer->IsGameMaster() || pPlayer->IsDead())
             return false;
 
-        if (instance_icecrown_citadel* pInstance = (instance_icecrown_citadel*)pPlayer->GetInstanceData())
+        if (instance_icecrown_citadel* pInstance = static_cast<instance_icecrown_citadel*>(pPlayer->GetInstanceData()))
             pInstance->DoHandleCitadelAreaTrigger(pAt->id, pPlayer);
     }
 
@@ -1203,6 +1492,11 @@ void AddSC_instance_icecrown_citadel()
     pNewScript = new Script;
     pNewScript->Name = "at_icecrown_citadel";
     pNewScript->pAreaTrigger = &AreaTrigger_at_icecrown_citadel;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_frost_freeze_trap";
+    pNewScript->GetAI = &GetAI_npc_frost_freeze_trap;
     pNewScript->RegisterSelf();
 
     pNewScript = new Script;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -238,6 +238,163 @@ void instance_icecrown_citadel::StartSindragosaFrostwyrm(uint32 entry, Player* p
             landed = true;
         }
     }
+    else if (uiTriggerId == AT_SAURFANG_PORTAL)
+    {
+        if (GetData(TYPE_DEATHBRINGER_SAURFANG) != DONE)
+            return;
+
+        float const destinationX = 4126.35f;
+        float const destinationY = 2769.23f;
+        float const destinationZ = 350.963f;
+        float const destinationO = 0.0f;
+
+        if (m_coldflameJetsState == NOT_STARTED)
+        {
+            // Trap AIs join the alternating schedule from the instance state.
+            // A one-time proximity scan here is unreliable in CMaNGOS because
+            // only the destination cell may be active while the player is
+            // being relocated; the other visible corridor emitters would
+            // then never receive an activation timer.
+            m_coldflameJetsState = IN_PROGRESS;
+        }
+
+        pPlayer->TeleportTo(instance->GetId(), destinationX, destinationY, destinationZ, destinationO);
+    }
+    else if (uiTriggerId == AT_SHUTDOWN_FROST_JETS)
+        SetData(DATA_COLDFLAME_JETS, DONE);
+}
+
+struct ColdflameJetSchedule
+{
+    float x;
+    float y;
+    uint32 initialDelay;
+};
+
+// Retail trap placements ordered by distance from the Upper Spire teleporter.
+// TrinityCore and AzerothCore alternate the initial delay in this order. Keep
+// that cadence while allowing every CMaNGOS grid-loaded trap to initialize
+// itself instead of depending on one proximity collection.
+static ColdflameJetSchedule const aColdflameJetSchedules[] =
+{
+    {4135.747f, 2781.602f, 11000},
+    {4156.651f, 2781.518f,  1000},
+    {4160.112f, 2788.294f, 11000},
+    {4159.713f, 2735.113f,  1000},
+    {4159.799f, 2804.188f, 11000},
+    {4183.785f, 2751.657f,  1000},
+    {4192.597f, 2733.280f, 11000},
+    {4201.849f, 2750.526f,  1000},
+    {4193.007f, 2829.084f, 11000},
+    {4225.138f, 2788.188f,  1000},
+    {4224.835f, 2735.236f, 11000},
+    {4224.706f, 2804.109f,  1000},
+};
+
+static uint32 GetColdflameJetInitialDelay(Creature* trap)
+{
+    float spawnX, spawnY, spawnZ;
+    trap->GetRespawnCoord(spawnX, spawnY, spawnZ);
+
+    float closestDistanceSq = 1000000.0f;
+    uint32 initialDelay = 11000;
+    for (ColdflameJetSchedule const& schedule : aColdflameJetSchedules)
+    {
+        float const deltaX = spawnX - schedule.x;
+        float const deltaY = spawnY - schedule.y;
+        float const distanceSq = deltaX * deltaX + deltaY * deltaY;
+        if (distanceSq < closestDistanceSq)
+        {
+            closestDistanceSq = distanceSq;
+            initialDelay = schedule.initialDelay;
+        }
+    }
+
+    return initialDelay;
+}
+
+// The corridor alternates two trap rows. Each loaded trap independently joins
+// the shared 22-second cycle with the reference 1- or 11-second initial offset.
+struct npc_frost_freeze_trapAI : public ScriptedAI
+{
+    npc_frost_freeze_trapAI(Creature* creature) : ScriptedAI(creature),
+        m_instance(static_cast<instance_icecrown_citadel*>(creature->GetInstanceData())),
+        m_activationTimer(0), m_scheduleInitialized(false)
+    {
+        SetCombatMovement(false);
+        // Keep the whole short gauntlet updating once its grids are loaded.
+        // Otherwise the first emitter can remain the only repeating caster
+        // while the more distant trap grids unload behind the player.
+        m_creature->SetActiveObjectState(true);
+    }
+
+    instance_icecrown_citadel* m_instance;
+    uint32 m_activationTimer;
+    bool m_scheduleInitialized;
+
+    void Reset() override
+    {
+        m_activationTimer = 0;
+        m_scheduleInitialized = false;
+        RestoreSpawnFacing();
+    }
+
+    void RestoreSpawnFacing()
+    {
+        float spawnX, spawnY, spawnZ, spawnOrientation;
+        m_creature->GetRespawnCoord(spawnX, spawnY, spawnZ, &spawnOrientation);
+        m_creature->SetOrientation(spawnOrientation);
+        m_creature->SetFacingTo(spawnOrientation);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        // Match the passive TC/AC trap behavior without disabling combat on
+        // the caster. 70460 must be allowed to trigger hostile spell 70461.
+        if (m_creature->IsInCombat())
+        {
+            m_creature->CombatStop(false);
+            RestoreSpawnFacing();
+        }
+
+        uint32 const state = m_instance ? m_instance->GetData(DATA_COLDFLAME_JETS) : NOT_STARTED;
+        if (state != IN_PROGRESS)
+        {
+            if (m_scheduleInitialized)
+                m_creature->RemoveAurasDueToSpell(SPELL_COLDFLAME_JETS);
+            m_activationTimer = 0;
+            m_scheduleInitialized = false;
+            if (state == DONE)
+                m_creature->SetActiveObjectState(false);
+            return;
+        }
+
+        if (!m_scheduleInitialized)
+        {
+            m_activationTimer = GetColdflameJetInitialDelay(m_creature);
+            m_scheduleInitialized = true;
+        }
+
+        if (m_activationTimer > diff)
+        {
+            m_activationTimer -= diff;
+            return;
+        }
+
+        // 70461 is a narrow hostile cone periodically triggered by 70460.
+        // A hit may turn an otherwise passive trigger toward its victim in
+        // CMaNGOS, so restore the spawn facing before every activation.
+        RestoreSpawnFacing();
+        if (DoCastSpellIfCan(m_creature, SPELL_COLDFLAME_JETS) == CAST_OK)
+            m_activationTimer = 22000;
+        else
+            m_activationTimer = 1000;
+    }
+};
+
+UnitAI* GetAI_npc_frost_freeze_trap(Creature* creature)
+{
+    return new npc_frost_freeze_trapAI(creature);
 }
 
 struct ColdflameJetSchedule

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.h
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.h
@@ -28,6 +28,11 @@ enum
     TYPE_PLAGUE_WING_ENTRANCE       = 14,
     TYPE_SPIRE_FROSTWYRM            = 15,
 
+    // Non-boss Frostwing and Upper Spire progression state. These values deliberately live
+    // outside the encounter array so neither event counts as a boss pull.
+    DATA_COLDFLAME_JETS             = 100,
+    DATA_SINDRAGOSA_GAUNTLET        = 101,
+
     // main boss entries
     NPC_LORD_MARROWGAR              = 36612,
     NPC_LADY_DEATHWHISPER           = 36855,
@@ -104,8 +109,25 @@ enum
     NPC_PUDDLE_STALKER              = 37013,        // related to Festergut and Rotface
     NPC_RIMEFANG                    = 37533,
     NPC_SPINESTALKER                = 37534,
+    NPC_FROSTWARDEN_HANDLER         = 37531,
+    NPC_FROSTWING_WHELP             = 37532,
+    NPC_SINDRAGOSA_GAUNTLET         = 37503,
+    NPC_NERUBAR_CHAMPION            = 37501,
+    NPC_NERUBAR_WEBWEAVER           = 37502,
+    NPC_NERUBAR_BROODLING           = 37232,
+    NPC_FROSTWARDEN_SORCERESS       = 37229,
+    NPC_FROSTWARDEN_WARRIOR         = 37228,
     NPC_OOZE_TENTACLE_STALKER       = 38308,        // accessories to Putricide
     NPC_SLIMY_TENTACLE_STALKER      = 38309,
+
+    // Frostwing Halls escort event
+    NPC_CAPTAIN_ARNATH              = 37122,
+    NPC_CAPTAIN_BRANDON             = 37123,
+    NPC_CAPTAIN_GRONDEL             = 37124,
+    NPC_CAPTAIN_RUPERT              = 37125,
+    NPC_SISTER_SVALNA               = 37126,
+    NPC_CROK_SCOURGEBANE            = 37129,
+    NPC_IMPALING_SPEAR              = 38248,
 
     // Blood wing entrance creatures
     NPC_DARFALLEN_NOBLE             = 37663,
@@ -220,11 +242,14 @@ enum
 
     // Area triggers
     AT_SINDRAGOSA_PLATFORM          = 5604,
+    AT_SINDRAGOSA_GAUNTLET          = 5623,
     AT_LIGHTS_HAMMER_INTRO_1        = 5611,
     AT_LIGHTS_HAMMER_INTRO_2        = 5612,
     AT_RAMPART_ALLIANCE             = 5628,
     AT_RAMPART_HORDE                = 5630,
     AT_PUTRICIDES_TRAP              = 5647,
+    AT_SHUTDOWN_FROST_JETS          = 5649,
+    AT_SAURFANG_PORTAL              = 5698,
     AT_DEATHWHISPER_INTRO           = 5709,
     AT_FROZEN_THRONE_TELE           = 5718,
     AT_MARROWGAR_INTRO              = 5732,
@@ -360,6 +385,8 @@ class instance_icecrown_citadel : public ScriptedInstance, private DialogueHelpe
         // Open Putricide door in a few seconds
         void DoPreparePutricideDoor() { m_uiPutricideValveTimer = 15000; }
 
+        void StartSindragosaFrostwyrm(uint32 entry, Player* player = nullptr);
+
         void SetSpecialAchievementCriteria(uint32 uiType, bool bIsMet);
         bool CheckAchievementCriteriaMeet(uint32 uiCriteriaId, Player const* pSource, Unit const* pTarget = nullptr, uint32 uiMiscvalue1 = 0) const override;
 
@@ -381,6 +408,8 @@ class instance_icecrown_citadel : public ScriptedInstance, private DialogueHelpe
 
         uint32 m_uiTeam;                                    // Team of first entered player, used on the Gunship event
         uint32 m_uiPutricideValveTimer;
+        uint32 m_coldflameJetsState;
+        uint32 m_sindragosaGauntletState;
 
         bool m_bHasMarrowgarIntroYelled;
         bool m_bHasDeathwhisperIntroYelled;
@@ -397,6 +426,8 @@ class instance_icecrown_citadel : public ScriptedInstance, private DialogueHelpe
         GuidSet m_sDarkfallenCreaturesLowerGuids;
         GuidSet m_sDarkfallenCreaturesLeftGuids;
         GuidSet m_sDarkfallenCreaturesRightGuids;
+        GuidSet m_rimefangTrashGuids;
+        GuidSet m_spinestalkerTrashGuids;
 };
 
 #endif

--- a/src/game/AI/ScriptDevAI/system/ScriptLoader.cpp
+++ b/src/game/AI/ScriptDevAI/system/ScriptLoader.cpp
@@ -312,6 +312,7 @@ extern void AddSC_boss_lord_marrowgar();
 extern void AddSC_boss_professor_putricide();
 extern void AddSC_boss_rotface();
 extern void AddSC_boss_sindragosa();
+extern void AddSC_boss_sister_svalna();
 extern void AddSC_boss_the_lich_king();
 extern void AddSC_boss_valithria_dreamwalker();
 extern void AddSC_gunship_battle();
@@ -816,6 +817,7 @@ void AddScripts()
     AddSC_boss_professor_putricide();
     AddSC_boss_rotface();
     AddSC_boss_sindragosa();
+    AddSC_boss_sister_svalna();
     AddSC_boss_the_lich_king();
     AddSC_boss_valithria_dreamwalker();
     AddSC_gunship_battle();


### PR DESCRIPTION
Restores the Crok/Svalna escort and captains, spider gauntlet, frostwyrm pack activation, and alternating Upper Spire coldflame jets. The jet work is included here because it belongs to the same Frostwing/Upper Spire path.

RP lines use BroadcastText, while escort/gauntlet timing and movement remain explicit scripted behavior.

DB companion: https://github.com/cmangos/wotlk-db/pull/1400

Tested in 10-player and 25-player normal, including Svalna progression, frostwyrm activation, and all twelve coldflame jets. Heroic still needs a dedicated pass.