### PR TITLE
ICC: restore Sindragosa

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sindragosa.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sindragosa.cpp
@@ -16,13 +16,14 @@
 
 /* ScriptData
 SDName: boss_sindragosa
-SD%Complete: 80%
+SD%Complete: 90%
 SDComment: requires core support for ice blocks (spells and GO in LoS checking)
 SDCategory: Icecrown Citadel
 EndScriptData */
 
 #include "AI/ScriptDevAI/include/sc_common.h"
 #include "icecrown_citadel.h"
+#include "Movement/MoveSplineInit.h"
 
 enum
 {
@@ -50,6 +51,7 @@ enum
     SPELL_FROST_AURA            = 70084,
     SPELL_FROST_BREATH          = 69649,
     SPELL_ICY_GRIP              = 70117,
+    SPELL_BLISTERING_COLD       = 70123,
     SPELL_PERMEATING_CHILL      = 70109,
     SPELL_UNCHAINED_MAGIC       = 69762,
 
@@ -65,6 +67,13 @@ enum
     // Phase 3
     SPELL_MYSTIC_BUFFET         = 70128,
     SPELL_ICE_TOMB_SINGLE       = 69675,
+    SPELL_FROST_BEACON          = 70126,
+    SPELL_ICE_TOMB_DAMAGE       = 70157,
+    SPELL_ASPHYXIATION          = 71665,
+
+    NPC_ICE_TOMB                = 36980,
+    NPC_FROST_BOMB              = 37186,
+    GO_ICE_BLOCK                = 201722,
 
     // Rimefang
     SPELL_RIMEFANG_FROST_AURA   = 71387,
@@ -74,7 +83,13 @@ enum
     // Spinestalker
     SPELL_SPINESTALKER_BELLOWING_ROAR   = 36922,
     SPELL_SPINESTALKER_CLEAVE           = 40505,
-    SPELL_SPINESTALKER_TAIL_SWEEP       = 71369
+    SPELL_SPINESTALKER_TAIL_SWEEP       = 71369,
+
+    // Frostwing Halls trash
+    SPELL_ORDER_WHELP                    = 71357,
+    SPELL_FOCUS_FIRE                     = 71350,
+    SPELL_CONCUSSIVE_SHOCK               = 71337,
+    SPELL_WHELP_FROST_BLAST              = 71361,
 };
 
 enum SindragosaPhase
@@ -125,17 +140,37 @@ enum SpinestalkerPoint
 
 static const float SindragosaPosition[10][3] =
 {
-    {4407.44f, 2484.37f, 203.37f},      // 0 center, ground
-    {4407.44f, 2484.37f, 235.37f},      // 1 center, air
-    {4470.00f, 2484.37f, 235.37f},      // 2 Sindragosa air phase point
-    {4414.32f, 2456.94f, 203.37f},      // 3 Rimefang landing point
-    {4414.32f, 2456.94f, 228.37f},      // 4 Rimefang above landing point
-    {4414.32f, 2512.73f, 203.37f},      // 5 Spinestalker landing point
-    {4414.32f, 2512.73f, 228.37f},      // 6 Spinestalker above landing point
-    {4505.00f, 2484.37f, 235.37f},      // 7 Sindragosa spawn point
-    {4505.00f, 2444.37f, 235.37f},      // 8 Sindragosa east flying point
-    {4505.00f, 2524.37f, 235.37f},      // 9 Sindragosa west flying point
+    {4419.19f, 2484.57f, 203.3848f},    // 0 Sindragosa landing point
+    {4420.19f, 2484.36f, 232.5150f},    // 1 Sindragosa fly-in / takeoff point
+    {4475.99f, 2484.43f, 247.9340f},    // 2 Sindragosa air phase point
+    {4413.31f, 2456.42f, 203.3848f},    // 3 Rimefang landing point
+    {4413.31f, 2456.42f, 233.3795f},    // 4 Rimefang above landing point
+    {4418.90f, 2514.23f, 203.3848f},    // 5 Spinestalker landing point
+    {4418.90f, 2514.23f, 230.4864f},    // 6 Spinestalker above landing point
+    {4818.70f, 2483.71f, 287.0650f},    // 7 retail Sindragosa spawn point
+    {4475.19f, 2444.37f, 247.9340f},    // 8 evade patrol east
+    {4475.19f, 2524.37f, 247.9340f},    // 9 evade patrol west
 };
+
+namespace
+{
+int32 LaunchSindragosaFlyIn(Creature* creature)
+{
+    Movement::PointsArray path;
+    path.push_back(Vector3(creature->GetPositionX(), creature->GetPositionY(), creature->GetPositionZ()));
+    path.push_back(Vector3(4655.0f, 2484.0f, 270.0f));
+    path.push_back(Vector3(4515.0f, 2484.3f, 247.0f));
+    path.push_back(Vector3(SindragosaPosition[1][0], SindragosaPosition[1][1], SindragosaPosition[1][2]));
+
+    Movement::MoveSplineInit movement(*creature);
+    movement.MovebyPath(path);
+    movement.SetFly();
+    movement.SetSmooth();
+    movement.SetVelocity(20.0f);
+    movement.SetFacing(M_PI_F);
+    return movement.Launch();
+}
+}
 
 struct boss_sindragosaAI : public ScriptedAI
 {
@@ -158,21 +193,33 @@ struct boss_sindragosaAI : public ScriptedAI
     uint32 m_uiFrostBreathTimer;
     uint32 m_uiTailSmashTimer;
     uint32 m_uiIcyGripTimer;
+    uint32 m_uiBlisteringColdTimer;
     uint32 m_uiUnchainedMagicTimer;
     uint32 m_uiFrostBombTimer;
     uint32 m_uiIceTombSingleTimer;
+    uint32 m_uiPendingTombTimer;
+    GuidList m_pendingTombTargets;
+    uint32 m_uiIntroFlightTimer;
 
     void Reset() override
     {
         m_uiPhase                   = SINDRAGOSA_PHASE_OOC;
-        m_uiPhaseTimer              = 45000;
+        // Retail starts the first air phase at 50 seconds.  Subsequent air
+        // phases are 110 seconds apart; this implementation spends 33
+        // seconds in the air, leaving a 77-second ground interval.
+        m_uiPhaseTimer              = 50000;
         m_uiBerserkTimer            = 10 * MINUTE * IN_MILLISECONDS;
-        m_uiCleaveTimer             = urand(5000, 15000);
+        m_uiCleaveTimer             = urand(10000, 15000);
         m_uiTailSmashTimer          = 20000;
-        m_uiFrostBreathTimer        = 5000;
+        m_uiFrostBreathTimer        = urand(8000, 12000);
         m_uiIcyGripTimer            = 35000;
+        m_uiBlisteringColdTimer     = 0;
         m_uiIceTombSingleTimer      = 15000;
-        m_uiUnchainedMagicTimer     = urand(15000, 30000);
+        m_uiUnchainedMagicTimer     = urand(9000, 14000);
+        m_uiPendingTombTimer        = 0;
+        m_uiIntroFlightTimer        = 0;
+        m_pendingTombTargets.clear();
+        CleanupIceTombs();
     }
 
     void SetFlying(bool bIsFlying)
@@ -183,7 +230,9 @@ struct boss_sindragosaAI : public ScriptedAI
             m_creature->SetAnimTier(AnimTier::Ground);
 
         m_creature->SetLevitate(bIsFlying);
-        m_creature->SetWalk(bIsFlying);
+        // Flight transitions use run-flight speed. Walking-speed point
+        // movement makes the large frostwyrm spline visibly step/jerk.
+        m_creature->SetWalk(false);
     }
 
     void EnterEvadeMode() override
