### PR TITLE
Group: Preserve member online status in group-list updates

### DIFF
--- a/src/game/Groups/Group.cpp
+++ b/src/game/Groups/Group.cpp
@@ -40,7 +40,7 @@
 extern Config botConfig;
 #endif
 
-GroupMemberStatus GetGroupMemberStatus(const Player* member = nullptr)
+GroupMemberStatus GetGroupMemberStatus(const Player* member)
 {
     uint8 flags = MEMBER_STATUS_OFFLINE;
     if (member && member->GetSession() && !member->GetSession()->PlayerLogout())
@@ -688,7 +688,7 @@ void Group::SendUpdateTo(Player* player)
             Player* player = sObjectMgr.GetPlayer(citr2->guid); // can be nullptr
             data << citr2->name;
             data << citr2->guid;
-            data << uint8(GetGroupMemberStatus());
+            data << uint8(GetGroupMemberStatus(player));
             data << uint8(citr2->group);                    // groupid
             data << uint8(GetFlags(*citr2));                // group flags
             data << uint8(player != nullptr ? player->GetLfgData().GetPlayerRoles() : 0); // lfg roles


### PR DESCRIPTION
## 🍰 Pullrequest

Connected party members are marked offline in `SMSG_GROUP_LIST`, which disables online-only party menu actions. Subsequent individual member-stat packets can restore their online display, making the problem appear intermittent.

`Group::SendUpdateTo` resolves each member but calls `GetGroupMemberStatus()` without passing that player. The default null argument therefore produces `MEMBER_STATUS_OFFLINE`. Pass the resolved member and remove the helper's default argument so another omitted argument is caught at compile time.

### Proof

The missing argument was introduced in [01026734a79863b9eb81d18b0f90b692f08e0137](https://github.com/cmangos/mangos-wotlk/commit/01026734a79863b9eb81d18b0f90b692f08e0137). The problem is present in current upstream master and affects both human players and bots.

A native regression harness compiling the actual helper and `Group::SendUpdateTo` reproduces the incorrect offline flag before the fix and passes afterward. It covers normal/LFG roster serialization, connected humans and bots, absent/logging-out/sessionless members, repeated updates, recipient exclusion, and status flags. These functions are identical between the tested downstream source and this patch.

The downstream Windows x64 RelWithDebInfo Wrath build passes. Live client confirmation after deployment is still pending.

### Issues

- No linked issue.

### How2Test

1. Form a party with two or more connected players.
2. Trigger roster updates by inviting/removing another member or changing the leader. Connected members should remain online, with Whisper and other online-only menu actions available.
3. Log out a member and confirm that member still appears offline.
4. Repeat with an LFG group; connected member status should remain correct.

### Todo / Checklist

- [x] Fix roster status and reject missing helper arguments at compile time.
- [x] Verify the regression before/after and compile the downstream Wrath core.