@@ -194,6 +243,7 @@ struct boss_sindragosaAI : public ScriptedAI
 
     void JustReachedHome() override
     {
+        CleanupIceTombs();
         if (m_pInstance)
             m_pInstance->SetData(TYPE_SINDRAGOSA, FAIL);
 
@@ -207,17 +257,31 @@ struct boss_sindragosaAI : public ScriptedAI
 
     void AttackStart(Unit* pWho) override
     {
-        ScriptedAI::AttackStart(pWho);
-
-        // on aggro: land first, then start the encounter
         if (m_uiPhase == SINDRAGOSA_PHASE_OOC)
         {
-            m_uiPhase = SINDRAGOSA_PHASE_AGGRO;
-            SetCombatMovement(false);
-            m_creature->SetWalk(true);
-            m_creature->GetMotionMaster()->Clear();
-            m_creature->GetMotionMaster()->MovePoint(SINDRAGOSA_POINT_AIR_CENTER, SindragosaPosition[1][0], SindragosaPosition[1][1], SindragosaPosition[1][2]);
+            ReceiveAIEvent(AI_EVENT_CUSTOM_A, pWho, m_creature, 0);
+            return;
         }
+
+        if (m_uiPhase == SINDRAGOSA_PHASE_AGGRO)
+            return;
+
+        ScriptedAI::AttackStart(pWho);
+    }
+
+    void ReceiveAIEvent(AIEventType eventType, Unit* /*sender*/, Unit* /*invoker*/, uint32 /*miscValue*/) override
+    {
+        if (eventType != AI_EVENT_CUSTOM_A || m_uiPhase != SINDRAGOSA_PHASE_OOC)
+            return;
+
+        m_uiPhase = SINDRAGOSA_PHASE_AGGRO;
+        SetCombatMovement(false);
+        SetFlying(true);
+        m_creature->SetActiveObjectState(true);
+        m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+        m_creature->GetMotionMaster()->Clear();
+        int32 travelTime = LaunchSindragosaFlyIn(m_creature);
+        m_uiIntroFlightTimer = travelTime > 0 ? uint32(travelTime) + 250 : 1;
     }
 
     void Aggro(Unit* /*pWho*/) override
@@ -228,10 +292,97 @@ struct boss_sindragosaAI : public ScriptedAI
 
     void JustDied(Unit* /*pKiller*/) override
     {
+        CleanupIceTombs();
         DoScriptText(SAY_DEATH, m_creature);
 
         if (m_pInstance)
             m_pInstance->SetData(TYPE_SINDRAGOSA, DONE);
+    }
+
+    void CleanupIceTombs()
+    {
+        std::list<Creature*> tombs;
+        GetCreatureListWithEntryInGrid(tombs, m_creature, NPC_ICE_TOMB, 250.0f);
+        for (Creature* tomb : tombs)
+            tomb->ForcedDespawn();
+
+        std::list<Creature*> bombs;
+        GetCreatureListWithEntryInGrid(bombs, m_creature, NPC_FROST_BOMB, 250.0f);
+        for (Creature* bomb : bombs)
+        {
+            bomb->CombatStop(true);
+            bomb->DeleteThreatList();
+            bomb->ForcedDespawn();
+        }
+
+        for (auto& playerRef : m_creature->GetMap()->GetPlayers())
+            if (Player* player = playerRef.getSource())
+            {
+                player->RemoveAurasDueToSpell(SPELL_ICE_TOMB_PROTECTION);
+                player->RemoveAurasDueToSpell(SPELL_ICE_TOMB_DAMAGE);
+                player->RemoveAurasDueToSpell(SPELL_ASPHYXIATION);
+                player->RemoveAurasDueToSpell(SPELL_FROST_BEACON);
+            }
+    }
+
+    void CheckMysticBuffetAchievement()
+    {
+        if (!m_pInstance || m_uiPhase != SINDRAGOSA_PHASE_THREE)
+            return;
+
+        static uint32 const buffetIds[] = {70127, 72528, 72529, 72530};
+        for (auto& playerRef : m_creature->GetMap()->GetPlayers())
+            if (Player* player = playerRef.getSource())
+                for (uint32 spellId : buffetIds)
+                    if (SpellAuraHolder* holder = player->GetSpellAuraHolder(spellId))
+                        if (holder->GetStackAmount() > 5)
+                        {
+                            m_pInstance->SetSpecialAchievementCriteria(TYPE_ACHIEV_ALL_YOU_CAN_EAT, false);
+                            return;
+                        }
+    }
+
+    void MarkIceTombTargets(uint32 count)
+    {
+        std::vector<Player*> targets;
+        for (auto& playerRef : m_creature->GetMap()->GetPlayers())
+        {
+            Player* player = playerRef.getSource();
+            if (player && player->IsAlive() && player != m_creature->GetVictim() &&
+                !player->HasAura(SPELL_FROST_BEACON) && m_creature->IsWithinDistInMap(player, 180.0f))
+                targets.push_back(player);
+        }
+
+        while (count-- && !targets.empty())
+        {
+            uint32 index = urand(0, targets.size() - 1);
+            Player* target = targets[index];
+            target->CastSpell(target, SPELL_FROST_BEACON, TRIGGERED_OLD_TRIGGERED);
+            m_pendingTombTargets.push_back(target->GetObjectGuid());
+            targets.erase(targets.begin() + index);
+        }
+
+        if (!m_pendingTombTargets.empty())
+            m_uiPendingTombTimer = 7000;
+    }
+
+    void CreatePendingIceTombs()
+    {
+        for (GuidList::const_iterator itr = m_pendingTombTargets.begin(); itr != m_pendingTombTargets.end(); ++itr)
+        {
+            Player* target = m_creature->GetMap()->GetPlayer(*itr);
+            if (!target || !target->IsAlive())
+                continue;
+
+            target->RemoveAurasDueToSpell(SPELL_FROST_BEACON);
+            target->CastSpell(target, SPELL_ICE_TOMB_PROTECTION, TRIGGERED_OLD_TRIGGERED);
+            target->CastSpell(target, SPELL_ICE_TOMB_DAMAGE, TRIGGERED_OLD_TRIGGERED);
+            if (Creature* tomb = m_creature->SummonCreature(NPC_ICE_TOMB, target->GetPositionX(), target->GetPositionY(),
+                    target->GetPositionZ(), target->GetOrientation(), TEMPSPAWN_DEAD_DESPAWN, 0))
+                tomb->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, target, tomb);
+        }
+        m_pendingTombTargets.clear();
+        m_uiPendingTombTimer = 0;
     }
 
     void MovementInform(uint32 uiMovementType, uint32 uiPointId) override
@@ -265,15 +416,20 @@ struct boss_sindragosaAI : public ScriptedAI
                     DoCastSpellIfCan(m_creature, SPELL_PERMEATING_CHILL, CAST_TRIGGERED);
 
                     if (m_pInstance)
+                    {
+                        m_pInstance->SetSpecialAchievementCriteria(TYPE_ACHIEV_ALL_YOU_CAN_EAT, true);
                         m_pInstance->SetData(TYPE_SINDRAGOSA, IN_PROGRESS);
+                    }
                 }
 
                 m_uiPhase = SINDRAGOSA_PHASE_GROUND;
                 SetFlying(false);
+                m_creature->SetActiveObjectState(false);
+                m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+                m_creature->SetRespawnCoord(SindragosaPosition[0][0], SindragosaPosition[0][1], SindragosaPosition[0][2], M_PI_F);
                 SetCombatMovement(true);
-
-                if (Unit* pVictim = m_creature->GetVictim())
-                    m_creature->GetMotionMaster()->MoveChase(pVictim);
+                m_creature->SetInCombatWithZone();
+                m_creature->AI()->AttackClosestEnemy();
             }
         }
         else if (uiPointId == SINDRAGOSA_POINT_AIR_CENTER)
@@ -292,8 +448,11 @@ struct boss_sindragosaAI : public ScriptedAI
         else if (uiPointId == SINDRAGOSA_POINT_AIR_PHASE_2)
         {
             m_creature->SetOrientation(M_PI_F); // face the platform
-            m_uiFrostBombTimer = 10000; // set initial Frost Bomb timer
-            DoCastSpellIfCan(m_creature, SPELL_ICE_TOMB);
+            m_uiFrostBombTimer = 7000; // first bomb after the air-phase tombs form
+            uint32 tombCount = 2;
+            if (m_pInstance && m_pInstance->Is25ManDifficulty())
+                tombCount = m_pInstance->IsHeroicDifficulty() ? 6 : 5;
+            MarkIceTombTargets(tombCount);
             m_uiPhase = SINDRAGOSA_PHASE_AIR;
         }
     }
@@ -309,8 +468,44 @@ struct boss_sindragosaAI : public ScriptedAI
 
     void UpdateAI(const uint32 uiDiff) override
     {
+        if (m_uiIntroFlightTimer)
+        {
+            if (m_uiIntroFlightTimer <= uiDiff)
+            {
+                m_uiIntroFlightTimer = 0;
+                m_creature->GetMotionMaster()->MovePoint(SINDRAGOSA_POINT_GROUND_CENTER,
+                    Position(SindragosaPosition[0][0], SindragosaPosition[0][1], SindragosaPosition[0][2], M_PI_F),
+                    FORCED_MOVEMENT_FLIGHT, 8.5f, false, ObjectGuid(), 0, AnimTier::Hover);
+            }
+            else
+                m_uiIntroFlightTimer -= uiDiff;
+        }
+
+        CheckMysticBuffetAchievement();
+        if (m_uiPendingTombTimer)
+        {
+            if (m_uiPendingTombTimer <= uiDiff)
+                CreatePendingIceTombs();
+            else
+                m_uiPendingTombTimer -= uiDiff;
+        }
+
         if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
             return;
+
+        if (m_uiBlisteringColdTimer)
+        {
+            if (m_uiBlisteringColdTimer <= uiDiff)
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_BLISTERING_COLD) == CAST_OK)
+                {
+                    DoScriptText(SAY_BLISTERING_COLD, m_creature);
+                    m_uiBlisteringColdTimer = 0;
+                }
+            }
+            else
+                m_uiBlisteringColdTimer -= uiDiff;
+        }
 
         // Berserk
         if (m_uiBerserkTimer)
@@ -334,11 +529,8 @@ struct boss_sindragosaAI : public ScriptedAI
                 // Ice Tomb
                 if (m_uiIceTombSingleTimer <= uiDiff)
                 {
-                    if (Unit* pTarget = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 1, SPELL_ICE_TOMB_SINGLE, SELECT_FLAG_PLAYER))
-                    {
-                        if (DoCastSpellIfCan(pTarget, SPELL_ICE_TOMB) == CAST_OK)
-                            m_uiIceTombSingleTimer = 15000;
-                    }
+                    MarkIceTombTargets(1);
+                    m_uiIceTombSingleTimer = urand(16000, 23000);
                 }
                 else
                     m_uiIceTombSingleTimer -= uiDiff;
@@ -351,11 +543,12 @@ struct boss_sindragosaAI : public ScriptedAI
                 if (m_uiPhase == SINDRAGOSA_PHASE_GROUND)
                 {
                     // Health Check
-                    if (m_creature->GetHealthPercent() <= 30.0f)
+                    if (m_creature->GetHealthPercent() <= 35.0f)
                     {
                         if (DoCastSpellIfCan(m_creature, SPELL_MYSTIC_BUFFET) == CAST_OK)
                         {
                             m_uiPhase = SINDRAGOSA_PHASE_THREE;
+                            m_uiIceTombSingleTimer = urand(7000, 10000);
                             DoScriptText(SAY_PHASE_3, m_creature);
                         }
                     }
@@ -385,7 +578,7 @@ struct boss_sindragosaAI : public ScriptedAI
                 if (m_uiTailSmashTimer <= uiDiff)
                 {
                     if (DoCastSpellIfCan(m_creature, SPELL_TAIL_SMASH) == CAST_OK)
-                        m_uiTailSmashTimer = urand(10000, 20000);
+                        m_uiTailSmashTimer = urand(22000, 27000);
                 }
                 else
                     m_uiTailSmashTimer -= uiDiff;
@@ -394,7 +587,7 @@ struct boss_sindragosaAI : public ScriptedAI
                 if (m_uiFrostBreathTimer <= uiDiff)
                 {
                     if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_FROST_BREATH) == CAST_OK)
-                        m_uiFrostBreathTimer = urand(15000, 20000);
+                        m_uiFrostBreathTimer = urand(20000, 25000);
                 }
                 else
                     m_uiFrostBreathTimer -= uiDiff;
@@ -404,7 +597,7 @@ struct boss_sindragosaAI : public ScriptedAI
                 {
                     if (DoCastSpellIfCan(m_creature, SPELL_UNCHAINED_MAGIC) == CAST_OK)
                     {
-                        m_uiUnchainedMagicTimer = urand(40000, 60000);
+                        m_uiUnchainedMagicTimer = urand(30000, 35000);
                         DoScriptText(SAY_UNCHAINED_MAGIC, m_creature);
                     }
                 }
@@ -416,8 +609,8 @@ struct boss_sindragosaAI : public ScriptedAI
                 {
                     if (DoCastSpellIfCan(m_creature, SPELL_ICY_GRIP) == CAST_OK)
                     {
-                        m_uiIcyGripTimer = 70000;
-                        DoScriptText(SAY_BLISTERING_COLD, m_creature);
+                        m_uiIcyGripTimer = urand(65000, 70000);
+                        m_uiBlisteringColdTimer = 1000;
                     }
                 }
                 else
@@ -435,7 +628,7 @@ struct boss_sindragosaAI : public ScriptedAI
                 if (m_uiPhaseTimer <= uiDiff)
                 {
                     m_uiPhase = SINDRAGOSA_PHASE_FLYING_TO_GROUND;
-                    m_uiPhaseTimer = 42000;
+                    m_uiPhaseTimer = 77000;
                     m_creature->GetMotionMaster()->MovePoint(SINDRAGOSA_POINT_AIR_CENTER, SindragosaPosition[1][0], SindragosaPosition[1][1], SindragosaPosition[1][2]);
                 }
                 else
@@ -456,6 +649,79 @@ struct boss_sindragosaAI : public ScriptedAI
     }
 };
 
+struct npc_ice_tomb_iccAI : public Scripted_NoMovementAI
+{
+    npc_ice_tomb_iccAI(Creature* creature) : Scripted_NoMovementAI(creature), m_asphyxiationTimer(20000)
+    {
+        // The creature is the attackable tomb; the gameobject supplies the
+        // physical line-of-sight cover required by Frost Bomb.
+        GameObject* iceBlock = new GameObject;
+        Map* map = m_creature->GetMap();
+        uint32 lowGuid = map->GenerateLocalLowGuid(HIGHGUID_GAMEOBJECT);
+        if (iceBlock->Create(lowGuid, lowGuid, GO_ICE_BLOCK, map, m_creature->GetPhaseMask(),
+                m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ(),
+                m_creature->GetOrientation()))
+        {
+            map->Add(iceBlock);
+            iceBlock->AIM_Initialize();
+            m_iceBlockGuid = iceBlock->GetObjectGuid();
+        }
+        else
+            delete iceBlock;
+    }
+
+    ObjectGuid m_targetGuid;
+    ObjectGuid m_iceBlockGuid;
+    uint32 m_asphyxiationTimer;
+
+    void ReceiveAIEvent(AIEventType eventType, Unit* sender, Unit* /*invoker*/, uint32 /*miscValue*/) override
+    {
+        if (eventType == AI_EVENT_CUSTOM_A && sender && sender->IsPlayer())
+            m_targetGuid = sender->GetObjectGuid();
+    }
+
+    void RemovePrisonAuras()
+    {
+        if (Player* target = m_creature->GetMap()->GetPlayer(m_targetGuid))
+        {
+            target->RemoveAurasDueToSpell(SPELL_ICE_TOMB_PROTECTION);
+            target->RemoveAurasDueToSpell(SPELL_ICE_TOMB_DAMAGE);
+            target->RemoveAurasDueToSpell(SPELL_ASPHYXIATION);
+            target->RemoveAurasDueToSpell(SPELL_FROST_BEACON);
+        }
+    }
+
+    void RemoveIceBlock()
+    {
+        if (GameObject* iceBlock = m_creature->GetMap()->GetGameObject(m_iceBlockGuid))
+            iceBlock->Delete();
+        m_iceBlockGuid.Clear();
+    }
+
+    void JustDied(Unit* /*killer*/) override
+    {
+        RemovePrisonAuras();
+        RemoveIceBlock();
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!m_asphyxiationTimer)
+            return;
+        if (m_asphyxiationTimer <= diff)
+        {
+            if (Player* target = m_creature->GetMap()->GetPlayer(m_targetGuid))
+                if (target->IsAlive())
+                    target->CastSpell(target, SPELL_ASPHYXIATION, TRIGGERED_OLD_TRIGGERED);
+            m_asphyxiationTimer = 0;
+        }
+        else
+            m_asphyxiationTimer -= diff;
+    }
+};
+
+UnitAI* GetAI_npc_ice_tomb_icc(Creature* creature) { return new npc_ice_tomb_iccAI(creature); }
+
 UnitAI* GetAI_boss_sindragosa(Creature* pCreature)
 {
     return new boss_sindragosaAI(pCreature);
@@ -467,10 +733,10 @@ struct npc_rimefang_iccAI : public ScriptedAI
     {
         m_pInstance = (instance_icecrown_citadel*)pCreature->GetInstanceData();
 
-        // Icy Blast - 3 casts on 10man, 6 on 25man
-        m_uiIcyBlastMaxCount = 3;
+        // Retail counts: 5/7 on normal and 6/8 on heroic (10/25).
+        m_uiIcyBlastMaxCount = m_pInstance && m_pInstance->IsHeroicDifficulty() ? 6 : 5;
         if (m_pInstance && m_pInstance->Is25ManDifficulty())
-            m_uiIcyBlastMaxCount = 6;
+            m_uiIcyBlastMaxCount += 2;
 
         m_bHasLanded = false;
         m_bIsReady = false;
@@ -492,8 +758,8 @@ struct npc_rimefang_iccAI : public ScriptedAI
     void Reset() override
     {
         m_uiPhase               = RIMEFANG_PHASE_GROUND;
-        m_uiPhaseTimer          = 25000;
-        m_uiFrostBreathTimer    = urand(5000, 8000);
+        m_uiPhaseTimer          = urand(30000, 35000);
+        m_uiFrostBreathTimer    = urand(12000, 15000);
         m_uiIcyBlastTimer       = 0;
         m_uiIcyBlastCounter     = 0;
 
@@ -508,7 +774,7 @@ struct npc_rimefang_iccAI : public ScriptedAI
             m_creature->SetAnimTier(AnimTier::Ground);
 
         m_creature->SetLevitate(bIsFlying);
-        m_creature->SetWalk(bIsFlying);
+        m_creature->SetWalk(false);
     }
 
     void Aggro(Unit* /*pWho*/) override
@@ -523,7 +789,12 @@ struct npc_rimefang_iccAI : public ScriptedAI
             if (!m_bHasLanded)
             {
                 m_bHasLanded = true;
-                m_creature->GetMotionMaster()->MovePoint(RIMEFANG_POINT_INITIAL_LAND_AIR, SindragosaPosition[4][0], SindragosaPosition[4][1], SindragosaPosition[4][2]);
+                SetFlying(true);
+                m_creature->SetActiveObjectState(true);
+                m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+                m_creature->GetMotionMaster()->MovePoint(RIMEFANG_POINT_INITIAL_LAND_AIR,
+                    Position(SindragosaPosition[4][0], SindragosaPosition[4][1], SindragosaPosition[4][2], M_PI_F),
+                    FORCED_MOVEMENT_FLIGHT, 18.0f, false);
             }
 
             return;
@@ -541,7 +812,7 @@ struct npc_rimefang_iccAI : public ScriptedAI
         if (!pSpinestalker || !pSpinestalker->IsAlive())
         {
             if (Creature* pSindragosa = m_creature->SummonCreature(NPC_SINDRAGOSA, SindragosaPosition[7][0], SindragosaPosition[7][1], SindragosaPosition[7][2], 0.0f, TEMPSPAWN_MANUAL_DESPAWN, 0))
-                pSindragosa->SetInCombatWithZone();
+                pSindragosa->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, m_creature, pSindragosa);
         }
     }
 
@@ -566,7 +837,9 @@ struct npc_rimefang_iccAI : public ScriptedAI
 
         if (uiPointId == RIMEFANG_POINT_INITIAL_LAND_AIR)
         {
-            m_creature->GetMotionMaster()->MovePoint(RIMEFANG_POINT_INITIAL_LAND, SindragosaPosition[3][0], SindragosaPosition[3][1], SindragosaPosition[3][2]);
+            m_creature->GetMotionMaster()->MovePoint(RIMEFANG_POINT_INITIAL_LAND,
+                Position(SindragosaPosition[3][0], SindragosaPosition[3][1], SindragosaPosition[3][2], M_PI_F),
+                FORCED_MOVEMENT_FLIGHT, 8.5f, false, ObjectGuid(), 0, AnimTier::Hover);
         }
         else if (uiPointId == RIMEFANG_POINT_INITIAL_LAND)
         {
@@ -574,6 +847,11 @@ struct npc_rimefang_iccAI : public ScriptedAI
             m_creature->SetFacingTo(M_PI_F);
             m_bIsReady = true;
             SetFlying(false);
+            m_creature->SetActiveObjectState(false);
+            m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+            m_creature->SetRespawnCoord(SindragosaPosition[3][0], SindragosaPosition[3][1], SindragosaPosition[3][2], M_PI_F);
+            m_creature->SetInCombatWithZone();
+            m_creature->AI()->AttackClosestEnemy();
         }
         else if (uiPointId == RIMEFANG_POINT_GROUND)
         {
@@ -601,7 +879,7 @@ struct npc_rimefang_iccAI : public ScriptedAI
             if (m_uiFrostBreathTimer <= uiDiff)
             {
                 if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_RIMEFANG_FROST_BREATH) == CAST_OK)
-                    m_uiFrostBreathTimer = urand(5000, 8000);
+                    m_uiFrostBreathTimer = urand(20000, 25000);
             }
             else
                 m_uiFrostBreathTimer -= uiDiff;
@@ -675,9 +953,9 @@ struct npc_spinestalker_iccAI : public ScriptedAI
 
     void Reset() override
     {
-        m_uiBellowingRoarTimer  = urand(8000, 24000);
-        m_uiTailSweepTimer      = urand(4000, 8000);
-        m_uiCleaveTimer         = urand(5000, 8000);
+        m_uiBellowingRoarTimer  = urand(20000, 25000);
+        m_uiTailSweepTimer      = urand(8000, 12000);
+        m_uiCleaveTimer         = urand(10000, 15000);
     }
 
     void SetFlying(bool bIsFlying)
@@ -688,7 +966,7 @@ struct npc_spinestalker_iccAI : public ScriptedAI
             m_creature->SetAnimTier(AnimTier::Ground);
 
         m_creature->SetLevitate(bIsFlying);
-        m_creature->SetWalk(bIsFlying);
+        m_creature->SetWalk(false);
     }
 
     void JustDied(Unit* /*pKiller*/) override
@@ -700,7 +978,7 @@ struct npc_spinestalker_iccAI : public ScriptedAI
         if (!pRimefang || !pRimefang->IsAlive())
         {
             if (Creature* pSindragosa = m_creature->SummonCreature(NPC_SINDRAGOSA, SindragosaPosition[7][0], SindragosaPosition[7][1], SindragosaPosition[7][2], 0.0f, TEMPSPAWN_MANUAL_DESPAWN, 0))
-                pSindragosa->SetInCombatWithZone();
+                pSindragosa->AI()->SendAIEvent(AI_EVENT_CUSTOM_A, m_creature, pSindragosa);
         }
     }
 
@@ -711,7 +989,12 @@ struct npc_spinestalker_iccAI : public ScriptedAI
             if (!m_bHasLanded)
             {
                 m_bHasLanded = true;
-                m_creature->GetMotionMaster()->MovePoint(SPINESTALKER_POINT_INITIAL_LAND_AIR, SindragosaPosition[6][0], SindragosaPosition[6][1], SindragosaPosition[6][2]);
+                SetFlying(true);
+                m_creature->SetActiveObjectState(true);
+                m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+                m_creature->GetMotionMaster()->MovePoint(SPINESTALKER_POINT_INITIAL_LAND_AIR,
+                    Position(SindragosaPosition[6][0], SindragosaPosition[6][1], SindragosaPosition[6][2], M_PI_F),
+                    FORCED_MOVEMENT_FLIGHT, 18.0f, false);
             }
 
             return;
@@ -740,7 +1023,9 @@ struct npc_spinestalker_iccAI : public ScriptedAI
 
         if (uiPointId == SPINESTALKER_POINT_INITIAL_LAND_AIR)
         {
-            m_creature->GetMotionMaster()->MovePoint(SPINESTALKER_POINT_INITIAL_LAND, SindragosaPosition[5][0], SindragosaPosition[5][1], SindragosaPosition[5][2]);
+            m_creature->GetMotionMaster()->MovePoint(SPINESTALKER_POINT_INITIAL_LAND,
+                Position(SindragosaPosition[5][0], SindragosaPosition[5][1], SindragosaPosition[5][2], M_PI_F),
+                FORCED_MOVEMENT_FLIGHT, 8.5f, false, ObjectGuid(), 0, AnimTier::Hover);
         }
         else if (uiPointId == SPINESTALKER_POINT_INITIAL_LAND)
         {
@@ -748,6 +1033,11 @@ struct npc_spinestalker_iccAI : public ScriptedAI
             m_creature->SetFacingTo(M_PI_F);
             m_bIsReady = true;
             SetFlying(false);
+            m_creature->SetActiveObjectState(false);
+            m_creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_PLAYER);
+            m_creature->SetRespawnCoord(SindragosaPosition[5][0], SindragosaPosition[5][1], SindragosaPosition[5][2], M_PI_F);
+            m_creature->SetInCombatWithZone();
+            m_creature->AI()->AttackClosestEnemy();
         }
     }
 
@@ -760,7 +1050,7 @@ struct npc_spinestalker_iccAI : public ScriptedAI
         if (m_uiCleaveTimer <= uiDiff)
         {
             if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_SPINESTALKER_CLEAVE) == CAST_OK)
-                m_uiCleaveTimer = urand(5000, 8000);
+                m_uiCleaveTimer = urand(10000, 15000);
         }
         else
             m_uiCleaveTimer -= uiDiff;
@@ -769,7 +1059,7 @@ struct npc_spinestalker_iccAI : public ScriptedAI
         if (m_uiTailSweepTimer <= uiDiff)
         {
             if (DoCastSpellIfCan(m_creature, SPELL_SPINESTALKER_TAIL_SWEEP) == CAST_OK)
-                m_uiTailSweepTimer = urand(4000, 8000);
+                m_uiTailSweepTimer = urand(22000, 25000);
         }
         else
             m_uiTailSweepTimer -= uiDiff;
@@ -778,7 +1068,7 @@ struct npc_spinestalker_iccAI : public ScriptedAI
         if (m_uiBellowingRoarTimer <= uiDiff)
         {
             if (DoCastSpellIfCan(m_creature, SPELL_SPINESTALKER_BELLOWING_ROAR) == CAST_OK)
-                m_uiBellowingRoarTimer = urand(8000, 24000);
+                m_uiBellowingRoarTimer = urand(25000, 30000);
         }
         else
             m_uiBellowingRoarTimer -= uiDiff;
@@ -790,6 +1080,142 @@ struct npc_spinestalker_iccAI : public ScriptedAI
 UnitAI* GetAI_npc_spinestalker_icc(Creature* pCreature)
 {
     return new npc_spinestalker_iccAI(pCreature);
+}
+
+struct npc_sindragosa_trashAI : public ScriptedAI
+{
+    npc_sindragosa_trashAI(Creature* creature) : ScriptedAI(creature) { Reset(); }
+
+    uint32 m_orderWhelpTimer;
+    uint32 m_concussiveShockTimer;
+    uint32 m_frostBlastTimer;
+    uint32 m_focusTimer;
+
+    bool IsRimefangPack() const
+    {
+        return m_creature->GetRespawnPosition().GetPositionY() < 2484.35f;
+    }
+
+    void Reset() override
+    {
+        m_orderWhelpTimer = 3000;
+        m_concussiveShockTimer = urand(8000, 10000);
+        m_frostBlastTimer = urand(3000, 6000);
+        m_focusTimer = 0;
+    }
+
+    void Aggro(Unit* who) override
+    {
+        if (m_creature->GetEntry() == NPC_FROSTWARDEN_HANDLER)
+        {
+            std::list<Creature*> whelps;
+            GetCreatureListWithEntryInGrid(whelps, m_creature, NPC_FROSTWING_WHELP, 40.0f);
+            for (Creature* whelp : whelps)
+                if (whelp->IsAlive() && !whelp->IsInCombat() &&
+                    (whelp->GetRespawnPosition().GetPositionY() < 2484.35f) == IsRimefangPack())
+                    whelp->AI()->AttackStart(who);
+        }
+        else
+        {
+            std::list<Creature*> handlers;
+            GetCreatureListWithEntryInGrid(handlers, m_creature, NPC_FROSTWARDEN_HANDLER, 40.0f);
+            for (Creature* handler : handlers)
+                if (handler->IsAlive() && !handler->IsInCombat() &&
+                    (handler->GetRespawnPosition().GetPositionY() < 2484.35f) == IsRimefangPack())
+                {
+                    handler->AI()->AttackStart(who);
+                    break;
+                }
+            m_creature->CallForHelp(15.0f);
+        }
+    }
+
+    bool HasFocusOrder() const
+    {
+        return m_focusTimer != 0;
+    }
+
+    void SetFocusOrder()
+    {
+        m_focusTimer = 10000;
+    }
+
+    void OrderOneWhelp()
+    {
+        Unit* target = m_creature->SelectAttackingTarget(ATTACKING_TARGET_RANDOM, 0, uint32(0), SELECT_FLAG_PLAYER);
+        if (!target)
+            return;
+
+        std::list<Creature*> whelps;
+        GetCreatureListWithEntryInGrid(whelps, m_creature, NPC_FROSTWING_WHELP, 150.0f);
+        whelps.remove_if([this](Creature* whelp)
+        {
+            return !whelp->IsAlive() ||
+                (whelp->GetRespawnPosition().GetPositionY() < 2484.35f) != IsRimefangPack() ||
+                (dynamic_cast<npc_sindragosa_trashAI*>(whelp->AI()) &&
+                    dynamic_cast<npc_sindragosa_trashAI*>(whelp->AI())->HasFocusOrder());
+        });
+        if (whelps.empty())
+            return;
+
+        auto itr = whelps.begin();
+        std::advance(itr, urand(0, whelps.size() - 1));
+        Creature* whelp = *itr;
+        whelp->CastSpell(target, SPELL_FOCUS_FIRE, TRIGGERED_OLD_TRIGGERED);
+        if (npc_sindragosa_trashAI* whelpAI = dynamic_cast<npc_sindragosa_trashAI*>(whelp->AI()))
+            whelpAI->SetFocusOrder();
+        whelp->AI()->AttackStart(target);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (m_focusTimer)
+        {
+            if (m_focusTimer <= diff)
+                m_focusTimer = 0;
+            else
+                m_focusTimer -= diff;
+        }
+
+        if (!m_creature->SelectHostileTarget() || !m_creature->GetVictim())
+            return;
+
+        if (m_creature->GetEntry() == NPC_FROSTWARDEN_HANDLER)
+        {
+            if (m_orderWhelpTimer <= diff)
+            {
+                OrderOneWhelp();
+                m_orderWhelpTimer = 3000;
+            }
+            else
+                m_orderWhelpTimer -= diff;
+
+            if (m_concussiveShockTimer <= diff)
+            {
+                if (DoCastSpellIfCan(m_creature, SPELL_CONCUSSIVE_SHOCK) == CAST_OK)
+                    m_concussiveShockTimer = urand(10000, 13000);
+            }
+            else
+                m_concussiveShockTimer -= diff;
+        }
+        else
+        {
+            if (m_frostBlastTimer <= diff)
+            {
+                if (DoCastSpellIfCan(m_creature->GetVictim(), SPELL_WHELP_FROST_BLAST) == CAST_OK)
+                    m_frostBlastTimer = urand(5000, 8000);
+            }
+            else
+                m_frostBlastTimer -= diff;
+        }
+
+        DoMeleeAttackIfReady();
+    }
+};
+
+UnitAI* GetAI_npc_sindragosa_trash(Creature* creature)
+{
+    return new npc_sindragosa_trashAI(creature);
 }
 
 /**
@@ -817,6 +1243,14 @@ struct mob_frost_bombAI : public ScriptedAI
 
     void UpdateAI(const uint32 uiDiff) override
     {
+        if (!m_pInstance || m_pInstance->GetData(TYPE_SINDRAGOSA) != IN_PROGRESS)
+        {
+            m_creature->CombatStop(true);
+            m_creature->DeleteThreatList();
+            m_creature->ForcedDespawn();
+            return;
+        }
+
         // Frost Bomb (dmg)
         if (m_uiFrostBombTimer)
         {
@@ -866,5 +1300,15 @@ void AddSC_boss_sindragosa()
     pNewScript = new Script;
     pNewScript->Name = "mob_frost_bomb";
     pNewScript->GetAI = &GetAI_mob_frost_bomb;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_ice_tomb_icc";
+    pNewScript->GetAI = &GetAI_npc_ice_tomb_icc;
+    pNewScript->RegisterSelf();
+
+    pNewScript = new Script;
+    pNewScript->Name = "npc_sindragosa_trash";
+    pNewScript->GetAI = &GetAI_npc_sindragosa_trash;
     pNewScript->RegisterSelf();
 }

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sindragosa.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/boss_sindragosa.cpp
@@ -27,16 +27,16 @@ EndScriptData */
 
 enum
 {
-    SAY_AGGRO                   = -1631148,
-    SAY_UNCHAINED_MAGIC         = -1631149,
-    SAY_BLISTERING_COLD         = -1631150,
-    SAY_RESPIRE                 = -1631151,
-    SAY_TAKEOFF                 = -1631152,
-    SAY_PHASE_3                 = -1631153,
-    SAY_SLAY_1                  = -1631154,
-    SAY_SLAY_2                  = -1631155,
-    SAY_BERSERK                 = -1631156,
-    SAY_DEATH                   = -1631157,
+    SAY_AGGRO                   = 37511,
+    SAY_UNCHAINED_MAGIC         = 37138,
+    SAY_BLISTERING_COLD         = 37137,
+    SAY_RESPIRE                 = 38550,
+    SAY_TAKEOFF                 = 37136,
+    SAY_PHASE_3                 = 37109,
+    SAY_SLAY_1                  = 37133,
+    SAY_SLAY_2                  = 37134,
+    SAY_BERSERK                 = 37140,
+    SAY_DEATH                   = 37139,
 
     // Spells
 
@@ -252,7 +252,10 @@ struct boss_sindragosaAI : public ScriptedAI
 
     void KilledUnit(Unit* /*pVictim*/) override
     {
-        DoScriptText(urand(0, 1) ? SAY_SLAY_1 : SAY_SLAY_2, m_creature);
+        if (urand(0, 1))
+            DoBroadcastText(SAY_SLAY_1, m_creature);
+        else
+            DoBroadcastText(SAY_SLAY_2, m_creature);
     }
 
     void AttackStart(Unit* pWho) override
@@ -286,14 +289,14 @@ struct boss_sindragosaAI : public ScriptedAI
 
     void Aggro(Unit* /*pWho*/) override
     {
-        DoScriptText(SAY_AGGRO, m_creature);
+        DoBroadcastText(SAY_AGGRO, m_creature);
         // instance data set when sindragosa lands
     }
 
     void JustDied(Unit* /*pKiller*/) override
     {
         CleanupIceTombs();
-        DoScriptText(SAY_DEATH, m_creature);
+        DoBroadcastText(SAY_DEATH, m_creature);
 
         if (m_pInstance)
             m_pInstance->SetData(TYPE_SINDRAGOSA, DONE);
@@ -499,7 +502,7 @@ struct boss_sindragosaAI : public ScriptedAI
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_BLISTERING_COLD) == CAST_OK)
                 {
-                    DoScriptText(SAY_BLISTERING_COLD, m_creature);
+                    DoBroadcastText(SAY_BLISTERING_COLD, m_creature);
                     m_uiBlisteringColdTimer = 0;
                 }
             }
@@ -514,7 +517,7 @@ struct boss_sindragosaAI : public ScriptedAI
             {
                 if (DoCastSpellIfCan(m_creature, SPELL_BERSERK) == CAST_OK)
                 {
-                    DoScriptText(SAY_BERSERK, m_creature);
+                    DoBroadcastText(SAY_BERSERK, m_creature);
                     m_uiBerserkTimer = 0;
                 }
             }
@@ -549,7 +552,7 @@ struct boss_sindragosaAI : public ScriptedAI
                         {
                             m_uiPhase = SINDRAGOSA_PHASE_THREE;
                             m_uiIceTombSingleTimer = urand(7000, 10000);
-                            DoScriptText(SAY_PHASE_3, m_creature);
+                            DoBroadcastText(SAY_PHASE_3, m_creature);
                         }
                     }
 
@@ -557,7 +560,7 @@ struct boss_sindragosaAI : public ScriptedAI
                     if (m_uiPhaseTimer <= uiDiff)
                     {
                         m_uiPhaseTimer = 33000;
-                        DoScriptText(SAY_TAKEOFF, m_creature);
+                        DoBroadcastText(SAY_TAKEOFF, m_creature);
                         SetCombatMovement(false);
                         m_creature->GetMotionMaster()->MovePoint(SINDRAGOSA_POINT_GROUND_CENTER, SindragosaPosition[0][0], SindragosaPosition[0][1], SindragosaPosition[0][2]);
                     }
@@ -598,7 +601,7 @@ struct boss_sindragosaAI : public ScriptedAI
                     if (DoCastSpellIfCan(m_creature, SPELL_UNCHAINED_MAGIC) == CAST_OK)
                     {
                         m_uiUnchainedMagicTimer = urand(30000, 35000);
-                        DoScriptText(SAY_UNCHAINED_MAGIC, m_creature);
+                        DoBroadcastText(SAY_UNCHAINED_MAGIC, m_creature);
                     }
                 }
                 else

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.cpp
@@ -1014,6 +1014,11 @@ bool instance_icecrown_citadel::CheckAchievementCriteriaMeet(uint32 uiCriteriaId
         case ACHIEV_CRIT_NAUSEA_10H:
         case ACHIEV_CRIT_NAUSEA_25H:
             return m_abAchievCriteria[TYPE_ACHIEV_NAUSEA];
+        case ACHIEV_CRIT_ALL_YOU_CAN_EAT_10N:
+        case ACHIEV_CRIT_ALL_YOU_CAN_EAT_25N:
+        case ACHIEV_CRIT_ALL_YOU_CAN_EAT_10V:
+        case ACHIEV_CRIT_ALL_YOU_CAN_EAT_25V:
+            return m_abAchievCriteria[TYPE_ACHIEV_ALL_YOU_CAN_EAT];
     }
 
     return false;

--- a/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.h
+++ b/src/game/AI/ScriptDevAI/scripts/northrend/icecrown_citadel/icecrown_citadel/icecrown_citadel.h
@@ -104,6 +104,8 @@ enum
     NPC_PUDDLE_STALKER              = 37013,        // related to Festergut and Rotface
     NPC_RIMEFANG                    = 37533,
     NPC_SPINESTALKER                = 37534,
+    NPC_FROSTWARDEN_HANDLER         = 37531,
+    NPC_FROSTWING_WHELP             = 37532,
     NPC_OOZE_TENTACLE_STALKER       = 38308,        // accessories to Putricide
     NPC_SLIMY_TENTACLE_STALKER      = 38309,
 
@@ -115,12 +117,13 @@ enum
     NPC_EMPOWERING_ORB_STALKER      = 36934,
 
     // achievement types
-    MAX_SPECIAL_ACHIEV_CRITS        = 4,
+    MAX_SPECIAL_ACHIEV_CRITS        = 8,
 
     TYPE_ACHIEV_BONED               = 0,
     TYPE_ACHIEV_MADE_A_MESS         = 1,
     TYPE_ACHIEV_DANCES_OOZES        = 2,
     TYPE_ACHIEV_NAUSEA              = 3,
+    TYPE_ACHIEV_ALL_YOU_CAN_EAT     = 6,
 
     // GameObjects entries
     GO_ICEWALL_1                    = 201911,


### PR DESCRIPTION
Restores Sindragosa's ground and air phases, Frost Beacon and Ice Tombs, Frost Bombs, Mystic Buffet, movement, dialogue, and the pre-Sindragosa frostwyrm handoff.

The encounter dialogue uses BroadcastText instead of legacy ScriptText entries.

DB companion: https://github.com/cmangos/wotlk-db/pull/1402

Tested in complete 10-player and 25-player normal ICC runs. Heroic-specific mechanics still need a separate pass.